### PR TITLE
FTA-33: Update export data to comply with LinkML v2.9.0.

### DIFF
--- a/src/AGR_data_retrieval_curation_agm.py
+++ b/src/AGR_data_retrieval_curation_agm.py
@@ -104,6 +104,17 @@ def main():
 
     generate_export_file(export_dict, log, output_filename)
 
+    if not reference_session:
+        # Export the agm-allele associations to a separate file.
+        association_output_filename = output_filename.replace('agm', 'agm_allele_association')
+        association_export_dict = {
+            'linkml_version': linkml_release,
+            'alliance_member_release_version': database_release,
+        }
+        association_export_dict['agm_allele_association_ingest_set'] = []
+        association_export_dict['agm_allele_association_ingest_set'].extend(genotype_handler.export_data['agm_allele_association_ingest_set'])
+        generate_export_file(association_export_dict, log, association_output_filename)
+
     log.info('Ended main function.\n')
 
 

--- a/src/agm_handlers.py
+++ b/src/agm_handlers.py
@@ -554,8 +554,8 @@ class GenotypeHandler(PrimaryEntityHandler):
         """Extend the method for the GenotypeHandler."""
         super().map_fb_data_to_alliance()
         self.map_genotype_basic()
-        # self.map_genotype_components()    # Suppressed until AGM-allele association file can be accepted.
-        # self.map_synonyms()               # Suppressed until AGM has proper support for synonyms.
+        self.map_genotype_components()
+        # self.map_synonyms()    # Suppressed until AGM has proper support for synonyms.
         self.map_data_provider_dto()
         self.map_xrefs()
         self.map_pubs()

--- a/src/agm_handlers.py
+++ b/src/agm_handlers.py
@@ -86,7 +86,7 @@ class StrainHandler(PrimaryEntityHandler):
         for strain in self.fb_data_entities.values():
             agr_strain = self.agr_export_type()
             agr_strain.obsolete = strain.chado_obj.is_obsolete
-            agr_strain.mod_entity_id = f'FB:{strain.uniquename}'
+            agr_strain.primary_external_id = f'FB:{strain.uniquename}'
             agr_strain.taxon_curie = strain.ncbi_taxon_id
             agr_strain.name = strain.name
             agr_strain.subtype_name = 'strain'
@@ -503,7 +503,7 @@ class GenotypeHandler(PrimaryEntityHandler):
         for genotype in self.fb_data_entities.values():
             agr_genotype = self.agr_export_type()
             agr_genotype.obsolete = genotype.chado_obj.is_obsolete
-            agr_genotype.mod_entity_id = f'FB:{genotype.fb_curie}'
+            agr_genotype.primary_external_id = f'FB:{genotype.fb_curie}'
             agr_genotype.taxon_curie = genotype.ncbi_taxon_id
             agr_genotype.name = genotype.name
             agr_genotype.subtype_name = 'genotype'

--- a/src/agm_handlers.py
+++ b/src/agm_handlers.py
@@ -157,6 +157,9 @@ class GenotypeHandler(PrimaryEntityHandler):
         # 525357: 'w[*]; betaTub60D[2] Kr[If-1]|CyO',                              # Genotype from stock; genotype_id here is for FB2024_06 only.
     }
 
+    # Additional export sets.
+    agm_component_associations = []    # A list of AgmAlleleAssociationDTOs.
+
     # Additional reference info.
     dmel_insertion_allele_ids = []    # feature_ids for alleles related to FBti insertions (associated_with/progenitor).
     transgenic_allele_ids = []        # feature_ids for alleles related to FBtp constructs.
@@ -521,9 +524,11 @@ class GenotypeHandler(PrimaryEntityHandler):
         for genotype in self.fb_data_entities.values():
             for zygosity, component_feature_id_list in genotype.component_features.items():
                 for feature_id in component_feature_id_list:
+                    geno_allele_rel = fb_datatypes.FBExportEntity()
                     component_curie = self.feature_lookup[feature_id]['curie']
-                    agm_component = agr_datatypes.AffectedGenomicModelComponentDTO(component_curie, zygosity)
-                    genotype.linkmldto.component_dtos.append(agm_component.dict_export())
+                    geno_allele_rel.linkmldto = agr_datatypes.AgmAlleleAssociationDTO(genotype.linkmldto.primary_external_id,
+                                                                                      component_curie, zygosity)
+                    self.agm_component_associations.append(geno_allele_rel)
         return
 
     def flag_unexportable_genotypes(self):
@@ -549,8 +554,8 @@ class GenotypeHandler(PrimaryEntityHandler):
         """Extend the method for the GenotypeHandler."""
         super().map_fb_data_to_alliance()
         self.map_genotype_basic()
-        self.map_genotype_components()
-        # self.map_synonyms()
+        # self.map_genotype_components()    # Suppressed until AGM-allele association file can be accepted.
+        # self.map_synonyms()               # Suppressed until AGM has proper support for synonyms.
         self.map_data_provider_dto()
         self.map_xrefs()
         self.map_pubs()
@@ -558,4 +563,13 @@ class GenotypeHandler(PrimaryEntityHandler):
         self.map_secondary_ids('agm_secondary_id_dtos')
         self.flag_internal_fb_entities('fb_data_entities')
         self.flag_unexportable_genotypes()
+        self.flag_internal_fb_entities('agm_component_associations')
+        return
+
+    # Elaborate on query_chado_and_export() for the GenotypeHandler.
+    def query_chado_and_export(self, session):
+        """Elaborate on query_chado_and_export method for the GenotypeHandler."""
+        super().query_chado_and_export(session)
+        self.flag_unexportable_entities(self.agm_component_associations, 'agm_allele_association_ingest_set')
+        self.generate_export_dict(self.agm_component_associations, 'agm_allele_association_ingest_set')
         return

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -71,7 +71,7 @@ class AffectedGenomicModelDTO(GenomicEntityDTO):
         self.subtype_name = None           # "strain" or "genotype".
         self.agm_secondary_id_dtos = []    # Secondary IDs.
         self.reference_curies = []         # Publication curies (PMID or FBrf).
-        self.component_dtos = []           # AffectedGenomicModelComponentDTOs.
+        # self.component_dtos = []         # Retired in LinkML v2.9.0.
         self.required_fields.extend(['subtype_name'])
 
 
@@ -163,6 +163,32 @@ class SingleReferenceAssociationDTO(AuditedObjectDTO):
         super().__init__()
         self.reference_curie = None
         self.required_fields.extend([])
+
+
+class AgmAlleleAssociationDTO(AuditedObjectDTO):
+    """AgmAlleleAssociationDTO class."""
+    def __init__(self, genotype_curie, component_curie, zygosity):
+        """Create AgmAlleleAssociationDTO for FlyBase object."""
+        super().__init__()
+        self.agm_subject_identifier = genotype_curie
+        self.allele_identifier = component_curie
+        self.zygosity_curie = self.zygosity_id[zygosity]
+        self.required_fields.extend(['agm_subject_identifier', 'allele_identifier', 'zygosity_curie'])
+    # Zygosity mapping to GENO IDs.
+    # https://github.com/monarch-initiative/GENO-ontology/blob/develop/geno-base.obo
+    zygosity_id = {
+        # 'hemizygous': 'GENO:0000134_hemizygous',                          # Not yet implemented in FB code.
+        # 'heterozygous': 'GENO:0000135',                                   # Retired in favor of more specific terms.
+        'simple heterozygous': 'GENO:0000458_simple_heterozygous',
+        'compound heterozygous': 'GENO:0000402_compound_heterozygous',
+        'homozygous': 'GENO:0000136_homozygous',
+        'unspecified zygosity': 'GENO:0000137_unspecified_zygosity',
+        # 'homoplasmic': 'GENO:0000602',
+        # 'heteroplasmic': 'GENO:0000603',
+        # 'hemizygous X-linked': 'GENO:0000604',
+        # 'hemizygous Y-linked': 'GENO:0000605',
+        # 'hemizygous insertion-linked': 'GENO:0000606'
+    }    
 
 
 class AlleleGenomicEntityAssociationDTO(EvidenceAssociationDTO):

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -38,7 +38,7 @@ class SubmittedObjectDTO(AuditedObjectDTO):
     def __init__(self):
         """Create SubmittedObjectDTO for FlyBase objects."""
         super().__init__()
-        self.mod_entity_id = None
+        self.primary_external_id = None
         self.mod_internal_id = None
         self.data_provider_dto = None
         self.required_fields.extend(['data_provider_dto'])
@@ -100,7 +100,7 @@ class AlleleDTO(GenomicEntityDTO):
         self.is_extrachromosomal = None                        # N/A (WB).
         self.is_integrated = None                              # N/A (WB).
         self.laboratory_of_origin_curie = None                 # N/A (WB).
-        self.required_fields.extend(['allele_symbol_dto', 'mod_entity_id'])
+        self.required_fields.extend(['allele_symbol_dto', 'primary_external_id'])
 
 
 class GeneDTO(GenomicEntityDTO):
@@ -231,7 +231,7 @@ class AnnotationDTO(SingleReferenceAssociationDTO):
         """Create AnnotationDTO for FlyBase object."""
         super().__init__()
         self.reference_curie = reference_curie
-        self.mod_entity_id = None
+        self.primary_external_id = None
         self.mod_internal_id = None
         self.data_provider_dto = None
         self.note_dtos = []

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -173,7 +173,8 @@ class AgmAlleleAssociationDTO(AuditedObjectDTO):
         self.agm_subject_identifier = genotype_curie
         self.allele_identifier = component_curie
         self.zygosity_curie = self.zygosity_id[zygosity]
-        self.required_fields.extend(['agm_subject_identifier', 'allele_identifier', 'zygosity_curie'])
+        self.relation_name = 'AGM Allele Association Relation'
+        self.required_fields.extend(['agm_subject_identifier', 'allele_identifier', 'zygosity_curie', 'relation_name'])
     # Zygosity mapping to GENO IDs.
     # https://github.com/monarch-initiative/GENO-ontology/blob/develop/geno-base.obo
     zygosity_id = {

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -188,7 +188,7 @@ class AgmAlleleAssociationDTO(AuditedObjectDTO):
         # 'hemizygous X-linked': 'GENO:0000604',
         # 'hemizygous Y-linked': 'GENO:0000605',
         # 'hemizygous insertion-linked': 'GENO:0000606'
-    }    
+    }
 
 
 class AlleleGenomicEntityAssociationDTO(EvidenceAssociationDTO):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -37,7 +37,7 @@ class MetaAlleleHandler(FeatureHandler):
         for metaallele in self.fb_data_entities.values():
             agr_allele = self.agr_export_type()
             agr_allele.obsolete = metaallele.chado_obj.is_obsolete
-            agr_allele.mod_entity_id = f'FB:{metaallele.uniquename}'
+            agr_allele.primary_external_id = f'FB:{metaallele.uniquename}'
             # agr_allele.mod_internal_id = f'FB.feature_id={metaallele.chado_obj.feature_id}'
             agr_allele.taxon_curie = metaallele.ncbi_taxon_id
             metaallele.linkmldto = agr_allele

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -402,7 +402,7 @@ class ConstructHandler(FeatureHandler):
         for construct in self.fb_data_entities.values():
             agr_construct = self.agr_export_type()
             agr_construct.obsolete = construct.chado_obj.is_obsolete
-            agr_construct.mod_entity_id = f'FB:{construct.uniquename}'
+            agr_construct.primary_external_id = f'FB:{construct.uniquename}'
             # agr_construct.mod_internal_id = f'FB.feature_id={construct.chado_obj.feature_id}'
             construct.linkmldto = agr_construct
         return

--- a/src/gene_handler.py
+++ b/src/gene_handler.py
@@ -139,7 +139,7 @@ class GeneHandler(FeatureHandler):
         for gene in self.fb_data_entities.values():
             agr_gene = self.agr_export_type()
             agr_gene.obsolete = gene.chado_obj.is_obsolete
-            agr_gene.mod_entity_id = f'FB:{gene.uniquename}'
+            agr_gene.primary_external_id = f'FB:{gene.uniquename}'
             # agr_gene.mod_internal_id = f'FB.feature_id={gene.db_primary_id}'
             agr_gene.taxon_curie = gene.ncbi_taxon_id
             gene.linkmldto = agr_gene


### PR DESCRIPTION
Key changes:
1. Use `primary_external_id` in place of `mod_entity_id`.
2. Export genotype(AGM)-allele associations in their own file, instead of as `component_dtos` listed under the genotype(AGM) itself.

The new code generates export files that validate against LinkML v2.9.0 (see run #39 of the Alliance_LinkML_Full_Test pipeline).