### PR TITLE
Report FBal as FBti; report aberration-gene associations; report pubs in evidence_curies slots.

### DIFF
--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,7 +25,7 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-from allele_handlers import AlleleHandler    # BOB, AberrationHandler, BalancerHandler
+from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.
@@ -82,16 +82,16 @@ def main():
 
     # Get the data and process it.
     allele_handler = AlleleHandler(log, testing)
-    # aberration_handler = AberrationHandler(log, testing)
-    # balancer_handler = BalancerHandler(log, testing)
+    aberration_handler = AberrationHandler(log, testing)
+    balancer_handler = BalancerHandler(log, testing)
     if reference_session:
         export_chado_data(session, log, allele_handler, reference_session=reference_session)
-        # export_chado_data(session, log, aberration_handler, reference_session=reference_session)
-        # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
+        export_chado_data(session, log, aberration_handler, reference_session=reference_session)
+        export_chado_data(session, log, balancer_handler, reference_session=reference_session)
     else:
         export_chado_data(session, log, allele_handler)
-        # export_chado_data(session, log, aberration_handler)
-        # export_chado_data(session, log, balancer_handler)
+        export_chado_data(session, log, aberration_handler)
+        export_chado_data(session, log, balancer_handler)
 
     # Export the data.
     export_dict = {
@@ -100,8 +100,8 @@ def main():
     }
     export_dict['allele_ingest_set'] = []
     export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
-    # export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
-    # export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
+    export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
+    export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
 
     if not reference_session:

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -85,11 +85,11 @@ def main():
     aberration_handler = AberrationHandler(log, testing)
     # balancer_handler = BalancerHandler(log, testing)
     if reference_session:
-        # export_chado_data(session, log, allele_handler, reference_session=reference_session)    # BOB
+        export_chado_data(session, log, allele_handler, reference_session=reference_session)
         export_chado_data(session, log, aberration_handler, reference_session=reference_session)
         # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
     else:
-        # export_chado_data(session, log, allele_handler)    # BOB
+        export_chado_data(session, log, allele_handler)
         export_chado_data(session, log, aberration_handler)
         # export_chado_data(session, log, balancer_handler)
 
@@ -99,7 +99,7 @@ def main():
         'alliance_member_release_version': database_release,
     }
     export_dict['allele_ingest_set'] = []
-    # export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])    # BOB
+    export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
     export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
     # export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
@@ -112,7 +112,7 @@ def main():
             'alliance_member_release_version': database_release,
         }
         association_export_dict['allele_gene_association_ingest_set'] = []
-        # association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])   # BOB
+        association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
         association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
         generate_export_file(association_export_dict, log, association_output_filename)
 

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,8 +25,7 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-# from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler
-from allele_handlers import AberrationHandler, BalancerHandler
+from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.
@@ -82,15 +81,15 @@ def main():
     log.info(f'Output JSON file corresponds to "agr_curation_schema" release: {linkml_release}')
 
     # Get the data and process it.
-    # allele_handler = AlleleHandler(log, testing)
+    allele_handler = AlleleHandler(log, testing)
     aberration_handler = AberrationHandler(log, testing)
     balancer_handler = BalancerHandler(log, testing)
     if reference_session:
-        # export_chado_data(session, log, allele_handler, reference_session=reference_session)
+        export_chado_data(session, log, allele_handler, reference_session=reference_session)
         export_chado_data(session, log, aberration_handler, reference_session=reference_session)
         export_chado_data(session, log, balancer_handler, reference_session=reference_session)
     else:
-        # export_chado_data(session, log, allele_handler)
+        export_chado_data(session, log, allele_handler)
         export_chado_data(session, log, aberration_handler)
         export_chado_data(session, log, balancer_handler)
 
@@ -100,7 +99,7 @@ def main():
         'alliance_member_release_version': database_release,
     }
     export_dict['allele_ingest_set'] = []
-    # export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
+    export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
     export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
     export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
@@ -113,8 +112,7 @@ def main():
             'alliance_member_release_version': database_release,
         }
         association_export_dict['allele_gene_association_ingest_set'] = []
-        # association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
-        # Suppress aberration-gene export for now.
+        association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
         association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
         generate_export_file(association_export_dict, log, association_output_filename)
 

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,7 +25,8 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler, InsertionHandler
+# from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler, InsertionHandler
+from allele_handlers import InsertionHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.
@@ -81,19 +82,19 @@ def main():
     log.info(f'Output JSON file corresponds to "agr_curation_schema" release: {linkml_release}')
 
     # Get the data and process it.
-    aberration_handler = AberrationHandler(log, testing)
-    allele_handler = AlleleHandler(log, testing)
-    balancer_handler = BalancerHandler(log, testing)
+    # aberration_handler = AberrationHandler(log, testing)
+    # allele_handler = AlleleHandler(log, testing)
+    # balancer_handler = BalancerHandler(log, testing)
     insertion_handler = InsertionHandler(log, testing)
     if reference_session:
-        export_chado_data(session, log, aberration_handler, reference_session=reference_session)
-        export_chado_data(session, log, allele_handler, reference_session=reference_session)
-        export_chado_data(session, log, balancer_handler, reference_session=reference_session)
+        # export_chado_data(session, log, aberration_handler, reference_session=reference_session)
+        # export_chado_data(session, log, allele_handler, reference_session=reference_session)
+        # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
         export_chado_data(session, log, insertion_handler, reference_session=reference_session)
     else:
-        export_chado_data(session, log, aberration_handler)
-        export_chado_data(session, log, allele_handler)
-        export_chado_data(session, log, balancer_handler)
+        # export_chado_data(session, log, aberration_handler)
+        # export_chado_data(session, log, allele_handler)
+        # export_chado_data(session, log, balancer_handler)
         export_chado_data(session, log, insertion_handler)
 
     # Export the data.
@@ -116,7 +117,7 @@ def main():
             'alliance_member_release_version': database_release,
         }
         association_export_dict['allele_gene_association_ingest_set'] = []
-        association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
+        # association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
         # association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
         generate_export_file(association_export_dict, log, association_output_filename)
 

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -85,11 +85,11 @@ def main():
     aberration_handler = AberrationHandler(log, testing)
     # balancer_handler = BalancerHandler(log, testing)
     if reference_session:
-        export_chado_data(session, log, allele_handler, reference_session=reference_session)
+        # export_chado_data(session, log, allele_handler, reference_session=reference_session)    # BOB
         export_chado_data(session, log, aberration_handler, reference_session=reference_session)
         # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
     else:
-        export_chado_data(session, log, allele_handler)
+        # export_chado_data(session, log, allele_handler)    # BOB
         export_chado_data(session, log, aberration_handler)
         # export_chado_data(session, log, balancer_handler)
 
@@ -99,7 +99,7 @@ def main():
         'alliance_member_release_version': database_release,
     }
     export_dict['allele_ingest_set'] = []
-    export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
+    # export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])    # BOB
     export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
     # export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
@@ -112,7 +112,7 @@ def main():
             'alliance_member_release_version': database_release,
         }
         association_export_dict['allele_gene_association_ingest_set'] = []
-        association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
+        # association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])   # BOB
         association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
         generate_export_file(association_export_dict, log, association_output_filename)
 

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,7 +25,7 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler
+from allele_handlers import AlleleHandler, AberrationHandler    #, BalancerHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.
@@ -83,15 +83,15 @@ def main():
     # Get the data and process it.
     allele_handler = AlleleHandler(log, testing)
     aberration_handler = AberrationHandler(log, testing)
-    balancer_handler = BalancerHandler(log, testing)
+    # balancer_handler = BalancerHandler(log, testing)
     if reference_session:
         export_chado_data(session, log, allele_handler, reference_session=reference_session)
         export_chado_data(session, log, aberration_handler, reference_session=reference_session)
-        export_chado_data(session, log, balancer_handler, reference_session=reference_session)
+        # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
     else:
         export_chado_data(session, log, allele_handler)
         export_chado_data(session, log, aberration_handler)
-        export_chado_data(session, log, balancer_handler)
+        # export_chado_data(session, log, balancer_handler)
 
     # Export the data.
     export_dict = {
@@ -101,7 +101,7 @@ def main():
     export_dict['allele_ingest_set'] = []
     export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
     export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
-    export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
+    # export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
 
     if not reference_session:

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,7 +25,8 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler, InsertionHandler
+# from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler, InsertionHandler
+from allele_handlers import InsertionHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.
@@ -81,19 +82,19 @@ def main():
     log.info(f'Output JSON file corresponds to "agr_curation_schema" release: {linkml_release}')
 
     # Get the data and process it.
-    aberration_handler = AberrationHandler(log, testing)
-    allele_handler = AlleleHandler(log, testing)
-    balancer_handler = BalancerHandler(log, testing)
+    # aberration_handler = AberrationHandler(log, testing)
+    # allele_handler = AlleleHandler(log, testing)
+    # balancer_handler = BalancerHandler(log, testing)
     insertion_handler = InsertionHandler(log, testing)
     if reference_session:
-        export_chado_data(session, log, aberration_handler, reference_session=reference_session)
-        export_chado_data(session, log, allele_handler, reference_session=reference_session)
-        export_chado_data(session, log, balancer_handler, reference_session=reference_session)
+        # export_chado_data(session, log, aberration_handler, reference_session=reference_session)
+        # export_chado_data(session, log, allele_handler, reference_session=reference_session)
+        # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
         export_chado_data(session, log, insertion_handler, reference_session=reference_session)
     else:
-        export_chado_data(session, log, aberration_handler)
-        export_chado_data(session, log, allele_handler)
-        export_chado_data(session, log, balancer_handler)
+        # export_chado_data(session, log, aberration_handler)
+        # export_chado_data(session, log, allele_handler)
+        # export_chado_data(session, log, balancer_handler)
         export_chado_data(session, log, insertion_handler)
 
     # Export the data.
@@ -102,9 +103,9 @@ def main():
         'alliance_member_release_version': database_release,
     }
     export_dict['allele_ingest_set'] = []
-    export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
-    export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
-    export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
+    # export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
+    # export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
+    # export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     export_dict['allele_ingest_set'].extend(insertion_handler.export_data[insertion_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
 
@@ -116,7 +117,7 @@ def main():
             'alliance_member_release_version': database_release,
         }
         association_export_dict['allele_gene_association_ingest_set'] = []
-        association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
+        # association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
         # Suppress aberration-gene export for now.
         # association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
         generate_export_file(association_export_dict, log, association_output_filename)

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,8 +25,7 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-# from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler, InsertionHandler
-from allele_handlers import InsertionHandler
+from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.
@@ -82,20 +81,17 @@ def main():
     log.info(f'Output JSON file corresponds to "agr_curation_schema" release: {linkml_release}')
 
     # Get the data and process it.
+    allele_handler = AlleleHandler(log, testing)
     # aberration_handler = AberrationHandler(log, testing)
-    # allele_handler = AlleleHandler(log, testing)
     # balancer_handler = BalancerHandler(log, testing)
-    insertion_handler = InsertionHandler(log, testing)
     if reference_session:
+        export_chado_data(session, log, allele_handler, reference_session=reference_session)
         # export_chado_data(session, log, aberration_handler, reference_session=reference_session)
-        # export_chado_data(session, log, allele_handler, reference_session=reference_session)
         # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
-        export_chado_data(session, log, insertion_handler, reference_session=reference_session)
     else:
+        export_chado_data(session, log, allele_handler)
         # export_chado_data(session, log, aberration_handler)
-        # export_chado_data(session, log, allele_handler)
         # export_chado_data(session, log, balancer_handler)
-        export_chado_data(session, log, insertion_handler)
 
     # Export the data.
     export_dict = {
@@ -103,10 +99,9 @@ def main():
         'alliance_member_release_version': database_release,
     }
     export_dict['allele_ingest_set'] = []
+    export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
     # export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
-    # export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
     # export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
-    export_dict['allele_ingest_set'].extend(insertion_handler.export_data[insertion_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
 
     if not reference_session:
@@ -117,7 +112,7 @@ def main():
             'alliance_member_release_version': database_release,
         }
         association_export_dict['allele_gene_association_ingest_set'] = []
-        # association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
+        association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
         # Suppress aberration-gene export for now.
         # association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
         generate_export_file(association_export_dict, log, association_output_filename)

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -82,16 +82,16 @@ def main():
 
     # Get the data and process it.
     allele_handler = AlleleHandler(log, testing)
-    aberration_handler = AberrationHandler(log, testing)
-    balancer_handler = BalancerHandler(log, testing)
+    # aberration_handler = AberrationHandler(log, testing)
+    # balancer_handler = BalancerHandler(log, testing)
     if reference_session:
         export_chado_data(session, log, allele_handler, reference_session=reference_session)
-        export_chado_data(session, log, aberration_handler, reference_session=reference_session)
-        export_chado_data(session, log, balancer_handler, reference_session=reference_session)
+        # export_chado_data(session, log, aberration_handler, reference_session=reference_session)
+        # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
     else:
         export_chado_data(session, log, allele_handler)
-        export_chado_data(session, log, aberration_handler)
-        export_chado_data(session, log, balancer_handler)
+        # export_chado_data(session, log, aberration_handler)
+        # export_chado_data(session, log, balancer_handler)
 
     # Export the data.
     export_dict = {
@@ -100,8 +100,8 @@ def main():
     }
     export_dict['allele_ingest_set'] = []
     export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
-    export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
-    export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
+    # export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
+    # export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
 
     if not reference_session:

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,8 +25,7 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-# from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler, InsertionHandler
-from allele_handlers import InsertionHandler
+from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler, InsertionHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.
@@ -82,19 +81,19 @@ def main():
     log.info(f'Output JSON file corresponds to "agr_curation_schema" release: {linkml_release}')
 
     # Get the data and process it.
-    # aberration_handler = AberrationHandler(log, testing)
-    # allele_handler = AlleleHandler(log, testing)
-    # balancer_handler = BalancerHandler(log, testing)
+    aberration_handler = AberrationHandler(log, testing)
+    allele_handler = AlleleHandler(log, testing)
+    balancer_handler = BalancerHandler(log, testing)
     insertion_handler = InsertionHandler(log, testing)
     if reference_session:
-        # export_chado_data(session, log, aberration_handler, reference_session=reference_session)
-        # export_chado_data(session, log, allele_handler, reference_session=reference_session)
-        # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
+        export_chado_data(session, log, aberration_handler, reference_session=reference_session)
+        export_chado_data(session, log, allele_handler, reference_session=reference_session)
+        export_chado_data(session, log, balancer_handler, reference_session=reference_session)
         export_chado_data(session, log, insertion_handler, reference_session=reference_session)
     else:
-        # export_chado_data(session, log, aberration_handler)
-        # export_chado_data(session, log, allele_handler)
-        # export_chado_data(session, log, balancer_handler)
+        export_chado_data(session, log, aberration_handler)
+        export_chado_data(session, log, allele_handler)
+        export_chado_data(session, log, balancer_handler)
         export_chado_data(session, log, insertion_handler)
 
     # Export the data.
@@ -103,9 +102,9 @@ def main():
         'alliance_member_release_version': database_release,
     }
     export_dict['allele_ingest_set'] = []
-    # export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
-    # export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
-    # export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
+    export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
+    export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
+    export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     export_dict['allele_ingest_set'].extend(insertion_handler.export_data[insertion_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
 
@@ -117,7 +116,8 @@ def main():
             'alliance_member_release_version': database_release,
         }
         association_export_dict['allele_gene_association_ingest_set'] = []
-        # association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
+        association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
+        # Suppress aberration-gene export for now.
         # association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
         generate_export_file(association_export_dict, log, association_output_filename)
 

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,7 +25,7 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler
+from allele_handlers import AlleleHandler    # BOB, AberrationHandler, BalancerHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,7 +25,8 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler
+# from allele_handlers import AlleleHandler, AberrationHandler, BalancerHandler
+from allele_handlers import AberrationHandler, BalancerHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.
@@ -81,15 +82,15 @@ def main():
     log.info(f'Output JSON file corresponds to "agr_curation_schema" release: {linkml_release}')
 
     # Get the data and process it.
-    allele_handler = AlleleHandler(log, testing)
+    # allele_handler = AlleleHandler(log, testing)
     aberration_handler = AberrationHandler(log, testing)
     balancer_handler = BalancerHandler(log, testing)
     if reference_session:
-        export_chado_data(session, log, allele_handler, reference_session=reference_session)
+        # export_chado_data(session, log, allele_handler, reference_session=reference_session)
         export_chado_data(session, log, aberration_handler, reference_session=reference_session)
         export_chado_data(session, log, balancer_handler, reference_session=reference_session)
     else:
-        export_chado_data(session, log, allele_handler)
+        # export_chado_data(session, log, allele_handler)
         export_chado_data(session, log, aberration_handler)
         export_chado_data(session, log, balancer_handler)
 
@@ -99,7 +100,7 @@ def main():
         'alliance_member_release_version': database_release,
     }
     export_dict['allele_ingest_set'] = []
-    export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
+    # export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
     export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
     export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
@@ -112,9 +113,9 @@ def main():
             'alliance_member_release_version': database_release,
         }
         association_export_dict['allele_gene_association_ingest_set'] = []
-        association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
+        # association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
         # Suppress aberration-gene export for now.
-        # association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
+        association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
         generate_export_file(association_export_dict, log, association_output_filename)
 
     log.info('Ended main function.\n')

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -25,7 +25,7 @@ import argparse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
-from allele_handlers import AlleleHandler, AberrationHandler    #, BalancerHandler
+from allele_handlers import AlleleHandler, AberrationHandler    # BalancerHandler
 from utils import export_chado_data, generate_export_file
 
 # Data types handled by this script.

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -82,16 +82,16 @@ def main():
 
     # Get the data and process it.
     allele_handler = AlleleHandler(log, testing)
-    # aberration_handler = AberrationHandler(log, testing)
-    # balancer_handler = BalancerHandler(log, testing)
+    aberration_handler = AberrationHandler(log, testing)
+    balancer_handler = BalancerHandler(log, testing)
     if reference_session:
         export_chado_data(session, log, allele_handler, reference_session=reference_session)
-        # export_chado_data(session, log, aberration_handler, reference_session=reference_session)
-        # export_chado_data(session, log, balancer_handler, reference_session=reference_session)
+        export_chado_data(session, log, aberration_handler, reference_session=reference_session)
+        export_chado_data(session, log, balancer_handler, reference_session=reference_session)
     else:
         export_chado_data(session, log, allele_handler)
-        # export_chado_data(session, log, aberration_handler)
-        # export_chado_data(session, log, balancer_handler)
+        export_chado_data(session, log, aberration_handler)
+        export_chado_data(session, log, balancer_handler)
 
     # Export the data.
     export_dict = {
@@ -100,8 +100,8 @@ def main():
     }
     export_dict['allele_ingest_set'] = []
     export_dict['allele_ingest_set'].extend(allele_handler.export_data[allele_handler.primary_export_set])
-    # export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
-    # export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
+    export_dict['allele_ingest_set'].extend(aberration_handler.export_data[aberration_handler.primary_export_set])
+    export_dict['allele_ingest_set'].extend(balancer_handler.export_data[balancer_handler.primary_export_set])
     generate_export_file(export_dict, log, output_filename)
 
     if not reference_session:

--- a/src/agm_handlers.py
+++ b/src/agm_handlers.py
@@ -430,8 +430,8 @@ class GenotypeHandler(PrimaryEntityHandler):
                     geno_allele_rel = fb_datatypes.FBExportEntity()
                     component_curie = self.feature_lookup[feature_id]['curie']
                     # Do not report FBtp construct or FBba balancer components for genotypes.
-                    # FBal alleles, FBti insertions and FBab aberrations are ok.
-                    if component_curie.startswith('FBtp') or component_curie.startswith('FBba'):
+                    # FBal alleles, FBti insertions, and FBab aberrations are ok.
+                    if component_curie.startswith('FB:FBtp') or component_curie.startswith('FB:FBba'):
                         continue
                     geno_allele_rel.linkmldto = agr_datatypes.AgmAlleleAssociationDTO(genotype.linkmldto.primary_external_id,
                                                                                       component_curie, zygosity)

--- a/src/agm_handlers.py
+++ b/src/agm_handlers.py
@@ -429,6 +429,10 @@ class GenotypeHandler(PrimaryEntityHandler):
                 for feature_id in component_feature_id_list:
                     geno_allele_rel = fb_datatypes.FBExportEntity()
                     component_curie = self.feature_lookup[feature_id]['curie']
+                    # Do not report FBtp construct or FBba balancer components for genotypes.
+                    # FBal alleles, FBti insertions and FBab aberrations are ok.
+                    if component_curie.startswith('FBtp') or component_curie.startswith('FBba'):
+                        continue
                     geno_allele_rel.linkmldto = agr_datatypes.AgmAlleleAssociationDTO(genotype.linkmldto.primary_external_id,
                                                                                       component_curie, zygosity)
                     self.agm_component_associations.append(geno_allele_rel)

--- a/src/agm_handlers.py
+++ b/src/agm_handlers.py
@@ -425,6 +425,8 @@ class GenotypeHandler(PrimaryEntityHandler):
         """Map genotype components."""
         self.log.info('Map genotype components.')
         for genotype in self.fb_data_entities.values():
+            if genotype.for_export is False:
+                continue
             for zygosity, component_feature_id_list in genotype.component_features.items():
                 for feature_id in component_feature_id_list:
                     geno_allele_rel = fb_datatypes.FBExportEntity()

--- a/src/agm_handlers.py
+++ b/src/agm_handlers.py
@@ -446,14 +446,17 @@ class GenotypeHandler(PrimaryEntityHandler):
         fbtp_counter = 0
         fbti_counter = 0
         for genotype in self.fb_data_entities.values():
-            if genotype.has_fbtp_component is True:
-                genotype.for_export = False
-                genotype.export_warnings.append('Directly related to FBtp construct feature')
-                fbtp_counter += 1
-            if genotype.has_fbti_component is True:
-                genotype.for_export = False
-                genotype.export_warnings.append('Directly related to FBti insertion feature')
-                fbti_counter += 1
+        # BOB - FBti will be submitted as alleles, so these are now allowed to be exported.
+        # What to do with genotypes referencing FBtp (or FBba) - do not export, or export but as internal or obsolete.
+
+            # if genotype.has_fbtp_component is True:
+            #     genotype.for_export = False
+            #     genotype.export_warnings.append('Directly related to FBtp construct feature')
+            #     fbtp_counter += 1
+            # if genotype.has_fbti_component is True:
+            #     genotype.for_export = False
+            #     genotype.export_warnings.append('Directly related to FBti insertion feature')
+            #     fbti_counter += 1
         self.log.info(f'Marked {fbtp_counter} genotypes as unexportable due to direct association with an FBtp construct feature.')
         self.log.info(f'Marked {fbti_counter} genotypes as unexportable due to direct association with an FBti insertion feature.')
         return

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -173,17 +173,17 @@ class AgmAlleleAssociationDTO(AuditedObjectDTO):
         self.agm_subject_identifier = genotype_curie
         self.allele_identifier = component_curie
         self.zygosity_curie = self.zygosity_id[zygosity]
-        self.relation_name = 'AGM Allele Association Relation'
+        self.relation_name = 'contains'
         self.required_fields.extend(['agm_subject_identifier', 'allele_identifier', 'zygosity_curie', 'relation_name'])
     # Zygosity mapping to GENO IDs.
     # https://github.com/monarch-initiative/GENO-ontology/blob/develop/geno-base.obo
     zygosity_id = {
         # 'hemizygous': 'GENO:0000134_hemizygous',                          # Not yet implemented in FB code.
         # 'heterozygous': 'GENO:0000135',                                   # Retired in favor of more specific terms.
-        'simple heterozygous': 'GENO:0000458_simple_heterozygous',
-        'compound heterozygous': 'GENO:0000402_compound_heterozygous',
-        'homozygous': 'GENO:0000136_homozygous',
-        'unspecified zygosity': 'GENO:0000137_unspecified_zygosity',
+        'simple heterozygous': 'GENO:0000458',
+        'compound heterozygous': 'GENO:0000402',
+        'homozygous': 'GENO:0000136',
+        'unspecified zygosity': 'GENO:0000137',
         # 'homoplasmic': 'GENO:0000602',
         # 'heteroplasmic': 'GENO:0000603',
         # 'hemizygous X-linked': 'GENO:0000604',

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -227,7 +227,6 @@ class AlleleGeneAssociationDTO(AlleleGenomicEntityAssociationDTO):
         self.gene_identifier = gene_id
         self.evidence_curies = evidence_curies
         self.required_fields.extend(['gene_identifier'])
-        # self.internal_fields.extend(['evidence_curies'])    # Suppress "evidence_curies" if file load takes too long.
 
 
 class ConstructGenomicEntityAssociationDTO(EvidenceAssociationDTO):
@@ -249,7 +248,6 @@ class ConstructGenomicEntityAssociationDTO(EvidenceAssociationDTO):
         # self.evidence_curies = evidence_curies
         self.note_dtos = []
         self.required_fields.extend(['construct_identifier', 'genomic_entity_relation_name', 'genomic_entity_identifier'])
-        # self.internal_fields.extend(['evidence_curies'])    # Suppress "evidence_curies" if file load takes too long.
 
 
 class AnnotationDTO(SingleReferenceAssociationDTO):
@@ -392,7 +390,6 @@ class SlotAnnotationDTO(AuditedObjectDTO):
         """
         super().__init__()
         self.evidence_curies = evidence_curies
-        # self.internal_fields.extend(['evidence_curies'])    # Suppress "evidence_curies" if file load takes too long.
 
 
 class AlleleDatabaseStatusSlotAnnotationDTO(SlotAnnotationDTO):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -283,7 +283,7 @@ class AlleleHandler(MetaAlleleHandler):
 
     def get_insertion_entities(self, session):
         """Have the AlleleHandler run the InsertionHandler."""
-        separator = 80*'#'
+        separator = 80 * '#'
         self.log.info(f'Have the AlleleHandler run the InsertionHandler.\n{separator}')
         insertion_handler = InsertionHandler(self.log, self.testing)
         export_chado_data(session, self.log, insertion_handler)
@@ -323,50 +323,58 @@ class AlleleHandler(MetaAlleleHandler):
     def merge_fbti_fbal(self):
         """Merge FBal allele info into FBti insertion entities as appropriate."""
         self.log.info('Merge FBal allele info into FBti insertion entities as appropriate.')
-        lists_to_extend = [
-            'dbxrefs',
-            'export_warnings',
-            'fb_sec_dbxrefs',
-            'internal_reasons',
-            'new_timestamps',
-            'phenstatements',
-            'pub_associations',
-            'synonyms',
-            'timestamps',
-        ]
-        dicts_to_add = [
-            'props_by_type',
-            'cvt_anno_ids_by_cv',
-            'cvt_anno_ids_by_prop',
-            'cvt_anno_ids_by_term',
-            'cvt_annos_by_id',
-            'obj_rel_ids_by_type',
-            'rels_by_id',
-            'sbj_rel_ids_by_type',
-        ]
+        counter = 0
         for insertion in self.fbti_entities:
-            if insertion.db_primary_id not in self.fbti_fbal_dict.keys():
-                self.fb_data_entities[insertion.db_primary_id] = insertion
-                continue
-            for fbal_feature_id in self.fbti_fbal_dict[insertion.db_primary_id]:
-                allele = self.fb_data_entities[fbal_feature_id]
-                for attr_name in lists_to_extend:
-                    allele_list = getattr(allele, attr_name)
-                    insertion_list = getattr(insertion, attr_name)
-                    insertion_list.extend(allele_list)
-                insertion.alt_fb_ids.append('FB:{allele.uniquename}')
-                for attr_name in dicts_to_add:
-                    allele_dict = getattr(allele, attr_name)
-                    insertion_dict = getattr(insertion, attr_name)
-                    for k, v in allele_dict.items():
-                        try:
-                            insertion_dict[k].extend(v)
-                        except KeyError:
-                            insertion_dict[k] = v
-                allele.superceded_by_insertion = True
-                allele.for_export = False
-                allele.export_warnings.append('Superceded by FBti insertion')
             self.fb_data_entities[insertion.db_primary_id] = insertion
+            counter += 1
+        self.log.info(f'Added {counter} FBti insertions to the initial FBal entities list.')
+        # BOB - CONTINUE BELOW
+        #######################################################################################################
+        # lists_to_extend = [
+        #     'dbxrefs',
+        #     'export_warnings',
+        #     'fb_sec_dbxrefs',
+        #     'internal_reasons',
+        #     'new_timestamps',
+        #     'phenstatements',
+        #     'pub_associations',
+        #     'synonyms',
+        #     'timestamps',
+        # ]
+        # dicts_to_add = [
+        #     'props_by_type',
+        #     'cvt_anno_ids_by_cv',
+        #     'cvt_anno_ids_by_prop',
+        #     'cvt_anno_ids_by_term',
+        #     'cvt_annos_by_id',
+        #     'obj_rel_ids_by_type',
+        #     'rels_by_id',
+        #     'sbj_rel_ids_by_type',
+        # ]
+        # for insertion in self.fbti_entities:
+        #     if insertion.db_primary_id not in self.fbti_fbal_dict.keys():
+        #         self.fb_data_entities[insertion.db_primary_id] = insertion
+        #         continue
+        #     for fbal_feature_id in self.fbti_fbal_dict[insertion.db_primary_id]:
+        #         allele = self.fb_data_entities[fbal_feature_id]
+        #         for attr_name in lists_to_extend:
+        #             allele_list = getattr(allele, attr_name)
+        #             insertion_list = getattr(insertion, attr_name)
+        #             insertion_list.extend(allele_list)
+        #         insertion.alt_fb_ids.append('FB:{allele.uniquename}')
+        #         for attr_name in dicts_to_add:
+        #             allele_dict = getattr(allele, attr_name)
+        #             insertion_dict = getattr(insertion, attr_name)
+        #             for k, v in allele_dict.items():
+        #                 try:
+        #                     insertion_dict[k].extend(v)
+        #                 except KeyError:
+        #                     insertion_dict[k] = v
+        #         allele.superceded_by_insertion = True
+        #         allele.for_export = False
+        #         allele.export_warnings.append('Superceded by FBti insertion')
+        #     self.fb_data_entities[insertion.db_primary_id] = insertion
+        #######################################################################################################
         return
 
     def synthesize_related_features(self):
@@ -819,6 +827,7 @@ class InsertionHandler(MetaAlleleHandler):
     #     super().query_chado_and_export(session)
     #     return
     # BOB - I THINK THIS IS UNNECESSARY - DELETE IF CONFIRMED.
+
 
 class AberrationHandler(MetaAlleleHandler):
     """This object gets, synthesizes and filters aberration data for export."""

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -347,18 +347,18 @@ class AlleleHandler(MetaAlleleHandler):
     # Additional sub-methods to be run by synthesize_info() below.
     def add_fbal_to_fbti(self, allele):
         """Add FBal data to a related FBti."""
-        # Safeguard to prevent changes to alleles not superceded by FBti insertion if this method is called by accident.
-        if allele.superceded_by_at_locus_insertion is None and not allele.superceded_by_transgnc_insertions:
+        # Safeguard to prevent changes to alleles not superseded by FBti insertion if this method is called by accident.
+        if allele.superseded_by_at_locus_insertion is None and not allele.superseded_by_transgnc_insertions:
             return
-        # Set FBal allele to be obsolete if it is superceded by any FBti insertion.
+        # Set FBal allele to be obsolete if it is superseded by any FBti insertion.
         allele.is_obsolete = True
         # For transgenic alleles, just add the export warning and move on.
-        if allele.superceded_by_transgnc_insertions:
+        if allele.superseded_by_transgnc_insertions:
             allele.export_warnings.append('Superceded by unspecified FBti insertion of FBtp construct')
             return
         # For alleles derived from at-locus FBti insertions, add FBal data to the FBti.
         allele.export_warnings.append('Superceded by FBti insertion')
-        insertion = self.fbti_entities[allele.superceded_by_at_locus_insertion]
+        insertion = self.fbti_entities[allele.superseded_by_at_locus_insertion]
         self.log.debug(f'Merge {allele} data into {insertion} data.')
         insertion.alt_fb_ids.append(f'FB:{allele.uniquename}')
         lists_to_extend = [
@@ -435,15 +435,15 @@ class AlleleHandler(MetaAlleleHandler):
                 self.log.error(f'Allele {allele} unexpectedly has both at-locus and transgenic unspecified FBti insertions.')
                 prob_counter += 1
             elif allele.db_primary_id in self.at_locus_fbal_fbti_dict.keys():
-                self.log.debug(f'Allele {allele} is superceded by an at-locus FBti insertion.')
-                allele.superceded_by_at_locus_insertion = self.at_locus_fbal_fbti_dict[allele.db_primary_id][0]
+                self.log.debug(f'Allele {allele} is superseded by an at-locus FBti insertion.')
+                allele.superseded_by_at_locus_insertion = self.at_locus_fbal_fbti_dict[allele.db_primary_id][0]
                 self.add_fbal_to_fbti(allele)
                 at_locus_counter += 1
             elif allele.db_primary_id in self.transgenic_fbal_fbti_dict.keys():
-                self.log.debug(f'Allele {allele} is superceded by unspecified FBti insertion(s).')
-                allele.superceded_by_transgnc_insertions = self.transgenic_fbal_fbti_dict[allele.db_primary_id]
+                self.log.debug(f'Allele {allele} is superseded by unspecified FBti insertion(s).')
+                allele.superseded_by_transgnc_insertions = self.transgenic_fbal_fbti_dict[allele.db_primary_id]
                 self.add_fbal_to_fbti(allele)
-                unspecified_ins_counter += len(allele.superceded_by_transgnc_insertions)
+                unspecified_ins_counter += len(allele.superseded_by_transgnc_insertions)
                 transgenic_counter += 1
             else:
                 classical_counter += 1
@@ -592,7 +592,7 @@ class AlleleHandler(MetaAlleleHandler):
         allele_counter = 0
         # Need to code for the rare possibility that gene-allele is represented by many feature_relationships.
         for allele in self.fb_data_entities.values():
-            if allele.superceded_by_at_locus_insertion or allele.superceded_by_transgnc_insertions:
+            if allele.superseded_by_at_locus_insertion or allele.superseded_by_transgnc_insertions:
                 continue
             # Skip transgenic alleles.
             elif allele.uniquename.startswith('FBti') and allele.name.endswith('unspecified'):
@@ -1061,7 +1061,7 @@ class AberrationHandler(MetaAlleleHandler):
                 self.log.debug(f'Aberration {aberration} is annotated to a "assortment_derived_deficiency"-type term.')
             if aberration.is_deletion:
                 counter += 1
-            self.log.info(f'Flagged {counter} aberrations as being some type of deletion.')
+        self.log.info(f'Flagged {counter} aberrations as being some type of deletion.')
         return
 
     def synthesize_aberration_gene_associations(self):
@@ -1211,7 +1211,7 @@ class AberrationHandler(MetaAlleleHandler):
         self.map_xrefs()
         self.map_extinction_info()
         self.map_collections()
-        self.map_pubs()    # Suppress if load times are slow.
+        self.map_pubs()
         self.map_timestamps()
         self.map_secondary_ids('allele_secondary_id_dtos')
         self.flag_internal_fb_entities('fb_data_entities')

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -129,7 +129,7 @@ class AlleleHandler(MetaAlleleHandler):
         super().__init__(log, testing)
         self.datatype = 'allele'
         self.fb_export_type = FBAllele
-        self.fbti_entitites = {}    # Will be feature_id-keyed FBAllele objects generated from FBti insertions.
+        self.fbti_entities = {}    # Will be feature_id-keyed FBAllele objects generated from FBti insertions.
         self.fbti_fbal_dict = {}    # Will be FBti-feature_id keys, with lists of FBal feature_ids to be replaced.
 
     test_set = {

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -375,9 +375,7 @@ class AlleleHandler(MetaAlleleHandler):
         ]
 
         for fbti_feature_id in fbti_feature_ids:
-            if fbti_feature_id not in self.fb_data_entities:
-                self.fb_data_entities[fbti_feature_id] = self.fbti_entities[fbti_feature_id]
-            insertion = self.fb_data_entities[fbti_feature_id]
+            insertion = self.fbti_entities[fbti_feature_id]
             self.log.debug(f'Merge {allele} data into {insertion} data.')
             insertion.alt_fb_ids.append(f'FB:{allele.uniquename}')
             for attr_name in lists_to_extend:
@@ -418,6 +416,7 @@ class AlleleHandler(MetaAlleleHandler):
         at_locus_counter = 0
         transgenic_counter = 0
         classical_counter = 0
+        fbti_counter = 0
         for allele in self.fb_data_entities.values():
             if allele.db_primary_id in self.at_locus_fbal_fbti_dict.keys() and allele.db_primary_id in self.transgenic_fbal_fbti_dict.keys():
                 self.log.error(f'Allele {allele} unexpectedly has both at-locus and transgenic unspecified FBti insertions.')
@@ -436,6 +435,10 @@ class AlleleHandler(MetaAlleleHandler):
         self.log.info(f'Found {at_locus_counter} FBal alleles related to at-locus FBti insertions.')
         self.log.info(f'Found {transgenic_counter} FBal alleles related to unspecified transgenic FBti insertions.')
         self.log.info(f'Found {classical_counter} FBal classical and/or complex alleles to be reported as they are (no FBti replacement).')
+        for fbti_feature_id, insertion in self.fbti_entities.items():
+            self.fb_data_entities[fbti_feature_id] = insertion
+            fbti_counter += 1
+        self.log.info(f'Added {fbti_counter} FBti insertions to the list of FBal alleles for export.')
         return
 
     def synthesize_related_features(self):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -374,6 +374,8 @@ class AlleleHandler(MetaAlleleHandler):
             'cvt_anno_ids_by_term',
             'obj_rel_ids_by_type',
             'sbj_rel_ids_by_type',
+            'sbj_rel_ids_by_obj_type',
+            'obj_rel_ids_by_sbj_type',
         ]
         for fbti_feature_id in fbti_feature_ids:
             insertion = self.fbti_entities[fbti_feature_id]
@@ -465,7 +467,7 @@ class AlleleHandler(MetaAlleleHandler):
                     allele.arg_rels.append(arg_rel)
                     has_args_counter += 1
             # Assess relationships to current constructs.
-            relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='derived_tp_assoc_alleles',
+            relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types=['derived_tp_assoc_alleles', 'producedby'],
                                                              rel_entity_types=self.feature_subtypes['construct'])
             self.log.debug(f'For {allele}, found {len(relevant_cons_rels)} cons rels to review.')
             for cons_rel in relevant_cons_rels:

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -406,11 +406,11 @@ class AlleleHandler(MetaAlleleHandler):
                 prob_counter += 1
             elif allele.db_primary_id in self.at_locus_fbal_fbti_dict.keys():
                 allele.superceded_by_at_locus_insertion = self.at_locus_fbal_fbti_dict[allele.db_primary_id][0]
-                self.add_fbal_to_fbti(self, allele)
+                self.add_fbal_to_fbti(allele)
                 at_locus_counter += 1
             elif allele.db_primary_id in self.transgenic_fbal_fbti_dict.keys():
                 allele.superceded_by_transgnc_insertions = self.transgenic_fbal_fbti_dict[allele.db_primary_id]
-                self.add_fbal_to_fbti(self, allele)
+                self.add_fbal_to_fbti(allele)
                 transgenic_counter += 1
             else:
                 classical_counter += 1

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -348,8 +348,10 @@ class AlleleHandler(MetaAlleleHandler):
     def add_fbal_to_fbti(self, allele):
         """Add FBal data to a related FBti."""
         fbti_feature_ids = []
-        fbti_feature_ids.append(allele.superceded_by_at_locus_insertion)
-        fbti_feature_ids.extend(allele.superceded_by_transgnc_insertions)
+        if allele.superceded_by_at_locus_insertion:
+            fbti_feature_ids.append(allele.superceded_by_at_locus_insertion)
+        if allele.superceded_by_transgnc_insertions:
+            fbti_feature_ids.extend(allele.superceded_by_transgnc_insertions)
         lists_to_extend = [
             'dbxrefs',
             'export_warnings',
@@ -373,7 +375,6 @@ class AlleleHandler(MetaAlleleHandler):
             'obj_rel_ids_by_type',
             'sbj_rel_ids_by_type',
         ]
-
         for fbti_feature_id in fbti_feature_ids:
             insertion = self.fbti_entities[fbti_feature_id]
             self.log.debug(f'Merge {allele} data into {insertion} data.')
@@ -418,14 +419,17 @@ class AlleleHandler(MetaAlleleHandler):
         classical_counter = 0
         fbti_counter = 0
         for allele in self.fb_data_entities.values():
+            self.log.debug(f'Assess FBti replacement for allele {allele}')
             if allele.db_primary_id in self.at_locus_fbal_fbti_dict.keys() and allele.db_primary_id in self.transgenic_fbal_fbti_dict.keys():
                 self.log.error(f'Allele {allele} unexpectedly has both at-locus and transgenic unspecified FBti insertions.')
                 prob_counter += 1
             elif allele.db_primary_id in self.at_locus_fbal_fbti_dict.keys():
+                self.log.debug(f'Allele {allele} is superceded by an at-locus FBti insertion.')
                 allele.superceded_by_at_locus_insertion = self.at_locus_fbal_fbti_dict[allele.db_primary_id][0]
                 self.add_fbal_to_fbti(allele)
                 at_locus_counter += 1
             elif allele.db_primary_id in self.transgenic_fbal_fbti_dict.keys():
+                self.log.debug(f'Allele {allele} is superceded by unspecified FBti insertion(s).')
                 allele.superceded_by_transgnc_insertions = self.transgenic_fbal_fbti_dict[allele.db_primary_id]
                 self.add_fbal_to_fbti(allele)
                 transgenic_counter += 1

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -20,6 +20,7 @@ from harvdev_utils.reporting import (
     Cvterm, Feature, FeatureCvterm, FeatureGenotype, Genotype, Phenotype,
     PhenotypeCvterm, Phenstatement, Pub
 )
+from utils import export_chado_data
 
 
 class MetaAlleleHandler(FeatureHandler):
@@ -243,17 +244,19 @@ class AlleleHandler(MetaAlleleHandler):
         self.log.info(f'Found {counter} allele phenotypes from single locus genotypes.')
         return
 
+    def get_insertion_entities(self, session):
+        """Have the AlleleHandler run the InsertionHandler."""
+        self.log.info('Have the AlleleHandler run the InsertionHandler.')
+        insertion_handler = InsertionHandler(self.log, self.testing)
+        export_chado_data(session, self.log, insertion_handler)
+        self.fbti_entities = insertion_handler.fb_data_entities
+        self.log.info(f'The AlleleHandler obtained {len(self.fbti_entities)} FBti insertions from chado.')
+        return
+
     def get_fbal_fbti_replacements(self, session):
         """Build allele-insertion replacement lookup."""
         self.log.info('Build allele-insertion replacement lookup.')
         # BOB: Build self.fbti_fbal_dict
-        return
-
-    def get_insertion_entities(self, session):
-        """Have the AlleleHandler run the InsertionHandler."""
-        self.log.info('Have the AlleleHandler run the InsertionHandler.')
-        # BOB: run insertion handler
-        # BOB: Copy InsertionHandler.fb_data_entities to AlleleHandler.fbti_entities.
         return
 
     # Elaborate on get_datatype_data() for the AlleleHandler.
@@ -280,8 +283,8 @@ class AlleleHandler(MetaAlleleHandler):
         self.get_very_indirect_reagent_collections(session)
         self.get_phenotypes(session)
         self.find_in_vitro_alleles(session)
-        self.get_fbal_fbti_replacements(session)
         self.get_insertion_entities(session)
+        self.get_fbal_fbti_replacements(session)
         return
 
     # Additional sub-methods to be run by synthesize_info() below.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1193,8 +1193,8 @@ class AberrationHandler(MetaAlleleHandler):
     def query_chado_and_export(self, session):
         """Elaborate on query_chado_and_export method for the AberrationHandler."""
         super().query_chado_and_export(session)
-        # self.flag_unexportable_entities(self.aberration_gene_associations, 'allele_gene_association_ingest_set')
-        # self.generate_export_dict(self.aberration_gene_associations, 'allele_gene_association_ingest_set')
+        self.flag_unexportable_entities(self.aberration_gene_associations, 'allele_gene_association_ingest_set')
+        self.generate_export_dict(self.aberration_gene_associations, 'allele_gene_association_ingest_set')
         return
 
 

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1047,7 +1047,7 @@ class AberrationHandler(MetaAlleleHandler):
         for aberration in self.fb_data_entities.values():
             annotated_cvterm_ids = set()
             for anno in aberration.cvt_annos_by_id.values():
-                annotated_cvterm_ids.add(anno.cvterm_id)
+                annotated_cvterm_ids.add(anno.chado_obj.cvterm_id)
             if annotated_cvterm_ids.intersection(set(self.chr_del_terms)):
                 aberration.is_deletion = True
                 self.log.debug(f'Aberration {aberration} is annotated to a child term of "chromosomal_deletion".')

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -381,29 +381,29 @@ class AlleleHandler(MetaAlleleHandler):
             for attr_name in lists_to_extend:
                 allele_list = getattr(allele, attr_name)
                 insertion_list = getattr(insertion, attr_name)
-                self.log.debug(f'For {attr_name}, add {len(allele_list)} allele elements to {len(insertion_list)} insertion elements.')
+                self.log.debug(f'For {attr_name}, add {len(allele_list)} elements from the allele to {len(insertion_list)} elements from the insertion.')
                 insertion_list.extend(allele_list)
-                self.log.debug(f'For {attr_name}, now have {len(insertion_list)} insertion elements.')
+                self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_list)} elements.')
             # Add to ID-keyed dict of single chado annotations (key is unique for FBCVtermAnnotation or FBRelationship).
             for attr_name in dicts_of_elements_to_add:
                 allele_dict = getattr(allele, attr_name)
                 insertion_dict = getattr(insertion, attr_name)
-                self.log.debug(f'For {attr_name}, add {len(allele_dict)} allele elements to {len(insertion_dict)} insertion elements.')
+                self.log.debug(f'For {attr_name}, add {len(allele_dict)} elements from the allele to {len(insertion_dict)} elements from the insertion.')
                 for k, v in allele_dict.items():
                     if k not in insertion_dict.keys():
                         insertion_dict[k] = v
-                self.log.debug(f'For {attr_name}, now have {len(insertion_dict)} insertion elements.')
+                self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_dict)} elements.')
             # Combine lists of annotations.
             for attr_name in dicts_of_lists_to_add:
                 allele_dict = getattr(allele, attr_name)
                 insertion_dict = getattr(insertion, attr_name)
-                self.log.debug(f'For {attr_name}, add {len(allele_dict)} allele lists to {len(insertion_dict)} insertion lists.')
+                self.log.debug(f'For {attr_name}, add {len(allele_dict)} lists from the allele to {len(insertion_dict)} lists from the insertion.')
                 for k, v in allele_dict.items():
                     try:
                         insertion_dict[k].extend(v)
                     except KeyError:
                         insertion_dict[k] = v
-                self.log.debug(f'For {attr_name}, now have {len(insertion_dict)} insertion lists.')
+                self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_dict)} lists.')
         allele.is_obsolete = False
         allele.for_export = False
         allele.export_warnings.append('Superceded by FBti insertion')

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -361,16 +361,19 @@ class AlleleHandler(MetaAlleleHandler):
             'synonyms',
             'timestamps',
         ]
-        dicts_to_add = [
+        dicts_of_elements_to_add = [
+            'cvt_annos_by_id',
+            'rels_by_id',
+        ]
+        dicts_of_lists_to_add = [
             'props_by_type',
             'cvt_anno_ids_by_cv',
             'cvt_anno_ids_by_prop',
             'cvt_anno_ids_by_term',
-            'cvt_annos_by_id',
             'obj_rel_ids_by_type',
-            'rels_by_id',
             'sbj_rel_ids_by_type',
         ]
+
         for fbti_feature_id in fbti_feature_ids:
             if fbti_feature_id not in self.fb_data_entities:
                 self.fb_data_entities[fbti_feature_id] = self.fbti_entities[fbti_feature_id]
@@ -382,10 +385,19 @@ class AlleleHandler(MetaAlleleHandler):
                 insertion_list = getattr(insertion, attr_name)
                 self.log.debug(f'For {attr_name}, add {len(allele_list)} allele elements to {len(insertion_list)} insertion elements.')
                 insertion_list.extend(allele_list)
-            for attr_name in dicts_to_add:
+            # Add to ID-keyed dict of single chado annotations (key is unique for FBCVtermAnnotation or FBRelationship).
+            for attr_name in dicts_of_elements_to_add:
                 allele_dict = getattr(allele, attr_name)
                 insertion_dict = getattr(insertion, attr_name)
                 self.log.debug(f'For {attr_name}, add {len(allele_dict)} allele elements to {len(insertion_dict)} insertion elements.')
+                for k, v in allele_dict.items():
+                    if k not in insertion_dict.keys():
+                        insertion_dict[k] = v
+            # Combine lists of annotations.
+            for attr_name in dicts_of_lists_to_add:
+                allele_dict = getattr(allele, attr_name)
+                insertion_dict = getattr(insertion, attr_name)
+                self.log.debug(f'For {attr_name}, add {len(allele_dict)} allele lists to {len(insertion_dict)} insertion lists.')
                 for k, v in allele_dict.items():
                     try:
                         insertion_dict[k].extend(v)

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1095,7 +1095,7 @@ class AberrationHandler(MetaAlleleHandler):
                     continue
                 agr_rel_type = fb_agr_aberr_rel_mapping[fb_rel_type]
                 # Adjust Alliance relationship type for non-deletion aberrations with curated "deletes" relationship to a gene.
-                if fb_rel_type == 'deletes' and aberration.is_deletion is False:
+                if fb_rel_type in ['deletes', 'part_deletes'] and aberration.is_deletion is False:
                     agr_rel_type = 'mutation_involves'
                 if fb_rel_type.startswith('molec'):
                     eco_id = 'ECO:0007736'    # molecule detection assay evidence used in manual assertion

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -247,8 +247,8 @@ class AlleleHandler(MetaAlleleHandler):
     def get_fbal_fbti_replacements(self, session):
         """Find FBal-FBti replacements to make."""
         self.log.info('Build allele-insertion replacement lookup.')
-        # self.fbal_fbti_dict = {}
         direct_fbal_fbti_counter = 0
+        indirect_fbal_fbti_counter = 0
         # First, get relationships for at-locus insertions.
         for allele in self.fb_data_entities.values():
             fbal_fbti_alliance_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='is_represented_at_alliance_as',
@@ -257,13 +257,13 @@ class AlleleHandler(MetaAlleleHandler):
                 insertion = self.feature_lookup[feat_rel.chado_obj.object_id]
                 self.log.debug(f'Report {allele} under {insertion["name"]} ({insertion["uniquename"]}).')
                 try:
-                    self.fbal_fbti[allele.db_primary_id].append(insertion["feature_id"])
+                    self.fbal_fbti_dict[allele.db_primary_id].append(insertion["feature_id"])
                     self.log.warning(f'Found another FBti for {allele}, but expected a one-to-one relationship.')
                 except KeyError:
-                    self.fbal_fbti[allele.db_primary_id] = [(insertion["feature_id"])]
+                    self.fbal_fbti_dict[allele.db_primary_id] = [(insertion["feature_id"])]
                     direct_fbal_fbti_counter += 1
         self.log.info(f'Found {direct_fbal_fbti_counter} FBal alleles to be replaced by at-locus FBti insertions in export file.')
-        # BILLY BOB - continue here
+        # BILLY BOB - CONTINUE HERE #1
         # Second, get relationships via constructs.
         allele = aliased(Feature, name='allele')
         construct = aliased(Feature, name='construct')
@@ -299,7 +299,8 @@ class AlleleHandler(MetaAlleleHandler):
         self.get_entity_relationships(session, 'subject', rel_type='alleleof', entity_type='gene', entity_regex=self.regex['gene'])
         al_cons_fr_types = ['derived_tp_assoc_alleles', 'associated_with', 'gets_expression_data_from']
         self.get_entity_relationships(session, 'subject', rel_type=al_cons_fr_types, entity_type='construct', entity_regex=self.regex['construct'])
-        self.get_entity_relationships(session, 'subject', rel_type='associated_with', entity_type='insertion', entity_regex=self.regex['insertion'])
+        al_ins_fr_types = ['is_represented_at_alliance_as', 'associated_with']
+        self.get_entity_relationships(session, 'subject', rel_type=al_ins_fr_types, entity_type='insertion', entity_regex=self.regex['insertion'])
         self.get_entity_relationships(session, 'object', rel_type='partof', entity_type='variation')
         self.get_entity_cvterms(session)
         self.get_entityprops(session)
@@ -328,7 +329,7 @@ class AlleleHandler(MetaAlleleHandler):
             self.fb_data_entities[insertion.db_primary_id] = insertion
             counter += 1
         self.log.info(f'Added {counter} FBti insertions to the initial FBal entities list.')
-        # BOB - CONTINUE BELOW
+        # BILLY BOB - CONTINUE HERE #2
         #######################################################################################################
         # lists_to_extend = [
         #     'dbxrefs',

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1044,7 +1044,7 @@ class AberrationHandler(MetaAlleleHandler):
 
     def flag_deletions(self):
         """Flag aberrations with the "chromosomal_deletion" annotation."""
-        additional_terms = set('assortment_derived_aneuploid', 'assortment_derived_deficiency', 'assortment_derived_deficiency_plus_duplication')
+        additional_terms = {'assortment_derived_aneuploid', 'assortment_derived_deficiency', 'assortment_derived_deficiency_plus_duplication'}
         counter = 0
         for aberration in self.fb_data_entities.values():
             annotated_cvterm_ids = set()

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -413,7 +413,7 @@ class AlleleHandler(MetaAlleleHandler):
                         insertion_dict[k] = []
                         insertion_dict[k].extend(v)
                 self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_dict)} lists.')
-        allele.is_obsolete = False
+        allele.is_obsolete = True
         allele.export_warnings.append('Superceded by FBti insertion')
         return
 
@@ -513,10 +513,9 @@ class AlleleHandler(MetaAlleleHandler):
             if allele.cons_rels:
                 continue
             parent_gene_ids = []
-            # BOB - for FBti, this pulls up 0, even though it seems like rels are being transferred????
-            self.log.debug(f'BOB: Have these f_r_ids: {allele.rels_by_id.keys()}')
-            self.log.debug(f'BOB: Have these f_r sbj types: {allele.sbj_rel_ids_by_type.keys()}')
-            self.log.debug(f'BOB: Have these f_r obj types: {allele.obj_rel_ids_by_type.keys()}')
+            # self.log.debug(f'Have these f_r_ids: {allele.rels_by_id.keys()}')
+            # self.log.debug(f'Have these f_r sbj types: {allele.sbj_rel_ids_by_type.keys()}')
+            # self.log.debug(f'Have these f_r obj types: {allele.obj_rel_ids_by_type.keys()}')
             relevant_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='alleleof', rel_entity_types='gene')
             self.log.debug(f'For {allele}, found {len(relevant_rels)} alleleof relationships to genes.')
             for allele_gene_rel in relevant_rels:
@@ -595,7 +594,6 @@ class AlleleHandler(MetaAlleleHandler):
             # Skip transgenic alleles.
             elif allele.uniquename.startswith('FBti') and allele.name.endswith('unspecified'):
                 continue
-            # BOB - for FBti, this pulls up 0, even though it seems like rels are being transferred????
             relevant_gene_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='alleleof', rel_entity_types='gene')
             if relevant_gene_rels:
                 allele_counter += 1
@@ -622,8 +620,8 @@ class AlleleHandler(MetaAlleleHandler):
         self.merge_fbti_fbal()
         self.flag_new_additions_and_obsoletes()
         self.synthesize_secondary_ids()
-        # self.synthesize_synonyms()    # BOB - TMP DEV
-        # self.synthesize_pubs()        # BOB - TMP DEV
+        self.synthesize_synonyms()
+        self.synthesize_pubs()
         self.synthesize_related_features()
         self.synthesize_parent_genes()
         self.flag_alleles_of_internal_genes()

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -385,6 +385,7 @@ class AlleleHandler(MetaAlleleHandler):
                 insertion_list = getattr(insertion, attr_name)
                 self.log.debug(f'For {attr_name}, add {len(allele_list)} allele elements to {len(insertion_list)} insertion elements.')
                 insertion_list.extend(allele_list)
+                self.log.debug(f'For {attr_name}, now have {len(insertion_list)} insertion elements.')
             # Add to ID-keyed dict of single chado annotations (key is unique for FBCVtermAnnotation or FBRelationship).
             for attr_name in dicts_of_elements_to_add:
                 allele_dict = getattr(allele, attr_name)
@@ -393,6 +394,7 @@ class AlleleHandler(MetaAlleleHandler):
                 for k, v in allele_dict.items():
                     if k not in insertion_dict.keys():
                         insertion_dict[k] = v
+                self.log.debug(f'For {attr_name}, now have {len(insertion_dict)} insertion elements.')
             # Combine lists of annotations.
             for attr_name in dicts_of_lists_to_add:
                 allele_dict = getattr(allele, attr_name)
@@ -403,6 +405,7 @@ class AlleleHandler(MetaAlleleHandler):
                         insertion_dict[k].extend(v)
                     except KeyError:
                         insertion_dict[k] = v
+                self.log.debug(f'For {attr_name}, now have {len(insertion_dict)} insertion lists.')
         allele.is_obsolete = False
         allele.for_export = False
         allele.export_warnings.append('Superceded by FBti insertion')

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1044,6 +1044,8 @@ class AberrationHandler(MetaAlleleHandler):
 
     def flag_deletions(self):
         """Flag aberrations with the "chromosomal_deletion" annotation."""
+        additional_terms = set('assortment_derived_aneuploid', 'assortment_derived_deficiency', 'assortment_derived_deficiency_plus_duplication')
+        counter = 0
         for aberration in self.fb_data_entities.values():
             annotated_cvterm_ids = set()
             for anno in aberration.cvt_annos_by_id.values():
@@ -1051,6 +1053,12 @@ class AberrationHandler(MetaAlleleHandler):
             if annotated_cvterm_ids.intersection(set(self.chr_del_terms)):
                 aberration.is_deletion = True
                 self.log.debug(f'Aberration {aberration} is annotated to a child term of "chromosomal_deletion".')
+            elif additional_terms.intersection(aberration.cvt_anno_ids_by_term.keys()):
+                aberration.is_deletion = True
+                self.log.debug(f'Aberration {aberration} is annotated to a "assortment_derived_deficiency"-type term.')
+            if aberration.is_deletion:
+                counter += 1
+            self.log.info(f'Flagged {counter} aberrations as being some type of deletion.')
         return
 
     def synthesize_aberration_gene_associations(self):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -296,9 +296,9 @@ class AlleleHandler(MetaAlleleHandler):
         for result in results:
             self.log.debug(f'The transgenic allele {allele} is related to the generic insertion {result.insertion.name} ({result.insertion.uniquename}).')
             try:
-                self.transgenic_fbal_fbti_dict[allele.db_primary_id].append(result.insertion.feature_id)
+                self.transgenic_fbal_fbti_dict[result.allele.feature_id].append(result.insertion.feature_id)
             except KeyError:
-                self.transgenic_fbal_fbti_dict[allele.db_primary_id] = [result.insertion.feature_id]
+                self.transgenic_fbal_fbti_dict[result.allele.feature_id] = [result.insertion.feature_id]
                 indirect_fbal_fbti_counter += 1
         self.log.info(f'Found {indirect_fbal_fbti_counter} FBal alleles to be replaced by transgenic FBti insertions in export file.')
         return

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -375,14 +375,17 @@ class AlleleHandler(MetaAlleleHandler):
             if fbti_feature_id not in self.fb_data_entities:
                 self.fb_data_entities[fbti_feature_id] = self.fbti_entities[fbti_feature_id]
             insertion = self.fb_data_entities[fbti_feature_id]
+            self.log.debug(f'Merge {allele} data into {insertion} data.')
             insertion.alt_fb_ids.append(f'FB:{allele.uniquename}')
             for attr_name in lists_to_extend:
                 allele_list = getattr(allele, attr_name)
                 insertion_list = getattr(insertion, attr_name)
+                self.log.debug(f'For {attr_name}, add {len(allele_list)} allele elements to {len(insertion_list)} insertion elements.')
                 insertion_list.extend(allele_list)
             for attr_name in dicts_to_add:
                 allele_dict = getattr(allele, attr_name)
                 insertion_dict = getattr(insertion, attr_name)
+                self.log.debug(f'For {attr_name}, add {len(allele_dict)} allele elements to {len(insertion_dict)} insertion elements.')
                 for k, v in allele_dict.items():
                     try:
                         insertion_dict[k].extend(v)

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -406,7 +406,6 @@ class AlleleHandler(MetaAlleleHandler):
                         insertion_dict[k] = v
                 self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_dict)} lists.')
         allele.is_obsolete = False
-        allele.for_export = False
         allele.export_warnings.append('Superceded by FBti insertion')
         return
 
@@ -505,6 +504,10 @@ class AlleleHandler(MetaAlleleHandler):
             if allele.cons_rels:
                 continue
             parent_gene_ids = []
+            # BOB - for FBti, this pulls up 0, even though it seems like rels are being transferred????
+            self.log.debug(f'BOB: Have these f_r_ids: {allele.rels_by_id.keys()}')
+            self.log.debug(f'BOB: Have these f_r sbj types: {allele.sbj_rel_ids_by_type.keys()}')
+            self.log.debug(f'BOB: Have these f_r obj types: {allele.obj_rel_ids_by_type.keys()}')
             relevant_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='alleleof', rel_entity_types='gene')
             self.log.debug(f'For {allele}, found {len(relevant_rels)} alleleof relationships to genes.')
             for allele_gene_rel in relevant_rels:
@@ -583,6 +586,7 @@ class AlleleHandler(MetaAlleleHandler):
             # Skip transgenic alleles.
             elif allele.uniquename.startswith('FBti') and allele.name.endswith('unspecified'):
                 continue
+            # BOB - for FBti, this pulls up 0, even though it seems like rels are being transferred????
             relevant_gene_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='alleleof', rel_entity_types='gene')
             if relevant_gene_rels:
                 allele_counter += 1
@@ -609,8 +613,8 @@ class AlleleHandler(MetaAlleleHandler):
         self.merge_fbti_fbal()
         self.flag_new_additions_and_obsoletes()
         self.synthesize_secondary_ids()
-        self.synthesize_synonyms()
-        self.synthesize_pubs()
+        # self.synthesize_synonyms()    # BOB - TMP DEV
+        # self.synthesize_pubs()        # BOB - TMP DEV
         self.synthesize_related_features()
         self.synthesize_parent_genes()
         self.flag_alleles_of_internal_genes()

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -787,12 +787,13 @@ class InsertionHandler(MetaAlleleHandler):
 
     # Elaborate on get_general_data() for the InsertionHandler.
     def get_general_data(self, session):
-        """Extend the method for the InsertionHandler."""
-        super().get_general_data(session)
-        self.build_bibliography(session)
-        self.build_cvterm_lookup(session)
-        self.build_organism_lookup(session)
-        self.build_feature_lookup(session, feature_types=['construct', 'transposon'])
+        """Suppress the method for the InsertionHandler."""
+        self.log.info('InsertionHandler does not get general data itself as it relies on the AlleleHandler.')
+        # super().get_general_data(session)
+        # self.build_bibliography(session)
+        # self.build_cvterm_lookup(session)
+        # self.build_organism_lookup(session)
+        # self.build_feature_lookup(session, feature_types=['construct', 'transposon'])
         return
 
     # Additional sub-methods for get_datatype_data().

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -788,7 +788,7 @@ class InsertionHandler(MetaAlleleHandler):
     # Elaborate on get_general_data() for the InsertionHandler.
     def get_general_data(self, session):
         """Suppress the method for the InsertionHandler."""
-        self.log.info('InsertionHandler does not get general data itself as it relies on the AlleleHandler.')
+        self.log.info('DO NOT GET FLYBASE INSERTION DATA FROM CHADO via InsertionHandler; use AlleleHandler.')
         return
 
     # Additional sub-methods for get_datatype_data().
@@ -817,13 +817,13 @@ class InsertionHandler(MetaAlleleHandler):
     # Elaborate on synthesize_info() for the InsertionHandler.
     def synthesize_info(self):
         """Suppress the method for the InsertionHandler."""
-        self.log.info('InsertionHandler does not get synthesize info itself as it relies on the AlleleHandler.')
+        self.log.info('DO NOT SYNTHESIZE FLYBASE ALLELE DATA FROM CHADO via the InsertionHandler; use AlleleHandler.')
         return
 
     # Elaborate on map_fb_data_to_alliance() for the InsertionHandler.
     def map_fb_data_to_alliance(self):
         """Suppress the method for the InsertionHandler."""
-        self.log.info('InsertionHandler does not map FB data to the Alliance as it relies on the AlleleHandler.')
+        self.log.info('DO NOT MAP FLYBASE DATA TO ALLIANCE DATA via the InsertionHandler; use AlleleHandler.')
         return
 
     # Elaborate on query_chado_and_export() for the InsertionHandler.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -13,7 +13,7 @@ from logging import Logger
 # from sqlalchemy.orm import aliased
 import agr_datatypes
 from fb_datatypes import (
-    FBAberration, FBAllele, FBBalancer, FBInsertion
+    FBAberration, FBAllele, FBBalancer
 )
 from feature_handler import FeatureHandler
 from harvdev_utils.reporting import (
@@ -591,7 +591,7 @@ class InsertionHandler(MetaAlleleHandler):
         """Create the InsertionHandler object."""
         super().__init__(log, testing)
         self.datatype = 'insertion'
-        self.fb_export_type = FBInsertion
+        self.fb_export_type = FBAllele
 
     # Types: 228747 transposable_element_insertion_site; 7726 insertion_site; 5753 transposable element; 3573 match (internal).
     # Relationships: 234754 FBti(producedby)FBtp; 64920 FBal(associated_with)FBti.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -324,7 +324,7 @@ class AlleleHandler(MetaAlleleHandler):
         """Merge FBal allele info into FBti insertion entities as appropriate."""
         self.log.info('Merge FBal allele info into FBti insertion entities as appropriate.')
         counter = 0
-        for insertion in self.fbti_entities:
+        for insertion in self.fbti_entities.values():
             self.fb_data_entities[insertion.db_primary_id] = insertion
             counter += 1
         self.log.info(f'Added {counter} FBti insertions to the initial FBal entities list.')
@@ -789,11 +789,6 @@ class InsertionHandler(MetaAlleleHandler):
     def get_general_data(self, session):
         """Suppress the method for the InsertionHandler."""
         self.log.info('InsertionHandler does not get general data itself as it relies on the AlleleHandler.')
-        # super().get_general_data(session)
-        # self.build_bibliography(session)
-        # self.build_cvterm_lookup(session)
-        # self.build_organism_lookup(session)
-        # self.build_feature_lookup(session, feature_types=['construct', 'transposon'])
         return
 
     # Additional sub-methods for get_datatype_data().
@@ -819,8 +814,17 @@ class InsertionHandler(MetaAlleleHandler):
         # self.get_very_indirect_reagent_collections(session)    # Suppressed because it's slow and perhaps too indirect.
         return
 
-    # Note: synthesize_info() is not run for the InsertionHandler, but by an AlleleHandler that takes InsertionHandler query results.
-    # Note: map_fb_data_to_alliance() is not run for the InsertionHandler, but by an AlleleHandler that takes InsertionHandler query results.
+    # Elaborate on synthesize_info() for the InsertionHandler.
+    def synthesize_info(self):
+        """Suppress the method for the InsertionHandler."""
+        self.log.info('InsertionHandler does not get synthesize info itself as it relies on the AlleleHandler.')
+        return
+
+    # Elaborate on map_fb_data_to_alliance() for the InsertionHandler.
+    def map_fb_data_to_alliance(self):
+        """Suppress the method for the InsertionHandler."""
+        self.log.info('InsertionHandler does not map FB data to the Alliance as it relies on the AlleleHandler.')
+        return
 
     # Elaborate on query_chado_and_export() for the InsertionHandler.
     # def query_chado_and_export(self, session):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -410,7 +410,8 @@ class AlleleHandler(MetaAlleleHandler):
                     try:
                         insertion_dict[k].extend(v)
                     except KeyError:
-                        insertion_dict[k] = v
+                        insertion_dict[k] = []
+                        insertion_dict[k].extend(v)
                 self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_dict)} lists.')
         allele.is_obsolete = False
         allele.export_warnings.append('Superceded by FBti insertion')
@@ -461,6 +462,7 @@ class AlleleHandler(MetaAlleleHandler):
         has_dmel_insertion_counter = 0
         has_non_dmel_insertion_counter = 0
         for allele in self.fb_data_entities.values():
+            self.log.debug(f'Assess {allele}, feature_id={allele.db_primary_id}')
             # Assess relationships to ARGs.
             relevant_rels = allele.recall_relationships(self.log, entity_role='object', rel_types='partof', rel_entity_types=self.feature_subtypes['variation'])
             # self.log.debug(f'For {allele}, found {len(relevant_rels)} partof relationships to ARGs.')

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -416,6 +416,7 @@ class AlleleHandler(MetaAlleleHandler):
         prob_counter = 0
         at_locus_counter = 0
         transgenic_counter = 0
+        unspecified_ins_counter = 0
         classical_counter = 0
         fbti_counter = 0
         for allele in self.fb_data_entities.values():
@@ -432,12 +433,13 @@ class AlleleHandler(MetaAlleleHandler):
                 self.log.debug(f'Allele {allele} is superceded by unspecified FBti insertion(s).')
                 allele.superceded_by_transgnc_insertions = self.transgenic_fbal_fbti_dict[allele.db_primary_id]
                 self.add_fbal_to_fbti(allele)
+                unspecified_ins_counter += len(allele.superceded_by_transgnc_insertions)
                 transgenic_counter += 1
             else:
                 classical_counter += 1
         self.log.info(f'Found {prob_counter} FBal alleles unexpectedly related to both at-locus and unspecified transgenic FBti insertions.')
         self.log.info(f'Found {at_locus_counter} FBal alleles related to at-locus FBti insertions.')
-        self.log.info(f'Found {transgenic_counter} FBal alleles related to unspecified transgenic FBti insertions.')
+        self.log.info(f'Found {transgenic_counter} FBal alleles related to {unspecified_ins_counter} unspecified transgenic FBti insertions.')
         self.log.info(f'Found {classical_counter} FBal classical and/or complex alleles to be reported as they are (no FBti replacement).')
         for fbti_feature_id, insertion in self.fbti_entities.items():
             self.fb_data_entities[fbti_feature_id] = insertion
@@ -574,7 +576,7 @@ class AlleleHandler(MetaAlleleHandler):
         allele_counter = 0
         # Need to code for the rare possibility that gene-allele is represented by many feature_relationships.
         for allele in self.fb_data_entities.values():
-            if allele.superceded_by_at_locus_insertion or allele.superceded_by_transgnc_insertion:
+            if allele.superceded_by_at_locus_insertion or allele.superceded_by_transgnc_insertions:
                 continue
             # Skip transgenic alleles.
             elif allele.uniquename.startswith('FBti') and allele.name.endswith('unspecified'):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -362,6 +362,11 @@ class AlleleHandler(MetaAlleleHandler):
             'pub_associations',
             'synonyms',
             'timestamps',
+            'reagent_colls',
+            'al_reagent_colls',
+            'ti_reagent_colls',
+            'tp_reagent_colls',
+            'sf_reagent_colls',
         ]
         dicts_of_elements_to_add = [
             'cvt_annos_by_id',

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -958,7 +958,9 @@ class PrimaryEntityHandler(DataHandler):
                 syno_dict['pub_curies'] = self.lookup_pub_curies(syno_dict['pub_ids'])
                 # Pick out current symbol for the entity.
                 if syno_dict['is_current'] is True and syno_dict['name_type_name'] in ['systematic_name', 'nomenclature_symbol']:
-                    fb_data_entity.curr_fb_symbol = syno_dict['display_text']
+                    # Add extra check for FBti alleles that inherit current symbols of FBal alleles.
+                    if syno_dict['format_text'] == fb_data_entity.name:
+                        fb_data_entity.curr_fb_symbol = syno_dict['display_text']
                 # Pick out current full name for the entity.
                 if syno_dict['is_current'] is True and syno_dict['name_type_name'] == 'full_name':
                     fb_data_entity.curr_fb_fullname = syno_dict['display_text']

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -907,7 +907,7 @@ class PrimaryEntityHandler(DataHandler):
             secondary_ids = []
             for xref in fb_data_entity.fb_sec_dbxrefs:
                 secondary_ids.append(f'FB:{xref.dbxref.accession}')
-            fb_data_entity.alt_fb_ids = list(set(secondary_ids))
+            fb_data_entity.alt_fb_ids.extend(list(set(secondary_ids)))
         return
 
     def synthesize_synonyms(self):

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -13,7 +13,7 @@ Author(s):
 import re
 from logging import Logger
 from sqlalchemy.orm import aliased
-from harvdev_utils.char_conversions import sub_sup_sgml_to_html
+from harvdev_utils.char_conversions import sub_sup_sgml_to_html, sub_sup_to_sgml
 from harvdev_utils.reporting import (
     Cv, Cvterm, Db, Dbxref, CellLine, CellLineCvterm, CellLineCvtermprop, CellLineDbxref, CellLineprop, CellLinepropPub, CellLinePub, CellLineRelationship,
     CellLineSynonym, Feature, FeatureCvterm, FeatureCvtermprop, FeatureDbxref, Featureprop, FeaturepropPub, FeaturePub, FeatureRelationship,
@@ -964,7 +964,6 @@ class PrimaryEntityHandler(DataHandler):
                 # Pick out current full name for the entity.
                 if syno_dict['is_current'] is True and syno_dict['name_type_name'] == 'full_name':
                     fb_data_entity.curr_fb_fullname = syno_dict['display_text']
-
         return
 
     def synthesize_pubs(self):
@@ -1136,7 +1135,8 @@ class PrimaryEntityHandler(DataHandler):
             # 1. Symbol.
             if len(linkml_synonym_bins['symbol_bin']) == 0:
                 self.log.warning(f'No current symbols found for {fb_data_entity}: create a generic one.')
-                generic_symbol_dto = agr_datatypes.NameSlotAnnotationDTO('nomenclature_symbol', fb_data_entity.name, fb_data_entity.name, []).dict_export()
+                generic_symbol_dto = agr_datatypes.NameSlotAnnotationDTO('nomenclature_symbol', fb_data_entity.name,
+                                                                         sub_sup_sgml_to_html(sub_sup_to_sgml(fb_data_entity.name)), []).dict_export()
                 setattr(fb_data_entity.linkmldto, linkml_synonym_slots['symbol_bin'], generic_symbol_dto)
             else:
                 setattr(fb_data_entity.linkmldto, linkml_synonym_slots['symbol_bin'], linkml_synonym_bins['symbol_bin'][0])

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -294,8 +294,8 @@ class FBAllele(FBFeature):
         super().__init__(chado_obj)
         # Primary FB chado data.
         self.phenstatements = []                        # List of SQLAlchemy (Feature, Genotype, Phenotype, Cvterm, Pub) results from Phenstatements.
-        self.superceded_by_at_locus_insertion = None    # Change to the feature_id of an at-locus FBti to be used for Alliance export.
-        self.superceded_by_transgnc_insertions = []     # Append feature_ids of "unspecified" FBti insertions to be used for Alliance export.
+        self.superseded_by_at_locus_insertion = None    # Change to the feature_id of an at-locus FBti to be used for Alliance export.
+        self.superseded_by_transgnc_insertions = []     # Append feature_ids of "unspecified" FBti insertions to be used for Alliance export.
         # Processed FB data.
         self.parent_gene_id = None              # The FBgn ID for the allele's parent gene.
         self.cons_rels = []                     # List of current cons FBRelationships.

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -372,8 +372,7 @@ class FBGenotype(FBDataEntity):
         self.stocks = []                         # Will be a list of associated chado Stock objects.
         # Processed FB data.
         self.fb_curie = None
-        self.has_fbtp_component = False          # True if genotype is directly related to an FBtp feature.
-        self.has_fbti_component = False          # True if genotype is directly related to an FBti feature.
+        self.is_alliance_compliant = False       # True if genotype has "alliance_compliant" CV term annotation.
         self.component_features = {}             # Zygosity-name-keyed lists of feature_ids.
         self.ncbi_taxon_id = 'NCBITaxon:7227'    # Default Dmel, adjusted later if needed.
 

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -283,6 +283,8 @@ class FBAberration(FBFeature):
     def __init__(self, chado_obj):
         """Create the FBAberration object."""
         super().__init__(chado_obj)
+        # Processed FB data.
+        self.is_deletion = False    # True if the aberration has an annotation from the "chromosomal_deletion" SO branch.
 
 
 class FBAllele(FBFeature):

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -292,6 +292,7 @@ class FBAllele(FBFeature):
         super().__init__(chado_obj)
         # Primary FB chado data.
         self.phenstatements = []                # List of SQLAlchemy (Feature, Genotype, Phenotype, Cvterm, Pub) results from Phenstatements.
+        self.superceded_by_insertion = False    # Change to True if an FBal allele is to be reported under the related FBti insertion(s) instead.
         # Processed FB data.
         self.parent_gene_id = None              # The FBgn ID for the allele's parent gene.
         self.cons_rels = []                     # List of current cons FBRelationships.

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -291,8 +291,9 @@ class FBAllele(FBFeature):
         """Create the FBAllele object."""
         super().__init__(chado_obj)
         # Primary FB chado data.
-        self.phenstatements = []                # List of SQLAlchemy (Feature, Genotype, Phenotype, Cvterm, Pub) results from Phenstatements.
-        self.superceded_by_insertion = False    # Change to True if an FBal allele is to be reported under the related FBti insertion(s) instead.
+        self.phenstatements = []                        # List of SQLAlchemy (Feature, Genotype, Phenotype, Cvterm, Pub) results from Phenstatements.
+        self.superceded_by_at_locus_insertion = None    # Change to the feature_id of an at-locus FBti to be used for Alliance export.
+        self.superceded_by_transgnc_insertions = []     # Append feature_ids of "unspecified" FBti insertions to be used for Alliance export.
         # Processed FB data.
         self.parent_gene_id = None              # The FBgn ID for the allele's parent gene.
         self.cons_rels = []                     # List of current cons FBRelationships.

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -348,14 +348,6 @@ class FBGene(FBFeature):
         self.gene_type_id = 'SO:0000704'    # Update this default gene ID to SO term ID from "promoted_gene_type" Featureprop, if available.
 
 
-# BOB - cue this object for deletion (use FBAllele instead).
-# class FBInsertion(FBFeature):
-#     """A FlyBase insertion entity with all its related data."""
-#     def __init__(self, chado_obj):
-#         """Create the FBInsertion object."""
-#         super().__init__(chado_obj)
-
-
 class FBStrain(FBDataEntity):
     """A FlyBase strain entity with all its related data."""
     def __init__(self, chado_obj):

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -286,7 +286,7 @@ class FBAberration(FBFeature):
 
 
 class FBAllele(FBFeature):
-    """A FlyBase allele entity with all its related data."""
+    """A FlyBase allele/insertion entity with all its related data."""
     def __init__(self, chado_obj):
         """Create the FBAllele object."""
         super().__init__(chado_obj)
@@ -346,11 +346,12 @@ class FBGene(FBFeature):
         self.gene_type_id = 'SO:0000704'    # Update this default gene ID to SO term ID from "promoted_gene_type" Featureprop, if available.
 
 
-class FBInsertion(FBFeature):
-    """A FlyBase insertion entity with all its related data."""
-    def __init__(self, chado_obj):
-        """Create the FBInsertion object."""
-        super().__init__(chado_obj)
+# BOB - cue this object for deletion (use FBAllele instead).
+# class FBInsertion(FBFeature):
+#     """A FlyBase insertion entity with all its related data."""
+#     def __init__(self, chado_obj):
+#         """Create the FBInsertion object."""
+#         super().__init__(chado_obj)
 
 
 class FBStrain(FBDataEntity):

--- a/src/handler.py
+++ b/src/handler.py
@@ -1037,7 +1037,7 @@ class DataHandler(object):
         self.get_general_data(session)
         self.get_datatype_data(session)
         # For the InsertionHandler, skip the last four steps because the AlleleHandler will take over the processing.
-        if self.datatype != 'insertion':
+        if self.datatype == 'insertion':
             return
         self.synthesize_info()
         self.map_fb_data_to_alliance()

--- a/src/handler.py
+++ b/src/handler.py
@@ -1036,11 +1036,11 @@ class DataHandler(object):
         self.log.info(f'RUN MAIN {type(self)} QUERY_CHADO_AND_EXPORT() METHOD.')
         self.get_general_data(session)
         self.get_datatype_data(session)
-        # For the InsertionHandler, skip the last four steps because the AlleleHandler will take over the processing.
-        if self.datatype == 'insertion':
-            return
         self.synthesize_info()
         self.map_fb_data_to_alliance()
+        # For the InsertionHandler, skip the last two steps because the AlleleHandler will take over the processing.
+        if self.datatype == 'insertion':
+            return
         self.flag_unexportable_entities(self.fb_data_entities.values(), self.primary_export_set)
         self.generate_export_dict(self.fb_data_entities.values(), self.primary_export_set)
         return

--- a/src/handler.py
+++ b/src/handler.py
@@ -1036,6 +1036,9 @@ class DataHandler(object):
         self.log.info(f'RUN MAIN {type(self)} QUERY_CHADO_AND_EXPORT() METHOD.')
         self.get_general_data(session)
         self.get_datatype_data(session)
+        # For the InsertionHandler, skip the last four steps because the AlleleHandler will take over the processing.
+        if self.datatype != 'insertion':
+            return
         self.synthesize_info()
         self.map_fb_data_to_alliance()
         self.flag_unexportable_entities(self.fb_data_entities.values(), self.primary_export_set)

--- a/src/retrieve_genotypes.py
+++ b/src/retrieve_genotypes.py
@@ -203,9 +203,12 @@ class GenotypeHandler(object):
             geno_specific_features = geno_anno.features.keys() - set(self.pub_associated_feature_ids)
             for feature_id in geno_specific_features:
                 input_symbol = geno_anno.features[feature_id]['input_symbol']
-                # geno_anno.warnings.append(f'"{input_symbol}" is not associated with {self.fbrf_pub_id}')    # DEV: For testing many genotypes, ignore this chk
-                geno_anno.errors.append(f'"{input_symbol}" is not associated with {self.fbrf_pub_id}')
-                log.error(f'"{input_symbol}" is not associated with {self.fbrf_pub_id}')
+                # Relaxed feature-pub constraint.
+                geno_anno.warnings.append(f'"{input_symbol}" is not associated with {self.fbrf_pub_id}')
+                log.warning(f'"{input_symbol}" is not associated with {self.fbrf_pub_id}')
+                # Stringent feature-pub constraint.
+                # geno_anno.errors.append(f'"{input_symbol}" is not associated with {self.fbrf_pub_id}')
+                # log.error(f'"{input_symbol}" is not associated with {self.fbrf_pub_id}')
                 no_counter += 1
         if no_counter > 0:
             log.error(f'Found {no_counter} listed features NOT associated with {self.fbrf_pub_id}')


### PR DESCRIPTION
AGR_data_retrieval_curation_allele.py
1. Suppress balancers from allele export file, leaving old code in place in case curators change their minds.
2. Add aberration-gene associations to the allele-gene association export file.

agr_datatypes.py
1. Add back evidence_curies (pubs) to export files now that the Alliance persistent store loading software has been optimized.

allele_handlers.py
1. Many changes required to handle reporting of FBal entity information under a related FBti entity.
2. One key change includes having the AlleleHandler run the InsertionHandler, rather than running them independently. This allows the AlleleHandler to integrate the FBal and FBti results.

entity_handler.py
1. Fix handling of secondary IDs and current symbols when information from an FBal allele is merged into an FBti entity.

fb_datatypes.py
1. Add FBAberration.is_deletion attribute for proper processing of FBab-FBgn relationships.
2. Remove FBInsertion class, as these will now be handled as FBAllele features.
3. Add FBAllele attributes (superceded_by*, phenstatements) for mapping of FBal to FBti entities, and transfer of phenstatement data, respectively.

handler.py
1. Bypass final steps of query_chado_and_export() for the InsertionHandler, as InsertionHandler output will be processed by the AlleleHandler (to facilitate FBal-FBti merging).
