### PR TITLE
Fix CV term annotation retrieval for genotypes

### DIFF
--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -488,7 +488,7 @@ class PrimaryEntityHandler(DataHandler):
         filters = (
             Cv.name.not_in((excluded_cv_names)),
         )
-        if self.datatype in self.regex.keys():
+        if self.datatype in self.regex.keys() and self.datatype != 'genotype':
             self.log.debug(f'Use this regex for primary entities: {self.regex[self.datatype]}')
             filters += (chado_table.uniquename.op('~')(self.regex[self.datatype]), )
         if self.datatype in self.feature_subtypes.keys():


### PR DESCRIPTION
The generic CV term annotation retrieval method assumes that table uniquename columns use the FB ids, which is usually true and helpful/required for getting data from the feature table for distinct feature types (gene, allele, etc). However, it's not true of the genotype table, so the uniquename regex filter needs to be ignored when processing genotypes.
Genotype CV term annotations are where we record if a chado genotype is "alliance_compliant" (to be made public) or not (kept internal at the Alliance).
Sorry I missed this bug in the recent PR.