### PR TITLE
Update genotype construction and relation type for AGMDiseaseAnnotation.

### DIFF
--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -272,7 +272,6 @@ class DiseaseAnnotationDTO(AnnotationDTO):
         """Create DiseaseAnnotationDTO for FlyBase object."""
         super().__init__(evidence_curie)
         self.do_term_curie = do_term_curie
-        self.disease_relation_name = 'is_implicated_in'
         self.annotation_type_name = 'manually_curated'
         self.negated = False
         self.evidence_code_curies = []
@@ -286,6 +285,7 @@ class AlleleDiseaseAnnotationDTO(DiseaseAnnotationDTO):
     def __init__(self, allele_identifier, do_term_curie, evidence_curie):
         """Create AlleleDiseaseAnnotationDTO for FlyBase object."""
         super().__init__(do_term_curie, evidence_curie)
+        self.disease_relation_name = 'is_implicated_in'
         self.allele_identifier = allele_identifier
         self.inferred_gene_identifier = None
         self.required_fields.extend(['allele_identifier'])
@@ -296,6 +296,7 @@ class AGMDiseaseAnnotationDTO(DiseaseAnnotationDTO):
     def __init__(self, agm_identifier, do_term_curie, evidence_curie):
         """Create AGMDiseaseAnnotationDTO for FlyBase object."""
         super().__init__(do_term_curie, evidence_curie)
+        self.disease_relation_name = None
         self.agm_identifier = agm_identifier
         self.inferred_gene_identifier = None
         self.asserted_gene_identifiers = []

--- a/src/disease_handlers.py
+++ b/src/disease_handlers.py
@@ -37,6 +37,8 @@ class AGMDiseaseHandler(DataHandler):
        Because there can be many driver combinations specified for a given genotype, there can be an expansion of
        annotations. So, new annotations (for each genotype-driver combination) are created (self.fb_data_entities).
     4. Then, a separate aberration TSV file is processed to add even more genotype-level annotations to list.
+    5. ***This handler is designed to process disease annotations from production_chado, but not the derived
+       annotations in a release build. So, only run this on a production_chado database.
 
     """
     def __init__(self, log: Logger, testing: bool):
@@ -1285,6 +1287,8 @@ class AGMDiseaseHandler(DataHandler):
             # Get all components.
             components = []
             components.extend(dis_anno.modeled_by)
+            if dis_anno.modifier_curie:
+                components.append(dis_anno.modifier_curie)
             if dis_anno.driver_combos:
                 driver_curies = list(dis_anno.driver_combos)[0].split('_')
                 components.extend(driver_curies)

--- a/src/disease_handlers.py
+++ b/src/disease_handlers.py
@@ -32,11 +32,11 @@ class AGMDiseaseHandler(DataHandler):
        Note that there are duplicated allele-level annotations in chado.
     2. Those allele-level annotations are converted into genotype-level annotations (self.genotype_dis_annos).
        Note that distinct allele-level annotations can represent the same genotype from different perspectives.
-    3. So, genotype-level annotations are grouped to deal with duplications and redundancies.
-    4. This object processes driver line info (from TSV file) and folds it into genotype-level annotations.
-    5. Because there can be many driver combinations for a given genotype, there can be an expansion of annotations.
-       So, new annotations (for each genotype-driver combination) are created (self.fb_data_entities).
-    6. Then, a separate aberration TSV file is processed to add even more genotype-level annotations to self.fb_data_entities.
+       So, allele-level annotations are grouped to deal with genotype-level redundancy.
+    3. This object processes driver line info (from TSV file) and folds it into genotype-level annotations.
+       Because there can be many driver combinations specified for a given genotype, there can be an expansion of
+       annotations. So, new annotations (for each genotype-driver combination) are created (self.fb_data_entities).
+    4. Then, a separate aberration TSV file is processed to add even more genotype-level annotations to list.
 
     """
     def __init__(self, log: Logger, testing: bool):

--- a/src/disease_handlers.py
+++ b/src/disease_handlers.py
@@ -83,6 +83,11 @@ class AGMDiseaseHandler(DataHandler):
         'DOES NOT exacerbate': 'not_exacerbated_by'
     }
 
+    disease_relation_types = {
+        'ameliorated_by': 'is_ameliorated_model_of',
+        'exacerbated_by': 'is_exacerbated_model_of',
+    }
+
     # Add methods to be run by get_general_data() below.
     def build_allele_name_lookup(self):
         """Build name-keyed dict of alleles."""
@@ -1502,6 +1507,11 @@ class AGMDiseaseHandler(DataHandler):
             if geno_dis_anno.for_export is False:
                 continue
             agr_dis_anno = self.agr_export_type(f'FB:{geno_dis_anno.genotype_curie}', geno_dis_anno.do_term_curie, geno_dis_anno.pub_curie)
+            # Set disease relation type based on type of allele modifier, if present.
+            try:
+                agr_dis_anno.disease_relation_name = self.disease_relation_types[geno_dis_anno.modifier_role]
+            except KeyError:
+                agr_dis_anno.disease_relation_name = 'model_of'
             if geno_dis_anno.is_not is True:
                 agr_dis_anno.negated = True
             agr_dis_anno.evidence_code_curies.append(self.evidence_code_xrefs[geno_dis_anno.eco_abbr])

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -450,6 +450,8 @@ class FBGenotypeDiseaseAnnotation(FBExportEntity):
         self.allele_annotations = []         # Allele-level annotations that map to this genotype-level annotation.
         # Information for model genotype.
         self.modeled_by = []                 # Will be a list of all allele FBal IDs that model the disease.
+        self.modifier_curie = None           # Will be FBal ID of the modifier, if applicable.
+        self.modifier_role = None            # Will be Alliance role for a modifier.
         self.driver_combos = set()           # Each item is a driver combo (ID concatenation) to be integrated into this genotype-level annotation.
         self.aberr_trans = False             # True if two aberr/alleles in model are trans from each other.
         self.input_genotype_name = ''        # Will be genotype.uniquename constructed from input symbols.
@@ -467,8 +469,6 @@ class FBGenotypeDiseaseAnnotation(FBExportEntity):
         self.do_term_curie = None            # The DO term curie.
         self.is_not = False                  # Becomes True for "DOES NOT model" annotations.
         self.eco_abbr = ''                   # Will be CEA or CEC, as appropriate.
-        self.modifier_curie = None           # Will be FBal ID of the modifier, if applicable.
-        self.modifier_role = None            # Will be Alliance role for a modifier.
 
 
 class FBRelationship(FBExportEntity):


### PR DESCRIPTION
Major changes:
`src/disease_handlers.py`:
1. Include disease modifier alleles in the components to be used to construct the genotype (AGM): lines 1290-1291
2. Consider modifiers when determining the appropriate disease relation type: lines 88-92, 1514-1518.

Minor changes:
`src/disease_handlers.py` - update the notes at the top of the script: lines 35-41.
`src/agr_datatypes.py` - changing the default relation type for allele- vs agm-disease annotations.
`src/fb_datatypes.py` - just moving position of the modifier attributes closer to other related attributes for clarity.