### PR TITLE
DB-1013: Code for reporting FlyBase expression as a bulk report (and the core required for Alliance LinkML export).

### DIFF
--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -930,9 +930,9 @@ class ExpressionHandler(DataHandler):
                         pair_combo_str = '|'.join(pair_combo)
                         if pair_combo_str in self.split_system_combo_strs:
                             split_system_features_represented.append(pair_combo_str)
-                    self.log.debug(f'BOB: sbj={allele_curie}, fx_id={feat_xprn.db_primary_id}, \
-                                   fbtp: {partner_construct_curies}, fbti: {partner_insertion_curies}, \
-                                   fbal: {partner_allele_curies}, combos: {split_system_counter}')
+                    # self.log.debug(f'BOB: sbj={allele_curie}, fx_id={feat_xprn.db_primary_id}, \
+                    #                fbtp: {partner_construct_curies}, fbti: {partner_insertion_curies}, \
+                    #                fbal: {partner_allele_curies}, combos: {split_system_counter}')
                     if split_system_features_represented:
                         feat_xprn.is_problematic = True
                         feat_xprn.notes.append('Suppress export of hemi-driver expression having split system combination feature.')

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -410,7 +410,7 @@ class ExpressionHandler(DataHandler):
                         if this_xprn_cvt.obo == 'FBcv':
                             xprn_pattern_slot[current_primary_cvt_id].qualifier_cvterm_ids.append(this_xprn_cvt.cvterm_id)
                         else:
-                            self.log.debug(f'Ignoring non-FBcv qualifier: "{this_xprn_cvt.cvterm_name}".')
+                            self.log.warning(f'Ignoring non-FBcv qualifier: "{this_xprn_cvt.cvterm_name}".')
                     else:
                         current_primary_cvt_id = this_xprn_cvt.db_primary_id
                         # self.log.debug(f'Found primary term="{this_xprn_cvt.cvterm_name}", xprn_cvterm_id={this_xprn_cvt.db_primary_id}')
@@ -462,18 +462,20 @@ class ExpressionHandler(DataHandler):
             start_terms = []
             end_terms = []
             for anatomy_term in xprn_pattern.anatomy_terms.values():
-                # Treat all anatomy terms as if they represent a tissue range, though it may be a range of only one.
-                anatomy_term.has_anat_term_ids.append(anatomy_term.cvterm_id)
                 if 'FROM' in anatomy_term.operators:
                     anatomy_term.is_anat_start = True
                     start_terms.append(anatomy_term)
                 if 'TO' in anatomy_term.operators:
                     anatomy_term.is_anat_end = True
                     end_terms.append(anatomy_term)
+                    if anatomy_term.qualifier_cvterm_ids:
+                        # qualifiers = [self.cvterm_lookup[i]['name'] for i in anatomy_term.qualifier_cvterm_ids]
+                        # self.log.debug(f'For xprn_id={xprn_pattern.db_primary_id}, "{anatomy_term.cvterm_name}" has qualifiers: {qualifiers}.')
+                        pass
             if not start_terms and not end_terms:
                 continue
             elif len(start_terms) == 1 and len(end_terms) == 1:
-                end_terms[0].has_anat_term_ids.append(start_terms[0].cvterm_id)    # Add start term to the range (under the end term object).
+                end_terms[0].has_anat_terms.append(start_terms[0].cvterm_id)    # Add start term to the range (under the end term object).
                 end_terms[0].operators.extend(start_terms[0].operators)    # Propagate operators from start of tissue range to end.
                 # Get intervening tissue range terms, then add them to the list of terms in the tissue range.
                 # tissue_range_string = f'{start_terms[0].cvterm_name}--{end_terms[0].cvterm_name}'
@@ -489,8 +491,8 @@ class ExpressionHandler(DataHandler):
                 anatomical_series_terms = self.get_anatomical_terms_by_regex(session, rgx)
                 filtered_terms = self.select_in_range_anatomical_terms(anatomical_series_terms, rgx, start, end)
                 anat_cvterm_ids = [i.cvterm_id for i in filtered_terms]
-                end_terms[0].has_anat_term_ids.extend(anat_cvterm_ids)
-                end_terms[0].has_anat_term_ids.sort()
+                end_terms[0].has_anat_terms.extend(anat_cvterm_ids)
+                end_terms[0].has_anat_terms.sort()
                 counter += 1
             else:
                 self.log.error(f'Many/partial tissue ranges found for xprn_id={xprn_pattern.db_primary_id}')
@@ -518,8 +520,8 @@ class ExpressionHandler(DataHandler):
                 if not potential_sub_parts:
                     self.log.error(f'For xprn_id={xprn_pattern.db_primary_id}, there are "main" parts but no sub-parts.')
                 else:
-                    if len(potential_sub_parts) > 1 or len(main_parts) > 1:
-                        self.log.warning(f'xprn_id={xprn_pattern.db_primary_id} has {len(main_parts)} main parts and {len(potential_sub_parts)} sub-parts.')
+                    if len(potential_sub_parts) > 1:
+                        self.log.warning(f'For xprn_id={xprn_pattern.db_primary_id}, there are {len(potential_sub_parts)} sub-parts.')
                     # Move anatomy sub_parts into a separate dict within the expression pattern object.
                     for sub_part in potential_sub_parts:
                         xprn_pattern.sub_anatomy_terms[sub_part.db_primary_id] = sub_part
@@ -532,44 +534,44 @@ class ExpressionHandler(DataHandler):
                 # self.log.debug(f'For xprn_id={xprn_pattern.db_primary_id}, have {n_combos} main/sub_part combinations.')
             else:
                 xprn_pattern.sub_anatomy_terms['placeholder'] = self.placeholder
-                xprn_pattern.sub_anatomy_terms['placeholder'].has_anat_term_ids.append(self.placeholder.cvterm_id)
         self.log.info(f'Found {counter} expression patterns having anatomy sub_parts.')
         return
 
-    def generate_xprn_pattern_dict(self, xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term, cellular_term):
+    def generate_xprn_pattern_dict(self, xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term, cellular_term, anatomy_range_term_id, sub_part_id):
         """Convert a specific combination of terms from an expression pattern into a simpler dict."""
-        # input_str = f'xprn_id={xprn_id}, assay="{assay_term.cvterm_name}", stage="{stage_term.cvterm_name}", '
-        # input_str += f'anatomy="{anatomy_term.cvterm_name}", sub_part="{anatomy_sub_term.cvterm_name}", cellular="{cellular_term.cvterm_name}"'
-        # self.log.debug(f'Process {input_str}')
-        xprn_pattern_dict_list = []
-        for main_part_id in anatomy_term.has_anat_term_ids:
-            for sub_part_id in anatomy_sub_term.has_anat_term_ids:
-                xprn_pattern_dict = {
-                    'assay_cvterm_id': assay_term.cvterm_id,
-                    'stage_start_cvterm_id': stage_term.cvterm_id,
-                    'stage_end_cvterm_id': 'placeholder',
-                    'stage_qualifier_cvterm_ids': stage_term.qualifier_cvterm_ids.copy(),
-                    'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
-                    'anatomical_structure_cvterm_id': main_part_id,
-                    'anatomical_structure_qualifier_cvterm_ids': anatomy_term.qualifier_cvterm_ids.copy(),
-                    'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[main_part_id]['slim_term_cvterm_ids'].copy(),
-                    'anatomical_substructure_cvterm_id': sub_part_id,
-                    'anatomical_substructure_qualifier_cvterm_ids': anatomy_sub_term.qualifier_cvterm_ids.copy(),
-                    'anatomical_substructure_slim_cvterm_ids': self.cvterm_lookup[sub_part_id]['slim_term_cvterm_ids'].copy(),
-                    'cellular_component_cvterm_id': cellular_term.cvterm_id,
-                    'cellular_component_qualifier_cvterm_ids': cellular_term.qualifier_cvterm_ids.copy(),
-                }
-                # Handle stage end.
-                if stage_term.has_stage_end:
-                    xprn_pattern_dict['stage_end_cvterm_id'] = stage_term.has_stage_end.cvterm_id
-                    xprn_pattern_dict['stage_qualifier_cvterm_ids'].extend(stage_term.has_stage_end.qualifier_cvterm_ids)
-                    additional_slim_term_ids = self.cvterm_lookup[stage_term.has_stage_end.cvterm_id]['slim_term_cvterm_ids'].copy()
-                    xprn_pattern_dict['stage_slim_cvterm_ids'].extend(additional_slim_term_ids)
-                    xprn_pattern_dict['stage_slim_cvterm_ids'] = list(set(xprn_pattern_dict['stage_slim_cvterm_ids']))
-                xprn_pattern_dict_list.append(xprn_pattern_dict)
-                # self.log.debug(f'For xprn_id={xprn_id}, generated xprn_pattern_dict: {xprn_pattern_dict}')
-        # self.log.debug(f'For xprn_id={xprn_id}, generated {len(xprn_pattern_dict_list)} xprn_pattern_dict entries.')
-        return xprn_pattern_dict_list
+        input_str = f'assay="{assay_term.cvterm_name}", stage="{stage_term.cvterm_name}", anatomy="{anatomy_term.cvterm_name}", '
+        input_str += f'cellular="{cellular_term.cvterm_name}", anatomy_range_term_id={anatomy_range_term_id}'
+        # self.log.debug(f'Generate xprn_pattern_dict for xprn_id={xprn_id}; input: {input_str}')
+        xprn_pattern_dict = {
+            'assay_cvterm_id': assay_term.cvterm_id,
+            'stage_start_cvterm_id': stage_term.cvterm_id,
+            'stage_end_cvterm_id': 'placeholder',
+            'stage_qualifier_cvterm_ids': stage_term.qualifier_cvterm_ids.copy(),
+            'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
+            'anatomical_structure_cvterm_id': anatomy_term.cvterm_id,
+            'anatomical_structure_qualifier_cvterm_ids': anatomy_term.qualifier_cvterm_ids.copy(),
+            'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[anatomy_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
+            'anatomical_substructure_cvterm_id': anatomy_sub_term.cvterm_id,
+            'anatomical_substructure_qualifier_cvterm_ids': anatomy_sub_term.qualifier_cvterm_ids.copy(),
+            'anatomical_substructure_slim_cvterm_ids': self.cvterm_lookup[anatomy_sub_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
+            'cellular_component_cvterm_id': cellular_term.cvterm_id,
+            'cellular_component_qualifier_cvterm_ids': cellular_term.qualifier_cvterm_ids.copy(),
+        }
+        # Handle stage end.
+        if stage_term.has_stage_end:
+            xprn_pattern_dict['stage_end_cvterm_id'] = stage_term.has_stage_end.cvterm_id
+            xprn_pattern_dict['stage_qualifier_cvterm_ids'].extend(stage_term.has_stage_end.qualifier_cvterm_ids)
+            additional_slim_term_ids = self.cvterm_lookup[stage_term.has_stage_end.cvterm_id]['slim_term_cvterm_ids'].copy()
+            xprn_pattern_dict['stage_slim_cvterm_ids'].extend(additional_slim_term_ids)
+            xprn_pattern_dict['stage_slim_cvterm_ids'] = list(set(xprn_pattern_dict['stage_slim_cvterm_ids']))
+        # If processing a term in a tissue range for the main anatomy part, replace the main anatomy term with the cvterm_id given.
+        if anatomy_range_term_id:
+            xprn_pattern_dict['anatomical_structure_cvterm_id'] = anatomy_range_term_id
+        # If processing a term in a tissue range for the anatomy sub_part, replace the anatomy sub_part term with the cvterm_id given.
+        if sub_part_id:
+            xprn_pattern_dict['anatomical_substructure_cvterm_id'] = sub_part_id
+        # self.log.debug(f'For xprn_id={xprn_id}, generated xprn_pattern_dict: {xprn_pattern_dict}')
+        return xprn_pattern_dict
 
     def split_out_expression_patterns(self):
         """Generate all combinations of anatomy/assay/cellular/stage terms for an expression pattern."""
@@ -591,18 +593,38 @@ class ExpressionHandler(DataHandler):
                     # Skip stage range end terms, as these are folded into reporting of the stage range start term.
                     if stage_term.is_stage_end:
                         continue
-                    for anatomy_term in xprn_pattern.anatomy_terms.values():
-                        # Skip anatomy range start terms, as these are folded into reporting of the stage range end term.
-                        if anatomy_term.is_anat_start:
-                            continue
-                        for anatomy_sub_term in xprn_pattern.sub_anatomy_terms.values():
-                            # Skip sub_part anatomy range start terms, as these are folded into reporting of the stage range end term.
-                            if anatomy_sub_term.is_anat_start:
+                    for cellular_term in xprn_pattern.cellular_terms.values():
+                        for anatomy_term in xprn_pattern.anatomy_terms.values():
+                            # Skip anatomy range start terms, as these are folded into reporting of the stage range end term.
+                            if anatomy_term.is_anat_start:
                                 continue
-                            for cellular_term in xprn_pattern.cellular_terms.values():
-                                xp_list = self.generate_xprn_pattern_dict(xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term, cellular_term)
-                                xprn_pattern.xprn_pattern_combos.extend(xp_list)
-                                n_combos += len(xp_list)
+                            for anatomy_sub_term in xprn_pattern.sub_anatomy_terms.values():
+                                # Skip sub_part anatomy range start terms, as these are folded into reporting of the stage range end term.
+                                if anatomy_sub_term.is_anat_start:
+                                    continue
+                                # Catch cases too complex to handle: i.e., tissue range in both the main and sub parts.
+                                if anatomy_term.has_anat_terms and anatomy_sub_term.has_anat_terms:
+                                    self.log.error(f'For xprn_id={xprn_id}, cannot handle tissue ranges for both main part and sub_part.')
+                                    xprn_pattern.is_problematic = True
+                                    xprn_pattern.notes.append('Found tissue ranges for both main part and sub_part.')
+                                    continue
+                                # If there is an anatomy range for the main body part, first report the start and intermediate anatomy range terms.
+                                for anatomy_range_term_id in anatomy_term.has_anat_terms:
+                                    xp = self.generate_xprn_pattern_dict(xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term,
+                                                                         cellular_term, anatomy_range_term_id, None)
+                                    xprn_pattern.xprn_pattern_combos.append(xp)
+                                    n_combos += 1
+                                # If there is an anatomy range for the anatomy sub_part, first report the start and intermediate anatomy range terms.
+                                for anatomy_sub_part_term_id in anatomy_sub_term.has_anat_terms:
+                                    xp = self.generate_xprn_pattern_dict(xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term,
+                                                                         cellular_term, None, anatomy_sub_part_term_id)
+                                    xprn_pattern.xprn_pattern_combos.append(xp)
+                                    n_combos += 1
+                                # Report for the main anatomy term, including end terms for anatomy ranges.
+                                xp = self.generate_xprn_pattern_dict(xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term,
+                                                                     cellular_term, None, None)
+                                xprn_pattern.xprn_pattern_combos.append(xp)
+                                n_combos += 1
             # self.log.debug(f'For xprn_id={xprn_id}, found {n_combos} total term combinations.')
         # Check these difficult cases in the output:
         # xprn_id=42175, <a> cell | subset &&of mesoderm | dorsal &&of parasegment 2--12
@@ -610,7 +632,6 @@ class ExpressionHandler(DataHandler):
         # xprn_id=34285, <a> parasegment 8 && parasegment 9 &&of midgut
         # xprn_id=32457, <a> neuron && glial cell &&of central nervous system
         return
-        
 
     def process_for_tsv_export(self):
         """Process expression patterns for export to TSV."""

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -444,8 +444,6 @@ class ExpressionHandler(DataHandler):
         for hemidriver_list in self.split_system_combos.values():
             hemidriver_list.sort()
             self.split_system_combo_strs.append('|'.join(hemidriver_list))
-        for i in self.split_system_combo_strs:
-            self.log.debug(f'Split system combination: {i}')
         return
 
     # Elaborate on get_general_data() for the ExpressionHandler.

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -28,8 +28,12 @@ class ExpressionHandler(DataHandler):
         self.agr_export_type = None
         self.slot_types = ['anatomy', 'assay', 'cellular', 'stage']
         self.placeholder = fb_datatypes.FBExpressionCvterm(None)
-        self.expression_patterns = {}    # expression_id-keyed FBExpressionAnnotation objects.
-        self.export_data_for_tsv = []    # List of dicts for export to TSV.
+        self.expression_patterns = {}            # expression_id-keyed FBExpressionAnnotation objects.
+        self.export_data_for_tsv = []            # List of dicts for export to TSV.
+        self.isoform_gene_product_lookup = {}    # Will be feature_id-keyed lists of feature_ids representing isoform "isa" XR/XP relationships.
+        self.gene_product_gene_lookup = {}       # Will be feature_id-keyed lists of feature_ids representing XR/XP to gene relationships.
+        self.gene_product_allele_lookup = {}     # Will be feature_id-keyed lists of feature_ids representing RA/PA to allele relationships.
+        self.hemi_driver_parents_lookup = {}     # Will be feature_id-keyed lsits of feature_ids representing hemi-driver to split system combinations.
 
     # Key info.
 
@@ -385,7 +389,6 @@ class ExpressionHandler(DataHandler):
             if 'RNA' in feat_type:
                 feat_xprn.xprn_type = 'RNA'
             self.fb_data_entities[feat_xprn_id] = feat_xprn
-            self.log.debug(f'BOB: feat_xprn_id={result.feature_expression_id}')
             counter += 1
         self.log.info(f'Found {counter} distinct feature_expression annotations in chado.')
         return

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -624,7 +624,7 @@ class ExpressionHandler(DataHandler):
             for xp_combo in xprn_pattern.xprn_pattern_combos:
                 xprn_tsv_dict = {
                     'expression_id': xprn_pattern.db_primary_id,
-                    'assay_term': self.cvterm_lookup[xp_combo['assay_cvterm_id']]['name_plus_curie'],
+                    'assay_term': self.cvterm_lookup[xp_combo['assay_cvterm_id']]['name'],
                     'stage_start': self.cvterm_lookup[xp_combo['stage_start_cvterm_id']]['name_plus_curie'],
                     'stage_end': self.cvterm_lookup[xp_combo['stage_end_cvterm_id']]['name_plus_curie'],
                     'stage_qualifiers': ' | '.join([self.cvterm_lookup[i]['name_plus_curie'] for i in xp_combo['stage_qualifier_cvterm_ids']]),

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -527,8 +527,11 @@ class ExpressionHandler(DataHandler):
             distinct()
         counter = 0
         for result in feat_xprnprops:
-            self.fb_data_entities[result.feature_expression_id].tap_stmt_notes.append(result.value)
-            counter += 1
+            try:
+                self.fb_data_entities[result.feature_expression_id].tap_stmt_notes.append(result.value)
+                counter += 1
+            except KeyError:
+                continue
         self.log.info(f'Found {counter} distinct feature_expressionprop notes in chado.')
         return
 

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -527,6 +527,7 @@ class ExpressionHandler(DataHandler):
             distinct()
         counter = 0
         for result in feat_xprnprops:
+            self.log.debug(f'BOB: Process feature_expressionprop_id={result.feature_expressionprop_id}')
             if result.value is None:
                 self.log.warning(f'feature_expression_id={result.feature_expression_id} has a NULL comment, skipping. ')
                 continue

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -632,7 +632,6 @@ class ExpressionHandler(DataHandler):
         # xprn_id=34285, <a> parasegment 8 && parasegment 9 &&of midgut
         # xprn_id=32457, <a> neuron && glial cell &&of central nervous system
         return
-        
 
     def process_for_tsv_export(self):
         """Process expression patterns for export to TSV."""

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -871,7 +871,6 @@ class ExpressionHandler(DataHandler):
                 partner_allele_curies = []
                 split_system_features_represented = []
                 if allele_feature_id in self.hemi_drivers:
-                    self.log.debug(f'BILLY: Check feat_xprn_id={feat_xprn.db_primary_id} for split system combos')
                     allele_curie = self.feature_lookup[allele_feature_id]['uniquename']
                     for note in feat_xprn.tap_stmt_notes:
                         if re.search(insertion_rgx, note):
@@ -886,6 +885,7 @@ class ExpressionHandler(DataHandler):
                         pair_combo_str = '|'.join(pair_combo)
                         if pair_combo_str in self.split_system_combo_strs:
                             split_system_features_represented.append(pair_combo_str)
+                    self.log.debug(f'BILLY: sbj={allele_curie}, fx_id={feat_xprn.db_primary_id}, fbti: {partner_insertion_curies}, fbal: {partner_allele_curies}, combos: {split_system_counter}')
                 if split_system_features_represented:
                     feat_xprn.is_problematic = True
                     feat_xprn.notes.append('Suppress export of hemi-driver expression having split system combination feature.')

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -382,7 +382,7 @@ class ExpressionHandler(DataHandler):
             feat_type = result.feature.type.name
             if xprn_id not in self.expression_patterns.keys():
                 continue
-            feat_xprn = fb_datatypes.FBFeatureExpressionAnnotation(result.FeatureExpression)
+            feat_xprn = fb_datatypes.FBFeatureExpressionAnnotation(result)
             if 'RNA' in feat_type:
                 feat_xprn.xprn_type = 'RNA'
             self.fb_data_entities[feat_xprn_id] = feat_xprn

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -561,8 +561,9 @@ class ExpressionHandler(DataHandler):
         if stage_term.has_stage_end:
             xprn_pattern_dict['stage_end_cvterm_id'] = stage_term.has_stage_end.cvterm_id
             xprn_pattern_dict['stage_qualifier_cvterm_ids'].extend(stage_term.has_stage_end.qualifier_cvterm_ids)
-            # additional_slim_terms = self.cvterm_lookup[stage_term.has_stage_end.cvterm_id]['slim_term_cvterm_ids']
-            # xprn_pattern_dict['stage_slim_cvterm_ids'].extend(additional_slim_terms)
+            additional_slim_term_ids = self.cvterm_lookup[stage_term.has_stage_end.cvterm_id]['slim_term_cvterm_ids']
+            xprn_pattern_dict['stage_slim_cvterm_ids'].extend(additional_slim_term_ids)
+            xprn_pattern_dict['stage_slim_cvterm_ids'] = list(set(xprn_pattern_dict['stage_slim_cvterm_ids']))
         # # If processing a term in a tissue range, replace the main anatomy term with the cvterm_id given for the term within the range.
         if anatomy_range_term_id:
             xprn_pattern_dict['anatomical_structure_cvterm_id'] = anatomy_range_term_id

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -606,6 +606,8 @@ class ExpressionHandler(DataHandler):
                 continue
             try:
                 cleaned_prop_text = clean_free_text(result.value)
+                if len(cleaned_prop_text) < 2:
+                    continue
                 self.fb_data_entities[result.feature_expression_id].tap_stmt_notes.append(cleaned_prop_text)
                 counter += 1
             except KeyError:

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -713,7 +713,7 @@ class ExpressionHandler(DataHandler):
         """Determine the public feature to report for each gene product."""
         self.log.info('Determine the public feature to report for each gene product.')
         isoform_to_gene_counter = 0
-        # gene_product_to_gene_counter = 0
+        gene_product_to_gene_counter = 0
         for feat_xprn in self.fb_data_entities.values():
             # 1. Deal with gene product isoforms.
             if feat_xprn.feature_id in self.isoform_gene_product_lookup.keys():
@@ -725,11 +725,19 @@ class ExpressionHandler(DataHandler):
                     feat_xprn.is_problematic = True
                     feat_xprn.notes.append('Could not find gene for gene product.')
                     self.log.error(f'Could not find gene for gene product ID {gene_product_id}.')
-
+            elif feat_xprn.feature_id in self.gene_product_gene_lookup.keys():
+                try:
+                    feat_xprn.public_feature_id = self.gene_product_gene_lookup[feat_xprn.feature_id]
+                    gene_product_to_gene_counter += 1
+                except KeyError:
+                    feat_xprn.is_problematic = True
+                    feat_xprn.notes.append('Could not find gene for gene product.')
+                    self.log.error(f'Could not find gene for gene product ID {feat_xprn.feature_id}.')
             # BOB - temporary default while we work out the public feature id.
             else:
                 feat_xprn.public_feature_id = feat_xprn.feature_id
-        self.log.info(f'Mapped {isoform_to_gene_counter} isoforms to their gene products and genes.')
+        self.log.info(f'Mapped {isoform_to_gene_counter} isoforms indirectly to genes (via gene products).')
+        self.log.info(f'Mapped {gene_product_to_gene_counter} gene products directly to genes.')
         return
 
     def process_for_tsv_export(self):

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -251,8 +251,8 @@ class ExpressionHandler(DataHandler):
         for cvterm in self.cvterm_lookup.values():
             if cvterm['db_name'] in ['FBbt', 'FBdv']:
                 cvterm['slim_term_cvterm_ids'] = list(set(cvterm['slim_term_cvterm_ids']))
-                # self.log.debug(f'BOB: For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {cvterm["slim_term_cvterm_ids"]}')
-                self.log.debug(f'BOB: For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {len(cvterm["slim_term_cvterm_ids"])}')
+                # self.log.debug(f' For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {cvterm["slim_term_cvterm_ids"]}')
+                # self.log.debug(f'For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {len(cvterm["slim_term_cvterm_ids"])}')
         return
 
     # Elaborate on get_general_data() for the ExpressionHandler.

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -523,11 +523,11 @@ class ExpressionHandler(DataHandler):
             select_from(Feature).\
             join(FeatureExpression, (Feature.feature_id == FeatureExpression.feature_id)).\
             join(FeatureExpressionprop, (FeatureExpressionprop.feature_expression_id == FeatureExpression.feature_expression_id)).\
+            join(Cvterm, (Cvterm.cvterm_id == FeatureExpressionprop.type_id)).\
             filter(*filters).\
             distinct()
         counter = 0
         for result in feat_xprnprops:
-            self.log.debug(f'BOB: Process feature_expressionprop_id={result.feature_expressionprop_id}')
             if result.value is None:
                 self.log.warning(f'feature_expression_id={result.feature_expression_id} has a NULL comment, skipping. ')
                 continue

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -404,12 +404,11 @@ class ExpressionHandler(DataHandler):
                 for rank in expected_rank_list:
                     this_xprn_cvt = rank_sorted_xprn_cvts[rank]
                     # self.log.debug(f'Evaluate type={slot_type}, rank={this_xprn_cvt.chado_obj.rank}, term={this_xprn_cvt.cvterm_name}')
-                    if this_xprn_cvt.cv_name == 'FlyBase miscellaneous CV':
+                    # Note that the check for FBcv OBO filters out the "presumptive" qualifier that has an internal ID so cannot be exported.
+                    if this_xprn_cvt.cv_name == 'FlyBase miscellaneous CV' and this_xprn_cvt.obo == 'FBcv':
                         xprn_pattern_slot[current_primary_cvt_id].qualifier_cvterm_ids.append(this_xprn_cvt.cvterm_id)
                         qualifier_xprn_cvt_ids.append(this_xprn_cvt.db_primary_id)
                         # self.log.debug(f'Found qualifier {this_xprn_cvt.cvterm_name} for primary term="{current_primary_cvterm_name}"')
-                        if this_xprn_cvt.obo != 'FBcv':
-                            self.log.warning(f'Found non-FBcv qualifier: "{this_xprn_cvt.cvterm_name}"')
                     else:
                         current_primary_cvt_id = this_xprn_cvt.db_primary_id
                         # self.log.debug(f'Found primary term="{this_xprn_cvt.cvterm_name}", xprn_cvterm_id={this_xprn_cvt.db_primary_id}')

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -535,11 +535,6 @@ class ExpressionHandler(DataHandler):
             else:
                 xprn_pattern.sub_anatomy_terms['placeholder'] = self.placeholder
         self.log.info(f'Found {counter} expression patterns having anatomy sub_parts.')
-        # Check these difficult cases in the output:
-        # xprn_id=42175, <a> cell | subset &&of mesoderm | dorsal &&of parasegment 2--12
-        # xprn_id=42170, <a> parasegment 3--12 &&of larval ventral nerve cord
-        # xprn_id=34285, <a> parasegment 8 && parasegment 9 &&of midgut
-        # xprn_id=32457, <a> neuron && glial cell &&of central nervous system
         return
 
     def generate_xprn_pattern_dict(self, xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term, cellular_term, anatomy_range_term_id, sub_part_id):
@@ -631,8 +626,13 @@ class ExpressionHandler(DataHandler):
                                 xprn_pattern.xprn_pattern_combos.append(xp)
                                 n_combos += 1
             # self.log.debug(f'For xprn_id={xprn_id}, found {n_combos} total term combinations.')
+        # Check these difficult cases in the output:
+        # xprn_id=42175, <a> cell | subset &&of mesoderm | dorsal &&of parasegment 2--12
+        # xprn_id=42170, <a> parasegment 3--12 &&of larval ventral nerve cord
+        # xprn_id=34285, <a> parasegment 8 && parasegment 9 &&of midgut
+        # xprn_id=32457, <a> neuron && glial cell &&of central nervous system
         return
-    # BOB - xprn_id=26072 - code is not reporting anatomy_sub_part tissue range (see only ventral_nerve_cord/PS7 and ventral_nerve_cord/PS13 combinations).
+        
 
     def process_for_tsv_export(self):
         """Process expression patterns for export to TSV."""

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -408,6 +408,8 @@ class ExpressionHandler(DataHandler):
                         xprn_pattern_slot[current_primary_cvt_id].qualifier_cvterm_ids.append(this_xprn_cvt.cvterm_id)
                         qualifier_xprn_cvt_ids.append(this_xprn_cvt.db_primary_id)
                         # self.log.debug(f'Found qualifier {this_xprn_cvt.cvterm_name} for primary term="{current_primary_cvterm_name}"')
+                        if this_xprn_cvt.obo != 'FBcv':
+                            self.log.warning(f'Found non-FBcv qualifier: "{this_xprn_cvt.cvterm_name}"')
                     else:
                         current_primary_cvt_id = this_xprn_cvt.db_primary_id
                         # self.log.debug(f'Found primary term="{this_xprn_cvt.cvterm_name}", xprn_cvterm_id={this_xprn_cvt.db_primary_id}')

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -405,10 +405,12 @@ class ExpressionHandler(DataHandler):
                     this_xprn_cvt = rank_sorted_xprn_cvts[rank]
                     # self.log.debug(f'Evaluate type={slot_type}, rank={this_xprn_cvt.chado_obj.rank}, term={this_xprn_cvt.cvterm_name}')
                     # Note that the check for FBcv OBO filters out the "presumptive" qualifier that has an internal ID so cannot be exported.
-                    if this_xprn_cvt.cv_name == 'FlyBase miscellaneous CV' and this_xprn_cvt.obo == 'FBcv':
-                        xprn_pattern_slot[current_primary_cvt_id].qualifier_cvterm_ids.append(this_xprn_cvt.cvterm_id)
+                    if this_xprn_cvt.cv_name == 'FlyBase miscellaneous CV':
                         qualifier_xprn_cvt_ids.append(this_xprn_cvt.db_primary_id)
-                        # self.log.debug(f'Found qualifier {this_xprn_cvt.cvterm_name} for primary term="{current_primary_cvterm_name}"')
+                        if this_xprn_cvt.obo == 'FBcv':
+                            xprn_pattern_slot[current_primary_cvt_id].qualifier_cvterm_ids.append(this_xprn_cvt.cvterm_id)
+                        else:
+                            self.log.warning(f'Ignoring non-FBcv qualifier: "{this_xprn_cvt.cvterm_name}".')
                     else:
                         current_primary_cvt_id = this_xprn_cvt.db_primary_id
                         # self.log.debug(f'Found primary term="{this_xprn_cvt.cvterm_name}", xprn_cvterm_id={this_xprn_cvt.db_primary_id}')

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -889,7 +889,7 @@ class ExpressionHandler(DataHandler):
                     feat_xprn.is_problematic = True
                     feat_xprn.notes.append('Suppress export of hemi-driver expression having split system combination feature.')
                     hemidriver_counter += 1
-                    self.log.debug(f'BOB: Suppress feat_xprn_id={feat_xprn.feature_expression_id} for split system combos {split_system_features_represented}')
+                    self.log.debug(f'BOB: Suppress feat_xprn_id={feat_xprn.db_primary_id} for split system combos {split_system_features_represented}')
                 else:
                     feat_xprn.public_feature_id = allele_feature_id
                     allele_product_to_allele_counter += 1

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -547,7 +547,7 @@ class ExpressionHandler(DataHandler):
             'stage_start_cvterm_id': stage_term.cvterm_id,
             'stage_end_cvterm_id': None,
             'stage_qualifier_cvterm_ids': stage_term.qualifier_cvterm_ids,
-            # 'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'],
+            'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'],
             'anatomical_structure_cvterm_id': anatomy_term.cvterm_id,
             'anatomical_structure_qualifier_cvterm_ids': anatomy_term.qualifier_cvterm_ids,
             # 'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[anatomy_term.cvterm_id]['slim_term_cvterm_ids'],

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -369,16 +369,17 @@ class ExpressionHandler(DataHandler):
         filters = (
             Feature.is_obsolete.is_(False),
         )
-        feature_expressions = session.query(Feature, FeatureExpression).\
+        feature_expressions = session.query(FeatureExpression).\
             select_from(Feature).\
             join(FeatureExpression, (Feature.feature_id == FeatureExpression.feature_id)).\
             filter(*filters).\
             distinct()
         counter = 0
         for result in feature_expressions:
-            feat_xprn_id = result.FeatureExpression.feature_expression_id
-            xprn_id = result.FeatureExpression.expression_id
-            feat_type = result.Feature.type.name
+            self.log.debug(f'BOB: feat_xprn_id={result.feature_expression_id}')
+            feat_xprn_id = result.feature_expression_id
+            xprn_id = result.expression_id
+            feat_type = result.feature.type.name
             if xprn_id not in self.expression_patterns.keys():
                 continue
             feat_xprn = fb_datatypes.FBFeatureExpressionAnnotation(result.FeatureExpression)
@@ -676,7 +677,7 @@ class ExpressionHandler(DataHandler):
                     'cellular_component_term': self.cvterm_lookup[xp_combo['cellular_component_cvterm_id']]['name_plus_curie'],
                     'cellular_component_qualifiers': ' | '.join([self.cvterm_lookup[i]['name_plus_curie'] for i in
                                                                 xp_combo['cellular_component_qualifier_cvterm_ids']]),
-                    'notes': ' | '.join(xprn_pattern.tap_stmt_notes),
+                    'notes': ' | '.join(feat_xprn.tap_stmt_notes),
                 }
                 self.export_data_for_tsv.append(xprn_tsv_dict)
                 counter += 1

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -553,7 +553,7 @@ class ExpressionHandler(DataHandler):
             # 'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[anatomy_term.cvterm_id]['slim_term_cvterm_ids'],
             'anatomical_substructure_cvterm_id': anatomy_sub_term.cvterm_id,
             'anatomical_substructure_qualifier_cvterm_ids': anatomy_sub_term.qualifier_cvterm_ids,
-            # 'anatomical_substructure_slim_cvterm_ids': self.cvterm_lookup[anatomy_sub_term.cvterm_id]['slim_term_cvterm_ids'],
+            'anatomical_substructure_slim_cvterm_ids': self.cvterm_lookup[anatomy_sub_term.cvterm_id]['slim_term_cvterm_ids'],
             'cellular_component_cvterm_id': cellular_term.cvterm_id,
             'cellular_component_qualifier_cvterm_ids': cellular_term.qualifier_cvterm_ids,
         }

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -546,25 +546,25 @@ class ExpressionHandler(DataHandler):
             'assay_cvterm_id': assay_term.cvterm_id,
             'stage_start_cvterm_id': stage_term.cvterm_id,
             'stage_end_cvterm_id': None,
-            'stage_qualifier_cvterm_ids': stage_term.qualifier_cvterm_ids,
-            'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'],
+            'stage_qualifier_cvterm_ids': stage_term.qualifier_cvterm_ids.copy(),
+            'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
             'anatomical_structure_cvterm_id': anatomy_term.cvterm_id,
-            'anatomical_structure_qualifier_cvterm_ids': anatomy_term.qualifier_cvterm_ids,
-            'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[anatomy_term.cvterm_id]['slim_term_cvterm_ids'],
+            'anatomical_structure_qualifier_cvterm_ids': anatomy_term.qualifier_cvterm_ids.copy(),
+            'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[anatomy_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
             'anatomical_substructure_cvterm_id': anatomy_sub_term.cvterm_id,
-            'anatomical_substructure_qualifier_cvterm_ids': anatomy_sub_term.qualifier_cvterm_ids,
-            'anatomical_substructure_slim_cvterm_ids': self.cvterm_lookup[anatomy_sub_term.cvterm_id]['slim_term_cvterm_ids'],
+            'anatomical_substructure_qualifier_cvterm_ids': anatomy_sub_term.qualifier_cvterm_ids.copy(),
+            'anatomical_substructure_slim_cvterm_ids': self.cvterm_lookup[anatomy_sub_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
             'cellular_component_cvterm_id': cellular_term.cvterm_id,
-            'cellular_component_qualifier_cvterm_ids': cellular_term.qualifier_cvterm_ids,
+            'cellular_component_qualifier_cvterm_ids': cellular_term.qualifier_cvterm_ids.copy(),
         }
-        # # Handle stage end.
+        # Handle stage end.
         if stage_term.has_stage_end:
             xprn_pattern_dict['stage_end_cvterm_id'] = stage_term.has_stage_end.cvterm_id
             xprn_pattern_dict['stage_qualifier_cvterm_ids'].extend(stage_term.has_stage_end.qualifier_cvterm_ids)
-            additional_slim_term_ids = self.cvterm_lookup[stage_term.has_stage_end.cvterm_id]['slim_term_cvterm_ids']
+            additional_slim_term_ids = self.cvterm_lookup[stage_term.has_stage_end.cvterm_id]['slim_term_cvterm_ids'].copy()
             xprn_pattern_dict['stage_slim_cvterm_ids'].extend(additional_slim_term_ids)
             xprn_pattern_dict['stage_slim_cvterm_ids'] = list(set(xprn_pattern_dict['stage_slim_cvterm_ids']))
-        # # If processing a term in a tissue range, replace the main anatomy term with the cvterm_id given for the term within the range.
+        # If processing a term in a tissue range, replace the main anatomy term with the cvterm_id given for the term within the range.
         if anatomy_range_term_id:
             xprn_pattern_dict['anatomical_structure_cvterm_id'] = anatomy_range_term_id
         self.log.debug(f'For xprn_id={xprn_id}, generated xprn_pattern_dict: {xprn_pattern_dict}')

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -376,7 +376,6 @@ class ExpressionHandler(DataHandler):
             distinct()
         counter = 0
         for result in feature_expressions:
-            self.log.debug(f'BOB: feat_xprn_id={result.feature_expression_id}')
             feat_xprn_id = result.feature_expression_id
             xprn_id = result.expression_id
             feat_type = result.feature.type.name
@@ -386,6 +385,7 @@ class ExpressionHandler(DataHandler):
             if 'RNA' in feat_type:
                 feat_xprn.xprn_type = 'RNA'
             self.fb_data_entities[feat_xprn_id] = feat_xprn
+            self.log.debug(f'BOB: feat_xprn_id={result.feature_expression_id}')
             counter += 1
         self.log.info(f'Found {counter} distinct feature_expression annotations in chado.')
         return

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -527,6 +527,9 @@ class ExpressionHandler(DataHandler):
             distinct()
         counter = 0
         for result in feat_xprnprops:
+            if result.value is None:
+                self.log.warning(f'feature_expression_id={result.feature_expression_id} has a NULL comment, skipping. ')
+                continue
             try:
                 self.fb_data_entities[result.feature_expression_id].tap_stmt_notes.append(result.value)
                 counter += 1

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -200,6 +200,7 @@ class ExpressionHandler(DataHandler):
             'cv_name': '',
             'db_name': '',
             'curie': '',
+            'name_plus_curie': '',
             'slim_term_cvterm_ids': [],
         }
         self.cvterm_lookup['placeholder'] = placeholder_cvterm_dict

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -384,7 +384,7 @@ class ExpressionHandler(DataHandler):
             feat_xprn = fb_datatypes.FBFeatureExpressionAnnotation(result.FeatureExpression)
             if 'RNA' in feat_type:
                 feat_xprn.xprn_type = 'RNA'
-            self.feat_xprn_annos[feat_xprn_id] = feat_xprn
+            self.fb_data_entities[feat_xprn_id] = feat_xprn
             counter += 1
         self.log.info(f'Found {counter} distinct feature_expression annotations in chado.')
         return
@@ -645,13 +645,18 @@ class ExpressionHandler(DataHandler):
         """Process expression patterns for export to TSV."""
         self.log.info('Process expression patterns for export to TSV.')
         counter = 0
-        for xprn_pattern in self.expression_patterns.values():
+        for feat_xprn in self.fb_data_entities.values():
+            xprn_pattern = self.expression_patterns[feat_xprn.expression_id]
             if xprn_pattern.is_problematic:
                 continue
             elif not xprn_pattern.xprn_pattern_combos:
                 continue
             for xp_combo in xprn_pattern.xprn_pattern_combos:
                 xprn_tsv_dict = {
+                    'feature_id': self.feature_lookup[feat_xprn.feature_id]['uniquename'],
+                    'feature_symbol': self.feature_lookup[feat_xprn.feature_id]['name'],
+                    'reference_id': feat_xprn.pub_curie,
+                    'expression_type': feat_xprn.xprn_type,
                     'expression_id': xprn_pattern.db_primary_id,
                     'assay_term': self.cvterm_lookup[xp_combo['assay_cvterm_id']]['name'],
                     'stage_start': self.cvterm_lookup[xp_combo['stage_start_cvterm_id']]['name_plus_curie'],
@@ -671,6 +676,7 @@ class ExpressionHandler(DataHandler):
                     'cellular_component_term': self.cvterm_lookup[xp_combo['cellular_component_cvterm_id']]['name_plus_curie'],
                     'cellular_component_qualifiers': ' | '.join([self.cvterm_lookup[i]['name_plus_curie'] for i in
                                                                 xp_combo['cellular_component_qualifier_cvterm_ids']]),
+                    'notes': ' | '.join(xprn_pattern.tap_stmt_notes),
                 }
                 self.export_data_for_tsv.append(xprn_tsv_dict)
                 counter += 1

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -410,7 +410,7 @@ class ExpressionHandler(DataHandler):
                         if this_xprn_cvt.obo == 'FBcv':
                             xprn_pattern_slot[current_primary_cvt_id].qualifier_cvterm_ids.append(this_xprn_cvt.cvterm_id)
                         else:
-                            self.log.warning(f'Ignoring non-FBcv qualifier: "{this_xprn_cvt.cvterm_name}".')
+                            self.log.debug(f'Ignoring non-FBcv qualifier: "{this_xprn_cvt.cvterm_name}".')
                     else:
                         current_primary_cvt_id = this_xprn_cvt.db_primary_id
                         # self.log.debug(f'Found primary term="{this_xprn_cvt.cvterm_name}", xprn_cvterm_id={this_xprn_cvt.db_primary_id}')
@@ -532,11 +532,15 @@ class ExpressionHandler(DataHandler):
                 # self.log.debug(f'For xprn_id={xprn_pattern.db_primary_id}, have {n_combos} main/sub_part combinations.')
             else:
                 xprn_pattern.sub_anatomy_terms['placeholder'] = self.placeholder
+                xprn_pattern.sub_anatomy_terms['placeholder'].has_anat_term_ids.append(self.placeholder.cvterm_id)
         self.log.info(f'Found {counter} expression patterns having anatomy sub_parts.')
         return
 
     def generate_xprn_pattern_dict(self, xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term, cellular_term):
         """Convert a specific combination of terms from an expression pattern into a simpler dict."""
+        # input_str = f'xprn_id={xprn_id}, assay="{assay_term.cvterm_name}", stage="{stage_term.cvterm_name}", '
+        # input_str += f'anatomy="{anatomy_term.cvterm_name}", sub_part="{anatomy_sub_term.cvterm_name}", cellular="{cellular_term.cvterm_name}"'
+        # self.log.debug(f'Process {input_str}')
         xprn_pattern_dict_list = []
         for main_part_id in anatomy_term.has_anat_term_ids:
             for sub_part_id in anatomy_sub_term.has_anat_term_ids:
@@ -564,6 +568,7 @@ class ExpressionHandler(DataHandler):
                     xprn_pattern_dict['stage_slim_cvterm_ids'] = list(set(xprn_pattern_dict['stage_slim_cvterm_ids']))
                 xprn_pattern_dict_list.append(xprn_pattern_dict)
                 # self.log.debug(f'For xprn_id={xprn_id}, generated xprn_pattern_dict: {xprn_pattern_dict}')
+        # self.log.debug(f'For xprn_id={xprn_id}, generated {len(xprn_pattern_dict_list)} xprn_pattern_dict entries.')
         return xprn_pattern_dict_list
 
     def split_out_expression_patterns(self):

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -547,7 +547,7 @@ class ExpressionHandler(DataHandler):
         xprn_pattern_dict = {
             'assay_cvterm_id': assay_term.cvterm_id,
             'stage_start_cvterm_id': stage_term.cvterm_id,
-            'stage_end_cvterm_id': None,
+            'stage_end_cvterm_id': 'placeholder',
             'stage_qualifier_cvterm_ids': stage_term.qualifier_cvterm_ids.copy(),
             'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
             'anatomical_structure_cvterm_id': anatomy_term.cvterm_id,

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -462,20 +462,18 @@ class ExpressionHandler(DataHandler):
             start_terms = []
             end_terms = []
             for anatomy_term in xprn_pattern.anatomy_terms.values():
+                # Treat all anatomy terms as if they represent a tissue range, though it may be a range of only one.
+                anatomy_term.has_anat_term_ids.append(anatomy_term.cvterm_id)
                 if 'FROM' in anatomy_term.operators:
                     anatomy_term.is_anat_start = True
                     start_terms.append(anatomy_term)
                 if 'TO' in anatomy_term.operators:
                     anatomy_term.is_anat_end = True
                     end_terms.append(anatomy_term)
-                    if anatomy_term.qualifier_cvterm_ids:
-                        # qualifiers = [self.cvterm_lookup[i]['name'] for i in anatomy_term.qualifier_cvterm_ids]
-                        # self.log.debug(f'For xprn_id={xprn_pattern.db_primary_id}, "{anatomy_term.cvterm_name}" has qualifiers: {qualifiers}.')
-                        pass
             if not start_terms and not end_terms:
                 continue
             elif len(start_terms) == 1 and len(end_terms) == 1:
-                end_terms[0].has_anat_terms.append(start_terms[0].cvterm_id)    # Add start term to the range (under the end term object).
+                end_terms[0].has_anat_term_ids.append(start_terms[0].cvterm_id)    # Add start term to the range (under the end term object).
                 end_terms[0].operators.extend(start_terms[0].operators)    # Propagate operators from start of tissue range to end.
                 # Get intervening tissue range terms, then add them to the list of terms in the tissue range.
                 # tissue_range_string = f'{start_terms[0].cvterm_name}--{end_terms[0].cvterm_name}'
@@ -491,8 +489,8 @@ class ExpressionHandler(DataHandler):
                 anatomical_series_terms = self.get_anatomical_terms_by_regex(session, rgx)
                 filtered_terms = self.select_in_range_anatomical_terms(anatomical_series_terms, rgx, start, end)
                 anat_cvterm_ids = [i.cvterm_id for i in filtered_terms]
-                end_terms[0].has_anat_terms.extend(anat_cvterm_ids)
-                end_terms[0].has_anat_terms.sort()
+                end_terms[0].has_anat_term_ids.extend(anat_cvterm_ids)
+                end_terms[0].has_anat_term_ids.sort()
                 counter += 1
             else:
                 self.log.error(f'Many/partial tissue ranges found for xprn_id={xprn_pattern.db_primary_id}')
@@ -520,8 +518,8 @@ class ExpressionHandler(DataHandler):
                 if not potential_sub_parts:
                     self.log.error(f'For xprn_id={xprn_pattern.db_primary_id}, there are "main" parts but no sub-parts.')
                 else:
-                    if len(potential_sub_parts) > 1:
-                        self.log.warning(f'For xprn_id={xprn_pattern.db_primary_id}, there are {len(potential_sub_parts)} sub-parts.')
+                    if len(potential_sub_parts) > 1 or len(main_parts) > 1:
+                        self.log.warning(f'xprn_id={xprn_pattern.db_primary_id} has {len(main_parts)} main parts and {len(potential_sub_parts)} sub-parts.')
                     # Move anatomy sub_parts into a separate dict within the expression pattern object.
                     for sub_part in potential_sub_parts:
                         xprn_pattern.sub_anatomy_terms[sub_part.db_primary_id] = sub_part
@@ -537,41 +535,36 @@ class ExpressionHandler(DataHandler):
         self.log.info(f'Found {counter} expression patterns having anatomy sub_parts.')
         return
 
-    def generate_xprn_pattern_dict(self, xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term, cellular_term, anatomy_range_term_id, sub_part_id):
+    def generate_xprn_pattern_dict(self, xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term, cellular_term):
         """Convert a specific combination of terms from an expression pattern into a simpler dict."""
-        input_str = f'assay="{assay_term.cvterm_name}", stage="{stage_term.cvterm_name}", anatomy="{anatomy_term.cvterm_name}", '
-        input_str += f'cellular="{cellular_term.cvterm_name}", anatomy_range_term_id={anatomy_range_term_id}'
-        # self.log.debug(f'Generate xprn_pattern_dict for xprn_id={xprn_id}; input: {input_str}')
-        xprn_pattern_dict = {
-            'assay_cvterm_id': assay_term.cvterm_id,
-            'stage_start_cvterm_id': stage_term.cvterm_id,
-            'stage_end_cvterm_id': 'placeholder',
-            'stage_qualifier_cvterm_ids': stage_term.qualifier_cvterm_ids.copy(),
-            'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
-            'anatomical_structure_cvterm_id': anatomy_term.cvterm_id,
-            'anatomical_structure_qualifier_cvterm_ids': anatomy_term.qualifier_cvterm_ids.copy(),
-            'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[anatomy_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
-            'anatomical_substructure_cvterm_id': anatomy_sub_term.cvterm_id,
-            'anatomical_substructure_qualifier_cvterm_ids': anatomy_sub_term.qualifier_cvterm_ids.copy(),
-            'anatomical_substructure_slim_cvterm_ids': self.cvterm_lookup[anatomy_sub_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
-            'cellular_component_cvterm_id': cellular_term.cvterm_id,
-            'cellular_component_qualifier_cvterm_ids': cellular_term.qualifier_cvterm_ids.copy(),
-        }
-        # Handle stage end.
-        if stage_term.has_stage_end:
-            xprn_pattern_dict['stage_end_cvterm_id'] = stage_term.has_stage_end.cvterm_id
-            xprn_pattern_dict['stage_qualifier_cvterm_ids'].extend(stage_term.has_stage_end.qualifier_cvterm_ids)
-            additional_slim_term_ids = self.cvterm_lookup[stage_term.has_stage_end.cvterm_id]['slim_term_cvterm_ids'].copy()
-            xprn_pattern_dict['stage_slim_cvterm_ids'].extend(additional_slim_term_ids)
-            xprn_pattern_dict['stage_slim_cvterm_ids'] = list(set(xprn_pattern_dict['stage_slim_cvterm_ids']))
-        # If processing a term in a tissue range for the main anatomy part, replace the main anatomy term with the cvterm_id given.
-        if anatomy_range_term_id:
-            xprn_pattern_dict['anatomical_structure_cvterm_id'] = anatomy_range_term_id
-        # If processing a term in a tissue range for the anatomy sub_part, replace the anatomy sub_part term with the cvterm_id given.
-        if sub_part_id:
-            xprn_pattern_dict['anatomical_substructure_cvterm_id'] = sub_part_id
-        # self.log.debug(f'For xprn_id={xprn_id}, generated xprn_pattern_dict: {xprn_pattern_dict}')
-        return xprn_pattern_dict
+        xprn_pattern_dict_list = []
+        for main_part_id in anatomy_term.has_anat_term_ids:
+            for sub_part_id in anatomy_sub_term.has_anat_term_ids:
+                xprn_pattern_dict = {
+                    'assay_cvterm_id': assay_term.cvterm_id,
+                    'stage_start_cvterm_id': stage_term.cvterm_id,
+                    'stage_end_cvterm_id': 'placeholder',
+                    'stage_qualifier_cvterm_ids': stage_term.qualifier_cvterm_ids.copy(),
+                    'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'].copy(),
+                    'anatomical_structure_cvterm_id': main_part_id,
+                    'anatomical_structure_qualifier_cvterm_ids': anatomy_term.qualifier_cvterm_ids.copy(),
+                    'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[main_part_id]['slim_term_cvterm_ids'].copy(),
+                    'anatomical_substructure_cvterm_id': sub_part_id,
+                    'anatomical_substructure_qualifier_cvterm_ids': anatomy_sub_term.qualifier_cvterm_ids.copy(),
+                    'anatomical_substructure_slim_cvterm_ids': self.cvterm_lookup[sub_part_id]['slim_term_cvterm_ids'].copy(),
+                    'cellular_component_cvterm_id': cellular_term.cvterm_id,
+                    'cellular_component_qualifier_cvterm_ids': cellular_term.qualifier_cvterm_ids.copy(),
+                }
+                # Handle stage end.
+                if stage_term.has_stage_end:
+                    xprn_pattern_dict['stage_end_cvterm_id'] = stage_term.has_stage_end.cvterm_id
+                    xprn_pattern_dict['stage_qualifier_cvterm_ids'].extend(stage_term.has_stage_end.qualifier_cvterm_ids)
+                    additional_slim_term_ids = self.cvterm_lookup[stage_term.has_stage_end.cvterm_id]['slim_term_cvterm_ids'].copy()
+                    xprn_pattern_dict['stage_slim_cvterm_ids'].extend(additional_slim_term_ids)
+                    xprn_pattern_dict['stage_slim_cvterm_ids'] = list(set(xprn_pattern_dict['stage_slim_cvterm_ids']))
+                xprn_pattern_dict_list.append(xprn_pattern_dict)
+                # self.log.debug(f'For xprn_id={xprn_id}, generated xprn_pattern_dict: {xprn_pattern_dict}')
+        return xprn_pattern_dict_list
 
     def split_out_expression_patterns(self):
         """Generate all combinations of anatomy/assay/cellular/stage terms for an expression pattern."""
@@ -593,38 +586,18 @@ class ExpressionHandler(DataHandler):
                     # Skip stage range end terms, as these are folded into reporting of the stage range start term.
                     if stage_term.is_stage_end:
                         continue
-                    for cellular_term in xprn_pattern.cellular_terms.values():
-                        for anatomy_term in xprn_pattern.anatomy_terms.values():
-                            # Skip anatomy range start terms, as these are folded into reporting of the stage range end term.
-                            if anatomy_term.is_anat_start:
+                    for anatomy_term in xprn_pattern.anatomy_terms.values():
+                        # Skip anatomy range start terms, as these are folded into reporting of the stage range end term.
+                        if anatomy_term.is_anat_start:
+                            continue
+                        for anatomy_sub_term in xprn_pattern.sub_anatomy_terms.values():
+                            # Skip sub_part anatomy range start terms, as these are folded into reporting of the stage range end term.
+                            if anatomy_sub_term.is_anat_start:
                                 continue
-                            for anatomy_sub_term in xprn_pattern.sub_anatomy_terms.values():
-                                # Skip sub_part anatomy range start terms, as these are folded into reporting of the stage range end term.
-                                if anatomy_sub_term.is_anat_start:
-                                    continue
-                                # Catch cases too complex to handle: i.e., tissue range in both the main and sub parts.
-                                if anatomy_term.has_anat_terms and anatomy_sub_term.has_anat_terms:
-                                    self.log.error(f'For xprn_id={xprn_id}, cannot handle tissue ranges for both main part and sub_part.')
-                                    xprn_pattern.is_problematic = True
-                                    xprn_pattern.notes.append('Found tissue ranges for both main part and sub_part.')
-                                    continue
-                                # If there is an anatomy range for the main body part, first report the start and intermediate anatomy range terms.
-                                for anatomy_range_term_id in anatomy_term.has_anat_terms:
-                                    xp = self.generate_xprn_pattern_dict(xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term,
-                                                                         cellular_term, anatomy_range_term_id, None)
-                                    xprn_pattern.xprn_pattern_combos.append(xp)
-                                    n_combos += 1
-                                # If there is an anatomy range for the anatomy sub_part, first report the start and intermediate anatomy range terms.
-                                for anatomy_sub_part_term_id in anatomy_sub_term.has_anat_terms:
-                                    xp = self.generate_xprn_pattern_dict(xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term,
-                                                                         cellular_term, None, anatomy_sub_part_term_id)
-                                    xprn_pattern.xprn_pattern_combos.append(xp)
-                                    n_combos += 1
-                                # Report for the main anatomy term, including end terms for anatomy ranges.
-                                xp = self.generate_xprn_pattern_dict(xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term,
-                                                                     cellular_term, None, None)
-                                xprn_pattern.xprn_pattern_combos.append(xp)
-                                n_combos += 1
+                            for cellular_term in xprn_pattern.cellular_terms.values():
+                                xp_list = self.generate_xprn_pattern_dict(xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term, cellular_term)
+                                xprn_pattern.xprn_pattern_combos.extend(xp_list)
+                                n_combos += len(xp_list)
             # self.log.debug(f'For xprn_id={xprn_id}, found {n_combos} total term combinations.')
         # Check these difficult cases in the output:
         # xprn_id=42175, <a> cell | subset &&of mesoderm | dorsal &&of parasegment 2--12

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -913,7 +913,10 @@ class ExpressionHandler(DataHandler):
                             partner_insertion_curies.extend(re.findall(insertion_rgx, note))
                     partner_construct_curies = set(partner_construct_curies)
                     for partner_construct_curie in partner_construct_curies:
-                        partner_insertion_curies.extend(self.construct_insertion_lookup[partner_construct_curie])
+                        try:
+                            partner_insertion_curies.extend(self.construct_insertion_lookup[partner_construct_curie])
+                        except KeyError:
+                            pass
                     partner_insertion_curies = set(partner_insertion_curies)
                     if not partner_construct_curies and not partner_insertion_curies:
                         feat_xprn.is_problematic = True

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -546,7 +546,7 @@ class ExpressionHandler(DataHandler):
         """Convert a specific combination of terms from an expression pattern into a simpler dict."""
         input_str = f'assay="{assay_term.cvterm_name}", stage="{stage_term.cvterm_name}", anatomy="{anatomy_term.cvterm_name}", '
         input_str += f'cellular="{cellular_term.cvterm_name}", anatomy_range_term_id={anatomy_range_term_id}'
-        self.log.debug(f'Generate xprn_pattern_dict for xprn_id={xprn_id}; input: {input_str}')
+        # self.log.debug(f'Generate xprn_pattern_dict for xprn_id={xprn_id}; input: {input_str}')
         xprn_pattern_dict = {
             'assay_cvterm_id': assay_term.cvterm_id,
             'stage_start_cvterm_id': stage_term.cvterm_id,
@@ -572,7 +572,7 @@ class ExpressionHandler(DataHandler):
         # If processing a term in a tissue range, replace the main anatomy term with the cvterm_id given for the term within the range.
         if anatomy_range_term_id:
             xprn_pattern_dict['anatomical_structure_cvterm_id'] = anatomy_range_term_id
-        self.log.debug(f'For xprn_id={xprn_id}, generated xprn_pattern_dict: {xprn_pattern_dict}')
+        # self.log.debug(f'For xprn_id={xprn_id}, generated xprn_pattern_dict: {xprn_pattern_dict}')
         return xprn_pattern_dict
 
     def split_out_expression_patterns(self):
@@ -612,7 +612,7 @@ class ExpressionHandler(DataHandler):
                                                                      cellular_term, None)
                                 xprn_pattern.xprn_pattern_combos.append(xp)
                                 n_combos += 1
-            self.log.debug(f'For xprn_id={xprn_id}, found {n_combos} total term combinations.')
+            # self.log.debug(f'For xprn_id={xprn_id}, found {n_combos} total term combinations.')
         return
 
     def process_for_tsv_export(self):

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -11,6 +11,7 @@ Author(s):
 import re
 from logging import Logger
 from sqlalchemy.orm import aliased
+from harvdev_utils.char_conversions import clean_free_text
 from harvdev_utils.reporting import (
     Cv, Cvterm, Db, Dbxref, Expression, ExpressionCvterm, ExpressionCvtermprop,
     Feature, FeatureExpression, FeatureExpressionprop, FeatureRelationship
@@ -532,7 +533,8 @@ class ExpressionHandler(DataHandler):
                 self.log.warning(f'feature_expression_id={result.feature_expression_id} has a NULL comment, skipping. ')
                 continue
             try:
-                self.fb_data_entities[result.feature_expression_id].tap_stmt_notes.append(result.value)
+                cleaned_prop_text = clean_free_text(result.value)
+                self.fb_data_entities[result.feature_expression_id].tap_stmt_notes.append(cleaned_prop_text)
                 counter += 1
             except KeyError:
                 continue

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -782,6 +782,8 @@ class ExpressionHandler(DataHandler):
         self.log.info('Process expression patterns for export to TSV.')
         counter = 0
         for feat_xprn in self.fb_data_entities.values():
+            if feat_xprn.is_problematic:
+                continue
             xprn_pattern = self.expression_patterns[feat_xprn.expression_id]
             if xprn_pattern.is_problematic:
                 continue

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -915,7 +915,7 @@ class ExpressionHandler(DataHandler):
                             partner_insertion_curies.extend(re.findall(insertion_rgx, note))
                     if not partner_construct_curies and not partner_insertion_curies:
                         feat_xprn.is_problematic = True
-                        feat_xprn.notes.append('Suppress export of hemi-driver expression having no partner hemidrivers mentioned.')
+                        feat_xprn.notes.append('Suppress export of hemi-driver expression having no mention of partner hemidrivers.')
                         self.log.debug(f'Suppress fx_id={feat_xprn.db_primary_id} as no partner hemidrivers are mentioned in notes')
                         hemidriver_counter += 1
                         continue
@@ -941,9 +941,6 @@ class ExpressionHandler(DataHandler):
                         pair_combo_str = '|'.join(pair_combo)
                         if pair_combo_str in self.split_system_combo_strs:
                             split_system_features_represented.append(pair_combo_str)
-                    # self.log.debug(f'BOB: sbj={allele_curie}, fx_id={feat_xprn.db_primary_id}, \
-                    #                fbtp: {partner_construct_curies}, fbti: {partner_insertion_curies}, \
-                    #                fbal: {partner_allele_curies}, combos: {split_system_counter}')
                     if split_system_features_represented:
                         feat_xprn.is_problematic = True
                         feat_xprn.notes.append('Suppress export of hemi-driver expression having split system combination feature.')

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -610,6 +610,7 @@ class ExpressionHandler(DataHandler):
         # xprn_id=34285, <a> parasegment 8 && parasegment 9 &&of midgut
         # xprn_id=32457, <a> neuron && glial cell &&of central nervous system
         return
+        
 
     def process_for_tsv_export(self):
         """Process expression patterns for export to TSV."""

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -251,8 +251,8 @@ class ExpressionHandler(DataHandler):
         for cvterm in self.cvterm_lookup.values():
             if cvterm['db_name'] in ['FBbt', 'FBdv']:
                 cvterm['slim_term_cvterm_ids'] = list(set(cvterm['slim_term_cvterm_ids']))
-                self.log.debug(f'BOB: For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {cvterm["slim_term_cvterm_ids"]}')
-                self.log.debug(f'BOB: For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {len(cvterm["slim_term_cvterm_ids"])}')
+                # self.log.debug(f'For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {cvterm["slim_term_cvterm_ids"]}')
+                # self.log.debug(f'For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {len(cvterm["slim_term_cvterm_ids"])}')
         return
 
     # Elaborate on get_general_data() for the ExpressionHandler.
@@ -550,7 +550,7 @@ class ExpressionHandler(DataHandler):
             'stage_slim_cvterm_ids': self.cvterm_lookup[stage_term.cvterm_id]['slim_term_cvterm_ids'],
             'anatomical_structure_cvterm_id': anatomy_term.cvterm_id,
             'anatomical_structure_qualifier_cvterm_ids': anatomy_term.qualifier_cvterm_ids,
-            # 'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[anatomy_term.cvterm_id]['slim_term_cvterm_ids'],
+            'anatomical_structure_slim_cvterm_ids': self.cvterm_lookup[anatomy_term.cvterm_id]['slim_term_cvterm_ids'],
             'anatomical_substructure_cvterm_id': anatomy_sub_term.cvterm_id,
             'anatomical_substructure_qualifier_cvterm_ids': anatomy_sub_term.qualifier_cvterm_ids,
             'anatomical_substructure_slim_cvterm_ids': self.cvterm_lookup[anatomy_sub_term.cvterm_id]['slim_term_cvterm_ids'],

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -871,6 +871,7 @@ class ExpressionHandler(DataHandler):
                 partner_allele_curies = []
                 split_system_features_represented = []
                 if allele_feature_id in self.hemi_drivers:
+                    self.log.debug(f'BILLY: Check feat_xprn_id={feat_xprn.db_primary_id} for split system combos')
                     allele_curie = self.feature_lookup[allele_feature_id]['uniquename']
                     for note in feat_xprn.tap_stmt_notes:
                         if re.search(insertion_rgx, note):

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -545,8 +545,7 @@ class ExpressionHandler(DataHandler):
         """Convert a specific combination of terms from an expression pattern into a simpler dict."""
         input_str = f'assay="{assay_term.cvterm_name}", stage="{stage_term.cvterm_name}", main_anatomy="{anatomy_term.cvterm_name}", '
         input_str += f'sub_part_anatomy="{anatomy_sub_term.cvterm_name}", cellular="{cellular_term.cvterm_name}"'
-        self.log.debug(f'Generate xprn_pattern_dict for xprn_id={xprn_id}; input: {input_str}')
-        self.log.debug(f'xprn_id={xprn_id} has {len(anatomy_term.has_anat_term_ids)} main parts and {len(anatomy_sub_term.has_anat_term_ids)} sub-parts.')
+        # self.log.debug(f'Generate xprn_pattern_dict for xprn_id={xprn_id}; input: {input_str}')
         xprn_pattern_dict_list = []
         for main_part_id in anatomy_term.has_anat_term_ids:
             for sub_part_id in anatomy_sub_term.has_anat_term_ids:
@@ -608,7 +607,7 @@ class ExpressionHandler(DataHandler):
                                 xp_list = self.generate_xprn_pattern_dict(xprn_id, assay_term, stage_term, anatomy_term, anatomy_sub_term, cellular_term)
                                 xprn_pattern.xprn_pattern_combos.extend(xp_list)
                                 n_combos += len(xp_list)
-            self.log.debug(f'For xprn_id={xprn_id}, found {n_combos} total term combinations.')
+            # self.log.debug(f'For xprn_id={xprn_id}, found {n_combos} total term combinations.')
         # Check these difficult cases in the output:
         # xprn_id=42175, <a> cell | subset &&of mesoderm | dorsal &&of parasegment 2--12
         # xprn_id=42170, <a> parasegment 3--12 &&of larval ventral nerve cord

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -303,6 +303,7 @@ class ExpressionHandler(DataHandler):
         self.get_slim_term_mappings(session)
         self.build_organism_lookup(session)
         self.build_feature_lookup(session, feature_types=['transcript', 'polypeptide', 'allele', 'gene', 'insertion', 'split system combination'])
+        self.get_isoform_mappings(session)
         return
 
     # Add methods to be run by get_datatype_data() below.

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -753,7 +753,7 @@ class ExpressionHandler(DataHandler):
                 feat_xprn.public_feature_id = feat_xprn.feature_id
                 split_system_counter += 1
             # 2. Deal with gene product isoforms, which map to genes indirectly.
-            if feat_xprn.feature_id in self.isoform_gene_product_lookup.keys():
+            elif feat_xprn.feature_id in self.isoform_gene_product_lookup.keys():
                 gene_product_id = self.isoform_gene_product_lookup[feat_xprn.feature_id]
                 try:
                     feat_xprn.public_feature_id = self.gene_product_gene_lookup[gene_product_id]

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -922,7 +922,10 @@ class ExpressionHandler(DataHandler):
                         hemidriver_counter += 1
                         continue
                     for partner_insertion_curie in partner_insertion_curies:
-                        partner_allele_curies.extend(self.insertion_allele_lookup[partner_insertion_curie])
+                        try:
+                            partner_allele_curies.extend(self.insertion_allele_lookup[partner_insertion_curie])
+                        except KeyError:
+                            pass
                     partner_allele_curies = set(partner_allele_curies)
                     for partner_allele_curie in partner_allele_curies:
                         pair_combo = [allele_curie, partner_allele_curie]

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -343,11 +343,11 @@ class ExpressionHandler(DataHandler):
         counter = 0
         for result in results:
             counter += 1
-            allele_product_str = f'{result.gene_product.name} ({result.gene_product.uniquename})'
+            allele_product_str = f'{result.allele_product.name} ({result.allele_product.uniquename})'
             allele_str = f'{result.allele.name} ({result.allele.uniquename})'
             self.log.debug(f'BOB: {allele_product_str} maps to allele {allele_str}.')
             if result.allele_product.feature_id in self.allele_product_allele_lookup.keys():
-                allele_product_str = f'{result.gene_product.name} ({result.gene_product.uniquename})'
+                allele_product_str = f'{result.allele_product.name} ({result.allele_product.uniquename})'
                 self.log.warning(f'Found multiple alleles for allele product {allele_product_str}.')
                 continue
             self.allele_product_allele_lookup[result.allele_product.feature_id] = result.allele.feature_id

--- a/src/expression_handler.py
+++ b/src/expression_handler.py
@@ -251,8 +251,8 @@ class ExpressionHandler(DataHandler):
         for cvterm in self.cvterm_lookup.values():
             if cvterm['db_name'] in ['FBbt', 'FBdv']:
                 cvterm['slim_term_cvterm_ids'] = list(set(cvterm['slim_term_cvterm_ids']))
-                # self.log.debug(f' For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {cvterm["slim_term_cvterm_ids"]}')
-                # self.log.debug(f'For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {len(cvterm["slim_term_cvterm_ids"])}')
+                self.log.debug(f'BOB: For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {cvterm["slim_term_cvterm_ids"]}')
+                self.log.debug(f'BOB: For {cvterm["db_name"]} term "{cvterm["name"]}", found slim terms: {len(cvterm["slim_term_cvterm_ids"])}')
         return
 
     # Elaborate on get_general_data() for the ExpressionHandler.

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -586,10 +586,11 @@ class FBFeatureExpressionAnnotation(FBExportEntity):
             chado_obj (SQLAlchemy FeatureExpression object): The Chado FeatureExpression object.
 
         """
-        # Features are usually Dmel XR/XP, transgenic RA/PA products, or FBco split system combination features.
-        # There are also a few hundred interal Dmel transcripts (e.g., "tkv[+]R4.4") or polypeptides (e.g., "Appl[+]P130kD") - report these for the gene.
+        # BOB: Features are usually Dmel XR/XP, transgenic RA/PA products, or FBco split system combination features.
+        # BOB: There are also a few hundred interal Dmel transcripts (e.g., "tkv[+]R4.4") or polypeptides (e.g., "Appl[+]P130kD") - report these for the gene.
         # BOB: NEED TO FILTER OUT xprn for FBco component FBal alleles!!!!!
         # BOB: NEED TO FILTER OUT xprn for transgenic transcripts/polypeptides lacking a current allele.
+        # BOB: FILTER OUT <note> with "when combined with", as this is detritus from old FBco-component annotation.
         super().__init__()
         # Primary FB chado data.
         self.chado_obj = chado_obj
@@ -599,8 +600,7 @@ class FBFeatureExpressionAnnotation(FBExportEntity):
         self.expression_id = chado_obj.expression_id
         self.pub_curie = chado_obj.pub.uniquename
         self.original_tap_stmts = []    # Will be the originally curated TAP statements (type='curated_as'); usually one, but up to seven.
-        self.tap_stmt_note = []         # Will be a list of <note> text from the original curation (type='comment'); usually one, rarely two.
-        # BOB: FILTER OUT <note> with "when combined with", as this is detritus from old FBco-component annotation.
+        self.tap_stmt_notes = []        # Will be a list of <note> text from the original curation (type='comment'); usually one, rarely two.
         # Processed FB data.
         self.current_gene_ids = []       # Will be gene feature_ids for the parental genes (for XR/XP).
         self.current_allele_ids = []     # Will be allele feature_ids for the current alleles (for RA/PA).

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -547,7 +547,7 @@ class FBExpressionCvterm(object):
         self.has_stage_end = None      # For a stage term having a "FROM" operator, put the matching "TO" FBExpressionCvterm stage term here.
         self.is_anat_start = False     # True for an anatomy term having a "FROM" operator.
         self.is_anat_end = False       # True for an anatomy term having a "TO" operator.
-        self.has_anat_term_ids = []    # For a term at the end of a tissue range, the list of cvterm_ids for all anatomy terms in the range (inc. itself).
+        self.has_anat_terms = []       # For a term at the end of a tissue range, the list of cvterm_ids for all anatomy terms in the range (inc. itself).
 
 
 class FBExpressionAnnotation(object):

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -595,7 +595,6 @@ class FBFeatureExpressionAnnotation(FBExportEntity):
         self.xprn_type = chado_obj.feature.type.name    # Simplify to polypeptide or RNA.
         self.expression_id = chado_obj.expression_id
         self.pub_curie = chado_obj.pub.uniquename
-        self.original_tap_stmts = []    # Will be the originally curated TAP statements (type='curated_as'); usually one, but up to seven.
         self.tap_stmt_notes = []        # Will be a list of <note> text from the original curation (type='comment'); usually one, rarely two.
         # Processed FB data.
         self.current_gp_ids = []         # Will be feature_ids of parental XR/XP features for isoforms (e.g., tkv[+]R4.4, Appl[+]P130kD)

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -594,12 +594,18 @@ class FBFeatureExpressionAnnotation(FBExportEntity):
         # Primary FB chado data.
         self.chado_obj = chado_obj
         self.db_primary_id = chado_obj.feature_expression_id
+        self.feature_id = chado_obj.feature_id
+        self.xprn_type = chado_obj.feature.type.name    # Simplify to polypeptide or RNA.
+        self.expression_id = chado_obj.expression_id
+        self.pub_curie = chado_obj.pub.uniquename
         self.original_tap_stmts = []    # Will be the originally curated TAP statements (type='curated_as'); usually one, but up to seven.
         self.tap_stmt_note = []         # Will be a list of <note> text from the original curation (type='comment'); usually one, rarely two.
         # BOB: FILTER OUT <note> with "when combined with", as this is detritus from old FBco-component annotation.
         # Processed FB data.
+        self.current_gene_ids = []       # Will be gene feature_ids for the parental genes (for XR/XP).
+        self.current_allele_ids = []     # Will be allele feature_ids for the current alleles (for RA/PA).
+        self.parental_fbco_ids = []      # Will be split system combination feature_ids for hemi-driver alleles.
         self.public_feature_id = None    # Will be the feature_id of the public feature: e.g., the gene, or the allele.
-        self.xprn_type = None            # Will be RNA or protein, as appropriate.
         self.is_problematic = False      # True if there are problems that preclude export.
         self.notes = []
 

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -586,10 +586,7 @@ class FBFeatureExpressionAnnotation(FBExportEntity):
             chado_obj (SQLAlchemy FeatureExpression object): The Chado FeatureExpression object.
 
         """
-        # BOB: Features are usually Dmel XR/XP, transgenic RA/PA products, or FBco split system combination features.
-        # BOB: There are also a few hundred interal Dmel transcripts (e.g., "tkv[+]R4.4") or polypeptides (e.g., "Appl[+]P130kD") - report these for the gene.
         # BOB: NEED TO FILTER OUT xprn for FBco component FBal alleles!!!!!
-        # BOB: NEED TO FILTER OUT xprn for transgenic transcripts/polypeptides lacking a current allele.
         # BOB: FILTER OUT <note> with "when combined with", as this is detritus from old FBco-component annotation.
         super().__init__()
         # Primary FB chado data.

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -547,7 +547,7 @@ class FBExpressionCvterm(object):
         self.has_stage_end = None      # For a stage term having a "FROM" operator, put the matching "TO" FBExpressionCvterm stage term here.
         self.is_anat_start = False     # True for an anatomy term having a "FROM" operator.
         self.is_anat_end = False       # True for an anatomy term having a "TO" operator.
-        self.has_anat_terms = []       # For a term at the end of a tissue range, the list of cvterm_ids for all anatomy terms in the range (inc. itself).
+        self.has_anat_term_ids = []    # For a term at the end of a tissue range, the list of cvterm_ids for all anatomy terms in the range (inc. itself).
 
 
 class FBExpressionAnnotation(object):

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -586,7 +586,6 @@ class FBFeatureExpressionAnnotation(FBExportEntity):
             chado_obj (SQLAlchemy FeatureExpression object): The Chado FeatureExpression object.
 
         """
-        # BOB: FILTER OUT <note> with "when combined with", as this is detritus from old FBco-component annotation.
         super().__init__()
         # Primary FB chado data.
         self.chado_obj = chado_obj

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -566,6 +566,7 @@ class FBExpressionAnnotation(object):
         self.anatomy_terms = {}          # expression_cvterm_id-keyed dict of FBExpressionCvterm objects, anatomy.
         self.cellular_terms = {}         # expression_cvterm_id-keyed dict of FBExpressionCvterm objects, cellular.
         self.stage_terms = {}            # expression_cvterm_id-keyed dict of FBExpressionCvterm objects, stage.
+        self.curated_notes = []          # Will be FeatureExpressionprop.value for type "comment".
         # Processed FB data.
         self.sub_anatomy_terms = {}      # expression_cvterm_id-keyed dict of FBExpressionCvterm objects, anatomy sub_parts.
         self.xprn_pattern_combos = []    # Discrete anatomy/assay/cellular/stage term combinations for this annotation.

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -606,7 +606,7 @@ class FBFeatureExpressionAnnotation(FBExportEntity):
         self.current_gene_ids = []       # Will be gene feature_ids for the parental genes (for XR/XP).
         self.current_allele_ids = []     # Will be allele feature_ids for the current alleles (for RA/PA).
         self.parental_fbco_ids = []      # Will be split system combination feature_ids for hemi-driver alleles.
-        self.public_feature_id = None    # Will be the feature_id of the public feature: e.g., the gene, or the allele.
+        self.public_feature_id = None    # Will be the feature_id of the feature to use in the TSV export file: e.g., the gene, or the allele/insertion.
         self.is_problematic = False      # True if there are problems that preclude export.
         self.notes = []
 

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -586,7 +586,6 @@ class FBFeatureExpressionAnnotation(FBExportEntity):
             chado_obj (SQLAlchemy FeatureExpression object): The Chado FeatureExpression object.
 
         """
-        # BOB: NEED TO FILTER OUT xprn for FBco component FBal alleles!!!!!
         # BOB: FILTER OUT <note> with "when combined with", as this is detritus from old FBco-component annotation.
         super().__init__()
         # Primary FB chado data.

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -602,6 +602,7 @@ class FBFeatureExpressionAnnotation(FBExportEntity):
         self.original_tap_stmts = []    # Will be the originally curated TAP statements (type='curated_as'); usually one, but up to seven.
         self.tap_stmt_notes = []        # Will be a list of <note> text from the original curation (type='comment'); usually one, rarely two.
         # Processed FB data.
+        self.current_gp_ids = []         # Will be feature_ids of parental XR/XP features for isoforms (e.g., tkv[+]R4.4, Appl[+]P130kD)
         self.current_gene_ids = []       # Will be gene feature_ids for the parental genes (for XR/XP).
         self.current_allele_ids = []     # Will be allele feature_ids for the current alleles (for RA/PA).
         self.parental_fbco_ids = []      # Will be split system combination feature_ids for hemi-driver alleles.

--- a/src/handler.py
+++ b/src/handler.py
@@ -288,6 +288,7 @@ class DataHandler(object):
                 'cv_name': result.cv.name,
                 'db_name': result.dbxref.db.name,
                 'curie': f'{result.dbxref.db.name}:{result.dbxref.accession}',
+                'name_plus_curie': f'{result.name} ({result.dbxref.db.name}:{result.dbxref.accession})',
                 'slim_term_cvterm_ids': [],
             }
             self.cvterm_lookup[result.cvterm_id] = cvterm_dict

--- a/src/report_expression.py
+++ b/src/report_expression.py
@@ -34,7 +34,7 @@ HEADER_LIST = [
     'feature_symbol',
     'reference_id',
     'expression_type',
-    'expression_id',    # Only for debugging.
+    'expression_id',    # BOB: Internal expression.expression_id, only for debugging.
     'assay_term',
     'stage_start',
     'stage_end',

--- a/src/report_expression.py
+++ b/src/report_expression.py
@@ -89,6 +89,7 @@ def main():
     expression_handler.get_general_data(session)
     expression_handler.get_datatype_data(session)
     expression_handler.synthesize_info(session)
+    expression_handler.process_for_tsv_export()
 
     # Export the data.
     data_to_export_as_tsv = generic_FB_tsv_dict(REPORT_TITLE, DATABASE)

--- a/src/report_expression.py
+++ b/src/report_expression.py
@@ -22,22 +22,45 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
 from expression_handler import ExpressionHandler
-# from utils import export_chado_data, generate_export_file
+from harvdev_utils.general_functions import (
+    generic_FB_tsv_dict, tsv_report_dump
+)
 
 # Data types handled by this script.
 REPORT_LABEL = 'curated_expression'
+REPORT_TITLE = 'FlyBase Expression Report'
+HEADER_LIST = [
+    # 'feature_id',
+    # 'feature_symbol',
+    # 'reference_id',
+    # 'expression_type',
+    'expression_id',    # Only for debugging.
+    'assay_term',
+    'stage_start',
+    'stage_end',
+    'stage_qualifiers',
+    'stage_slim_terms',
+    'anatomical_structure_term',
+    'anatomical_structure_qualifiers',
+    'anatomical_structure_slim_terms',
+    'anatomical_substructure_term',
+    'anatomical_substructure_qualifiers',
+    'anatomical_substructure_slim_terms',
+    'cellular_component_term',
+    'cellular_component_qualifiers',
+    # 'notes',
+]
 
 # Now proceed with generic setup.
 set_up_dict = set_up_db_reading(REPORT_LABEL)
-server = set_up_dict['server']
-database = set_up_dict['database']
-username = set_up_dict['username']
-password = set_up_dict['password']
-database_release = set_up_dict['database_release']
-input_dir = set_up_dict['input_dir']
-output_filename = set_up_dict['output_filename']
+SERVER = set_up_dict['server']
+DATABASE = set_up_dict['database']
+USERNAME = set_up_dict['username']
+PASSWORD = set_up_dict['password']
+DATABASE_RELEASE = set_up_dict['database_release']
+OUTPUT_FILENAME = set_up_dict['output_filename']
+TESTING = set_up_dict['testing']
 log = set_up_dict['log']
-testing = set_up_dict['testing']
 
 # Process additional input parameters not handled by the set_up_db_reading() function above.
 parser = argparse.ArgumentParser(description='inputs')
@@ -47,7 +70,7 @@ args, extra_args = parser.parse_known_args()
 log.info('Parsing args specific to this script; ignoring these: {}'.format(extra_args))
 
 # Create SQL Alchemy engines from environmental variables.
-engine_var_rep = 'postgresql://' + username + ":" + password + '@' + server + '/' + database
+engine_var_rep = 'postgresql://' + USERNAME + ":" + PASSWORD + '@' + SERVER + '/' + DATABASE
 engine = create_engine(engine_var_rep)
 # insp = inspect(engine)    # I always have this line, but I do not know what it does.
 Session = sessionmaker(bind=engine)
@@ -59,15 +82,18 @@ def main():
     """Run the steps for exporting feature_expression data to a TSV file."""
     log.info(f'Running script "{__file__}"')
     log.info('Started main function.')
-    log.info(f'Exporting data from FlyBase release: {database_release}')
+    log.info(f'Exporting data from FlyBase release: {DATABASE_RELEASE}')
 
     # Get the data and process it.
-    expression_handler = ExpressionHandler(log, testing)
+    expression_handler = ExpressionHandler(log, TESTING)
     expression_handler.get_general_data(session)
     expression_handler.get_datatype_data(session)
     expression_handler.synthesize_info(session)
 
     # Export the data.
+    data_to_export_as_tsv = generic_FB_tsv_dict(REPORT_TITLE, DATABASE)
+    data_to_export_as_tsv['data'] = expression_handler.export_data_for_tsv
+    tsv_report_dump(data_to_export_as_tsv, OUTPUT_FILENAME, headers=HEADER_LIST)
     log.info('Ended main function.\n')
 
 

--- a/src/report_expression.py
+++ b/src/report_expression.py
@@ -34,7 +34,7 @@ HEADER_LIST = [
     'feature_symbol',
     'reference_id',
     'expression_type',
-    'expression_id',    # BOB: Internal expression.expression_id, only for debugging.
+    # 'expression_id',    # Internal debugging only.
     'assay_term',
     'stage_start',
     'stage_end',

--- a/src/report_expression.py
+++ b/src/report_expression.py
@@ -30,10 +30,10 @@ from harvdev_utils.general_functions import (
 REPORT_LABEL = 'curated_expression'
 REPORT_TITLE = 'FlyBase Expression Report'
 HEADER_LIST = [
-    # 'feature_id',
-    # 'feature_symbol',
-    # 'reference_id',
-    # 'expression_type',
+    'feature_id',
+    'feature_symbol',
+    'reference_id',
+    'expression_type',
     'expression_id',    # Only for debugging.
     'assay_term',
     'stage_start',
@@ -48,7 +48,7 @@ HEADER_LIST = [
     'anatomical_substructure_slim_terms',
     'cellular_component_term',
     'cellular_component_qualifiers',
-    # 'notes',
+    'notes',
 ]
 
 # Now proceed with generic setup.


### PR DESCRIPTION
1. New objects representing aspects of FlyBase chado expression data in `fb_datatypes.py`.
2. A new `expression_handler.py` gets FlyBase expression data out of chado and reorganizes it into something approximating the current (though perhaps not final) Alliance LinkML expression model.
3.  A new `report_expression.py` script that reports FlyBase expression in a format that approximates the Alliance FMS and LinkML models.
4. Changes to the parental `handler.py` in support of the changes above.

The script runs in under 4 minutes and the output looks good, even for various edge cases.