### PR TITLE
FTA-87: Report allele-construct associations (FBti-producedby-FBtp)

### DIFF
--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -113,19 +113,26 @@ def main():
 
     if not reference_session:
         # Export the gene-allele associations to a separate file.
-        association_output_filename = output_filename.replace('allele', 'allele_gene_association')
+        association_output_filename = output_filename.replace('allele', 'allele_association')
         association_export_dict = {
             'linkml_version': linkml_release,
             'alliance_member_release_version': database_release,
         }
+        # Allele-gene associations.
         association_export_dict['allele_gene_association_ingest_set'] = []
         association_export_dict['allele_gene_association_ingest_set'].extend(allele_handler.export_data['allele_gene_association_ingest_set'])
         association_export_dict['allele_gene_association_ingest_set'].extend(aberration_handler.export_data['allele_gene_association_ingest_set'])
         if len(association_export_dict['allele_gene_association_ingest_set']) == 0:
             log.error('The "allele_gene_association_ingest_set" is unexpectedly empty.')
             raise ValueError('The "allele_gene_association_ingest_set" is unexpectedly empty.')
-        else:
-            generate_export_file(association_export_dict, log, association_output_filename)
+        # Allele-construct associations.
+        association_export_dict['allele_construct_association_ingest_set'] = []
+        association_export_dict['allele_construct_association_ingest_set'].extend(allele_handler.export_data['allele_construct_association_ingest_set'])
+        if len(association_export_dict['allele_construct_association_ingest_set']) == 0:
+            log.error('The "allele_construct_association_ingest_set" is unexpectedly empty.')
+            raise ValueError('The "allele_construct_association_ingest_set" is unexpectedly empty.')
+        # Print the output file.
+        generate_export_file(association_export_dict, log, association_output_filename)
 
     log.info('Ended main function.\n')
 

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -211,6 +211,26 @@ class AlleleGenomicEntityAssociationDTO(EvidenceAssociationDTO):
         self.required_fields.extend(['allele_identifier', 'relation_name'])
 
 
+class AlleleConstructAssociationDTO(AlleleGenomicEntityAssociationDTO):
+    """AlleleConstructAssociationDTO class."""
+    def __init__(self, allele_id: str, rel_type: str, construct_id: str, evidence_curies: list):
+        """Create AlleleConstructAssociationDTO for FlyBase object.
+
+        Args:
+            allele_id (str): The FB:FBal curie for the allele subject.
+            rel_type (str): A CV term: TBD.
+            construct_id (str): The FB:FBtp curie for the construct object.
+            evidence_curies (list): A list of FB:FBrf or PMID:### curies.
+
+        """
+        super().__init__(evidence_curies)
+        self.allele_identifier = allele_id
+        self.relation_name = rel_type
+        self.construct_identifier = construct_id
+        self.evidence_curies = evidence_curies
+        self.required_fields.extend(['construct_identifier'])
+
+
 class AlleleGeneAssociationDTO(AlleleGenomicEntityAssociationDTO):
     """AlleleGeneAssociationDTO class."""
     def __init__(self, allele_id: str, rel_type: str, gene_id: str, evidence_curies: list):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -637,16 +637,18 @@ class AlleleHandler(MetaAlleleHandler):
         for allele in self.fb_data_entities.values():
             if not allele.uniquename.startswith('FBti'):
                 continue
-            for rel_type, rel_list in allele.sbj_rel_ids_by_type.items():
+            for rel_type, rel_id_list in allele.sbj_rel_ids_by_type.items():
                 if rel_type != 'producedby':
                     continue
-                self.log.debug(f'BOB: {allele} has {len(rel_list)} sbj rels of type {rel_type}')
-                for rel_id in rel_list:
+                self.log.debug(f'BOB: {allele} has {len(rel_id_list)} sbj rels of type {rel_type}')
+                for rel_id in rel_id_list:
                     rel = allele.rels_by_id[rel_id]
                     object_id = rel.chado_obj.object_id
                     object = self.feature_lookup[object_id]
                     obj_type = object['type']
                     self.log.debug(f"BILLY: {allele} is producedby {object['name']} ({object['uniquename']}) of type {obj_type}")
+            for obj_type, rel_id_list in allele.sbj_rel_ids_by_obj_type.items():
+                self.log.debug(f'DAVE: {allele} has {len(rel_id_list)} associations to objects of type {obj_type}')
             relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby',
                                                              rel_entity_types=self.feature_subtypes['construct'])
             if relevant_cons_rels:

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -633,30 +633,14 @@ class AlleleHandler(MetaAlleleHandler):
         self.log.info('Synthesize allele-to-construct associations.')
         construct_counter = 0
         allele_counter = 0
-        # For now, we want only FBti-producedby-FBtp, but we can expand this (put in list of chado rel type names in "rel_types" kwarg).
+        # For now, we want only FBti-producedby-FBtp, but we can expand this (put a list of chado rel type names in "rel_types" kwarg).
         for allele in self.fb_data_entities.values():
             if not allele.uniquename.startswith('FBti'):
                 continue
-            # for rel_type, rel_id_list in allele.sbj_rel_ids_by_type.items():
-            #     if rel_type != 'producedby':
-            #         continue
-            #     self.log.debug(f'BOB: {allele} has {len(rel_id_list)} sbj rels of type {rel_type}')
-            #     for rel_id in rel_id_list:
-            #         rel = allele.rels_by_id[rel_id]
-            #         object_id = rel.chado_obj.object_id
-            #         object = self.feature_lookup[object_id]
-            #         obj_type = object['type']
-            #         self.log.debug(f"BILLY: {allele} is producedby {object['name']} ({object['uniquename']}) of type {obj_type}")
-            # if not allele.sbj_rel_ids_by_obj_type:
-            #     self.log.debug(f'DAVE1: {allele} has no rels indexed by obj type?')
-            # else:
-            #     for obj_type, rel_id_list in allele.sbj_rel_ids_by_obj_type.items():
-            #         self.log.debug(f'DAVE2: {allele} has {len(rel_id_list)} associations to objects of type {obj_type}')
             relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby',
                                                              rel_entity_types=self.feature_subtypes['construct'])
             if relevant_cons_rels:
                 allele_counter += 1
-                self.log.debug(f'GIL: For {allele}, found {len(relevant_cons_rels)} allele rels to review.')
             for cons_rel in relevant_cons_rels:
                 cons_feature_id = cons_rel.chado_obj.object_id
                 rel_type_name = cons_rel.chado_obj.type.name

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -631,14 +631,14 @@ class AlleleHandler(MetaAlleleHandler):
     def synthesize_allele_construct_associations(self):
         """Synthesize allele-to-construct associations."""
         self.log.info('Synthesize allele-to-construct associations.')
-        input_counter = 0
         construct_counter = 0
         allele_counter = 0
         # For now, we want only FBti-producedby-FBtp, but we can expand this (put in list of chado rel type names in "rel_types" kwarg).
         for allele in self.fb_data_entities.values():
             if not allele.uniquename.startswith('FBti'):
                 continue
-            input_counter += 1
+            for rel_type, rel_list in allele.sbj_rel_ids_by_type.items():
+                self.log.debug(f'BOB: {allele} has {len(rel_list)} sbj rels of type {rel_type}')
             relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby',
                                                              rel_entity_types=self.feature_subtypes['construct'])
             if relevant_cons_rels:
@@ -653,7 +653,6 @@ class AlleleHandler(MetaAlleleHandler):
                 except KeyError:
                     self.allele_construct_rels[allele_cons_key] = [cons_rel]
                     construct_counter += 1
-        self.log.info(f'BOB: Assessed {input_counter} FBti alleles.')
         self.log.info(f'Found {construct_counter} constructs for {allele_counter} alleles.')
         return
 

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -637,21 +637,21 @@ class AlleleHandler(MetaAlleleHandler):
         for allele in self.fb_data_entities.values():
             if not allele.uniquename.startswith('FBti'):
                 continue
-            for rel_type, rel_id_list in allele.sbj_rel_ids_by_type.items():
-                if rel_type != 'producedby':
-                    continue
-                self.log.debug(f'BOB: {allele} has {len(rel_id_list)} sbj rels of type {rel_type}')
-                for rel_id in rel_id_list:
-                    rel = allele.rels_by_id[rel_id]
-                    object_id = rel.chado_obj.object_id
-                    object = self.feature_lookup[object_id]
-                    obj_type = object['type']
-                    self.log.debug(f"BILLY: {allele} is producedby {object['name']} ({object['uniquename']}) of type {obj_type}")
-            if not allele.sbj_rel_ids_by_obj_type:
-                self.log.debug(f'DAVE1: {allele} has no rels indexed by obj type?') 
-            else:
-                for obj_type, rel_id_list in allele.sbj_rel_ids_by_obj_type.items():
-                    self.log.debug(f'DAVE2: {allele} has {len(rel_id_list)} associations to objects of type {obj_type}')
+            # for rel_type, rel_id_list in allele.sbj_rel_ids_by_type.items():
+            #     if rel_type != 'producedby':
+            #         continue
+            #     self.log.debug(f'BOB: {allele} has {len(rel_id_list)} sbj rels of type {rel_type}')
+            #     for rel_id in rel_id_list:
+            #         rel = allele.rels_by_id[rel_id]
+            #         object_id = rel.chado_obj.object_id
+            #         object = self.feature_lookup[object_id]
+            #         obj_type = object['type']
+            #         self.log.debug(f"BILLY: {allele} is producedby {object['name']} ({object['uniquename']}) of type {obj_type}")
+            # if not allele.sbj_rel_ids_by_obj_type:
+            #     self.log.debug(f'DAVE1: {allele} has no rels indexed by obj type?')
+            # else:
+            #     for obj_type, rel_id_list in allele.sbj_rel_ids_by_obj_type.items():
+            #         self.log.debug(f'DAVE2: {allele} has {len(rel_id_list)} associations to objects of type {obj_type}')
             relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby',
                                                              rel_entity_types=self.feature_subtypes['construct'])
             if relevant_cons_rels:
@@ -1017,8 +1017,13 @@ class InsertionHandler(MetaAlleleHandler):
 
     # Elaborate on get_general_data() for the InsertionHandler.
     def get_general_data(self, session):
-        """Suppress the method for the InsertionHandler."""
-        self.log.info('DO NOT GET FLYBASE INSERTION DATA FROM CHADO via InsertionHandler; use AlleleHandler.')
+        """Extend the method for the InsertionHandler."""
+        super().get_general_data(session)
+        self.build_bibliography(session)
+        self.build_cvterm_lookup(session)
+        self.build_organism_lookup(session)
+        self.build_feature_lookup(session, feature_types=['construct', 'gene', 'insertion', 'variation', 'transposon'])
+        self.get_internal_genes(session)
         return
 
     # Elaborate on get_datatype_data() for the InsertionHandler.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -653,7 +653,7 @@ class AlleleHandler(MetaAlleleHandler):
                                                              rel_entity_types=self.feature_subtypes['construct'])
             if relevant_cons_rels:
                 allele_counter += 1
-                # self.log.debug(f'For {allele}, found {len(relevant_cons_rels)} allele rels to review.')
+                self.log.debug(f'GIL: For {allele}, found {len(relevant_cons_rels)} allele rels to review.')
             for cons_rel in relevant_cons_rels:
                 cons_feature_id = cons_rel.chado_obj.object_id
                 rel_type_name = cons_rel.chado_obj.type.name

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -638,7 +638,14 @@ class AlleleHandler(MetaAlleleHandler):
             if not allele.uniquename.startswith('FBti'):
                 continue
             for rel_type, rel_list in allele.sbj_rel_ids_by_type.items():
+                if rel_type != 'producedby':
+                    continue
                 self.log.debug(f'BOB: {allele} has {len(rel_list)} sbj rels of type {rel_type}')
+                for rel in rel_list:
+                    object_id = rel.chado_obj.object_id
+                    object = self.feature_lookup[object_id]
+                    obj_type = object['type']
+                    self.log.debug(f'BILLY: {allele} is producedby {object['name']} ({object['uniquename']}) of type {obj_type}')
             relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby',
                                                              rel_entity_types=self.feature_subtypes['construct'])
             if relevant_cons_rels:

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -639,7 +639,8 @@ class AlleleHandler(MetaAlleleHandler):
             if not allele.uniquename.startswith('FBti'):
                 continue
             input_counter += 1
-            relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby', rel_entity_types='construct')
+            relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby',
+                                                             rel_entity_types=self.feature_subtypes['construct'])
             if relevant_cons_rels:
                 allele_counter += 1
                 # self.log.debug(f'For {allele}, found {len(relevant_cons_rels)} allele rels to review.')

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -641,7 +641,8 @@ class AlleleHandler(MetaAlleleHandler):
                 if rel_type != 'producedby':
                     continue
                 self.log.debug(f'BOB: {allele} has {len(rel_list)} sbj rels of type {rel_type}')
-                for rel in rel_list:
+                for rel_id in rel_list:
+                    rel = allele.rels_by_id[rel_id]
                     object_id = rel.chado_obj.object_id
                     object = self.feature_lookup[object_id]
                     obj_type = object['type']

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -647,8 +647,11 @@ class AlleleHandler(MetaAlleleHandler):
                     object = self.feature_lookup[object_id]
                     obj_type = object['type']
                     self.log.debug(f"BILLY: {allele} is producedby {object['name']} ({object['uniquename']}) of type {obj_type}")
-            for obj_type, rel_id_list in allele.sbj_rel_ids_by_obj_type.items():
-                self.log.debug(f'DAVE: {allele} has {len(rel_id_list)} associations to objects of type {obj_type}')
+            if not allele.sbj_rel_ids_by_obj_type:
+                self.log.debug(f'DAVE1: {allele} has no rels indexed by obj type?') 
+            else:
+                for obj_type, rel_id_list in allele.sbj_rel_ids_by_obj_type.items():
+                    self.log.debug(f'DAVE2: {allele} has {len(rel_id_list)} associations to objects of type {obj_type}')
             relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby',
                                                              rel_entity_types=self.feature_subtypes['construct'])
             if relevant_cons_rels:

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -645,7 +645,7 @@ class AlleleHandler(MetaAlleleHandler):
                     object_id = rel.chado_obj.object_id
                     object = self.feature_lookup[object_id]
                     obj_type = object['type']
-                    self.log.debug(f'BILLY: {allele} is producedby {object['name']} ({object['uniquename']}) of type {obj_type}')
+                    self.log.debug(f"BILLY: {allele} is producedby {object['name']} ({object['uniquename']}) of type {obj_type}")
             relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby',
                                                              rel_entity_types=self.feature_subtypes['construct'])
             if relevant_cons_rels:

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -631,12 +631,14 @@ class AlleleHandler(MetaAlleleHandler):
     def synthesize_allele_construct_associations(self):
         """Synthesize allele-to-construct associations."""
         self.log.info('Synthesize allele-to-construct associations.')
+        input_counter = 0
         construct_counter = 0
         allele_counter = 0
         # For now, we want only FBti-producedby-FBtp, but we can expand this (put in list of chado rel type names in "rel_types" kwarg).
         for allele in self.fb_data_entities.values():
             if not allele.uniquename.startswith('FBti'):
                 continue
+            input_counter += 1
             relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='producedby', rel_entity_types='construct')
             if relevant_cons_rels:
                 allele_counter += 1
@@ -650,6 +652,7 @@ class AlleleHandler(MetaAlleleHandler):
                 except KeyError:
                     self.allele_construct_rels[allele_cons_key] = [cons_rel]
                     construct_counter += 1
+        self.log.info(f'BOB: Assessed {input_counter} FBti alleles.')
         self.log.info(f'Found {construct_counter} constructs for {allele_counter} alleles.')
         return
 


### PR DESCRIPTION
This includes a bug fix for the `InsertionHandler` object, as the `get_general_data()` method must create a feature_lookup in order to properly index feature_relationships.