### PR TITLE
FTA-81: Submit aminoacid_rep/molecular_info/nucleotide_sub allele props as mutation_description NoteDTOs.

### DIFF
--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -169,7 +169,7 @@ class AlleleHandler(MetaAlleleHandler):
     # The value is a tuple representing the Alliance note type, and where to append the note: (Alliance note type name, Alliance slot name).
     # NB - This mapping is not for cases where FlyBase props need to be merged, split, or handled in ways that depend on the text of the prop.
     # NB - the code assumes that the Alliance slot for these notes is multivalued (props in FlyBase are almost always multivalued).
-    aberration_prop_to_note_mapping = {
+    allele_prop_to_note_mapping = {
         'aminoacid_rep': ('mutation_description', 'note_dtos'),
         'molecular_info': ('mutation_description', 'note_dtos'),
         'nucleotide_sub': ('mutation_description', 'note_dtos'),

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -135,6 +135,8 @@ class AlleleHandler(MetaAlleleHandler):
         self.fbti_entities = {}                # Will be feature_id-keyed FBAllele objects generated from FBti insertions.
 
     test_set = {
+        'FBal0386858': 'SppL[CR70402-TG4.1]',   # Insertion allele superceded by FBti0226866 (superseded_by_at_locus_insertion).
+        'FBal0386745': 'Scer_GAL4[SppL...]',    # Insertion allele superceded by FBti0226866 too (superseded_by_at_locus_insertion).
         'FBal0137236': 'gukh[142]',             # Insertion allele superceded by FBti0000040 (superseded_by_at_locus_insertion).
         'FBal0137618': 'Xrp1[142]',             # Insertion allele superceded by FBti0000040 too (superseded_by_at_locus_insertion).
         'FBal0036007': 'wg[en11]',              # Insertion allele superceded by FBti0002065 (superseded_by_at_locus_insertion).
@@ -981,6 +983,7 @@ class InsertionHandler(MetaAlleleHandler):
     # Types: 228747 transposable_element_insertion_site; 7726 insertion_site; 5753 transposable element; 3573 match (internal).
     # Relationships: 234754 FBti(producedby)FBtp; 64920 FBal(associated_with)FBti.
     test_set = {
+        'FBti0226866': 'TI{CRIMIC.TG4.1}SppL[]',    # Supercedes FBal0386858, FBal0386745 (superseded_by_at_locus_insertion).
         'FBti0012506': 'P{hs-yCDC42.V12}AM1',       # Supercedes FBal0062057 (superseded_by_transgnc_insertions).
         'FBti0249909': 'P{hs-yCDC42.V12}unsp',      # Supercedes FBal0062057 (superseded_by_transgnc_insertions).
         'FBti0099413': 'P{GD9857}v25458',           # Supercedes FBal0198528 (superseded_by_transgnc_insertions).

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1356,7 +1356,8 @@ class AberrationHandler(MetaAlleleHandler):
         self.map_internal_metaallele_status()
         self.map_aberration_mutation_types()
         self.map_aberration_gene_associations()
-        self.map_aberration_props_to_notes()
+        # self.map_aberration_props_to_notes()    # BOB - suppress while testing more generic approach
+        self.map_entity_props_to_notes('aberration_prop_to_note_mapping')
         self.map_synonyms()
         self.map_data_provider_dto()
         self.map_xrefs()

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1202,3 +1202,27 @@ class PrimaryEntityHandler(DataHandler):
                 note_dto.internal = True
             note_dtos.append(note_dto.dict_export())
         return note_dtos
+
+    def map_entity_props_to_notes(self, mapping_dict_name):
+        """Map entity props to Alliance notes."""
+        self.log.info(f'Map "{self.datatype}" props to Alliance notes.')
+        NOTE_TYPE_NAME = 0
+        NOTE_SLOT_NAME = 1
+        mapping_dict = getattr(self, mapping_dict_name)
+        for fb_prop_type, note_specs in mapping_dict.items():
+            entity_counter = 0
+            prop_counter = 0
+            agr_note_type_name = note_specs[NOTE_TYPE_NAME]
+            agr_slot_name = note_specs[NOTE_SLOT_NAME]
+            self.log.info(f'Map "{fb_prop_type}" "{self.datatype}" props to Alliance "{agr_note_type_name}" notes.')
+            for entity in self.fb_data_entities.values():
+                if entity.linkmldto is None:
+                    continue
+                agr_notes = self.convert_prop_to_note(entity, fb_prop_type, agr_note_type_name)
+                agr_note_slot = getattr(entity.linkmldto, agr_slot_name)
+                agr_note_slot.extend(agr_notes)
+                if agr_notes:
+                    entity_counter += 1
+                prop_counter += len(agr_notes)
+            self.log.info(f'For "{fb_prop_type}", mapped {prop_counter} props for {entity_counter} {self.datatype}s.')
+        return

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1198,16 +1198,13 @@ class PrimaryEntityHandler(DataHandler):
         prop_list = fb_entity.props_by_type[fb_prop_type]
         for fb_prop in prop_list:
             free_text = clean_free_text(fb_prop.chado_obj.value)
-            self.log.debug(f'BOB1: Have these pub_ids: {fb_prop.pubs}')
             try:
                 text_keyed_props[free_text].extend(fb_prop.pubs)
             except KeyError:
                 text_keyed_props[free_text] = fb_prop.pubs
         for free_text, fb_prop_pub_ids in text_keyed_props.items():
             uniq_fb_prop_pub_ids = list(set(fb_prop_pub_ids))
-            self.log.debug(f'BOB2: Have these pub_ids: {uniq_fb_prop_pub_ids}')
             pub_curies = self.lookup_pub_curies(uniq_fb_prop_pub_ids)
-            self.log.debug(f'BOB3: Have these pub_curies: {pub_curies}')
             note_dto = agr_datatypes.NoteDTO(agr_note_type, free_text, pub_curies)
             if fb_prop_type in internal_note_types:
                 note_dto.internal = True

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1198,15 +1198,16 @@ class PrimaryEntityHandler(DataHandler):
         prop_list = fb_entity.props_by_type[fb_prop_type]
         for fb_prop in prop_list:
             free_text = clean_free_text(fb_prop.chado_obj.value)
+            self.log.debug(f'BOB1: Have these pub_ids: {uniq_fb_prop_pub_ids}')
             try:
                 text_keyed_props[free_text].extend(fb_prop.pubs)
             except KeyError:
                 text_keyed_props[free_text] = fb_prop.pubs
         for free_text, fb_prop_pub_ids in text_keyed_props.items():
             uniq_fb_prop_pub_ids = list(set(fb_prop_pub_ids))
-            self.log.debug(f'BOB: Have these pub_ids: {uniq_fb_prop_pub_ids}')
+            self.log.debug(f'BOB2: Have these pub_ids: {uniq_fb_prop_pub_ids}')
             pub_curies = self.lookup_pub_curies(uniq_fb_prop_pub_ids)
-            self.log.debug(f'BOB: Have these pub_curies: {pub_curies}')
+            self.log.debug(f'BOB3: Have these pub_curies: {pub_curies}')
             note_dto = agr_datatypes.NoteDTO(agr_note_type, free_text, pub_curies)
             if fb_prop_type in internal_note_types:
                 note_dto.internal = True

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -656,7 +656,7 @@ class PrimaryEntityHandler(DataHandler):
                 distinct()
         prop_pub_counter = 0
         for prop_pub_result in prop_pub_results:
-            prop_id = getattr(prop_result, f'{chado_type}prop_id')
+            prop_id = getattr(prop_pub_result, f'{chado_type}prop_id')
             try:
                 prop_dict[prop_id].pubs.append(prop_pub_result.pub_id)
                 prop_pub_counter += 1

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1204,13 +1204,13 @@ class PrimaryEntityHandler(DataHandler):
                 text_keyed_props[free_text] = fb_prop.pubs
         for free_text, fb_prop_pub_ids in text_keyed_props.items():
             uniq_fb_prop_pub_ids = list(set(fb_prop_pub_ids))
+            self.log.debug(f'BOB: Have these pub_ids: {uniq_fb_prop_pub_ids}')
             pub_curies = self.lookup_pub_curies(uniq_fb_prop_pub_ids)
             self.log.debug(f'BOB: Have these pub_curies: {pub_curies}')
             note_dto = agr_datatypes.NoteDTO(agr_note_type, free_text, pub_curies)
             if fb_prop_type in internal_note_types:
                 note_dto.internal = True
             note_dtos.append(note_dto.dict_export())
-            self.log.debug(f'BOB: Have this note_dto_exported: {note_dto.dict_export()}')
         return note_dtos
 
     def map_entity_props_to_notes(self, mapping_dict_name):

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1198,7 +1198,7 @@ class PrimaryEntityHandler(DataHandler):
         prop_list = fb_entity.props_by_type[fb_prop_type]
         for fb_prop in prop_list:
             free_text = clean_free_text(fb_prop.chado_obj.value)
-            self.log.debug(f'BOB1: Have these pub_ids: {uniq_fb_prop_pub_ids}')
+            self.log.debug(f'BOB1: Have these pub_ids: {fb_prop.pubs}')
             try:
                 text_keyed_props[free_text].extend(fb_prop.pubs)
             except KeyError:

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1205,10 +1205,12 @@ class PrimaryEntityHandler(DataHandler):
         for free_text, fb_prop_pub_ids in text_keyed_props.items():
             uniq_fb_prop_pub_ids = list(set(fb_prop_pub_ids))
             pub_curies = self.lookup_pub_curies(uniq_fb_prop_pub_ids)
+            self.log.debug(f'BOB: Have these pub_curies: {pub_curies}')
             note_dto = agr_datatypes.NoteDTO(agr_note_type, free_text, pub_curies)
             if fb_prop_type in internal_note_types:
                 note_dto.internal = True
             note_dtos.append(note_dto.dict_export())
+            self.log.debug(f'BOB: Have this note_dto_exported: {note_dto.dict_export()}')
         return note_dtos
 
     def map_entity_props_to_notes(self, mapping_dict_name):

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1175,7 +1175,6 @@ class PrimaryEntityHandler(DataHandler):
         Returns:
             Returns a list of NoteDTO.dict_export() dict entities.
 
-
         Notes:
             If the fb_prop_type given is recognized as an "internal" type of FlyBase prop, the output NoteDTO is set to internal.
 

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -485,7 +485,8 @@ class FBRelationship(FBExportEntity):
         self.chado_obj = chado_obj
         self.db_primary_id = getattr(chado_obj, f'{table_name}_id')
         self.entity_desc = f'{table_name}_id={self.db_primary_id}'
-        self.pubs = []    # Will be list of Pub.pub_ids supporting the relationship.
+        self.pubs = []             # Will be list of Pub.pub_ids supporting the relationship.
+        self.props_by_type = {}    # Lists of FBProp objects keyed by prop type name.
 
 
 class FBCVTermAnnotation(FBExportEntity):
@@ -503,6 +504,7 @@ class FBCVTermAnnotation(FBExportEntity):
         self.db_primary_id = getattr(chado_obj, f'{table_name}_id')
         self.entity_desc = f'{table_name}_id={self.db_primary_id}'
         self.pub_id = self.chado_obj.pub_id
+        self.props_by_type = {}    # Lists of FBProp objects keyed by prop type name.
 
 
 class FBExpressionCvterm(object):

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -485,7 +485,6 @@ class FBRelationship(FBExportEntity):
         self.chado_obj = chado_obj
         self.db_primary_id = getattr(chado_obj, f'{table_name}_id')
         self.entity_desc = f'{table_name}_id={self.db_primary_id}'
-        self.props_by_type = {}    # Lists of FBProp objects keyed by prop type name.
         self.pubs = []    # Will be list of Pub.pub_ids supporting the relationship.
 
 
@@ -503,7 +502,6 @@ class FBCVTermAnnotation(FBExportEntity):
         self.chado_obj = chado_obj
         self.db_primary_id = getattr(chado_obj, f'{table_name}_id')
         self.entity_desc = f'{table_name}_id={self.db_primary_id}'
-        self.props_by_type = {}    # Lists of FBProp objects keyed by prop type name.
         self.pub_id = self.chado_obj.pub_id
 
 


### PR DESCRIPTION
1. These prop types are reported for all directly-related alleles (whether they are obsolete or current at the Alliance, for posterity). These prop types are also propagated to related at-locus FBti insertions (no propagation to transgenic "unspecified" insertions). See the `AlleleHandler.add_fbal_to_fbti()` method for the logic of what gets propagated from FBal allele entities to the superseding FBti insertion entities (this may require tuning in the future). 
2. There is now a step in the `EntityHandler.convert_prop_to_note` method that prevents the submission of redundant statements of a given FB prop type (which happens when many alleles have their props propagated to an FBti insertion).
3. The code has been made even more generic so that given some type of fb_prop_name-alliance_note_type_name key, any type of entity can have its props exported as NoteDTOs using the `EntityHandler.map_entity_props_to_notes()` method. The FTA-82 `AberrationHandler.map_aberration_props_to_notes()` method has been deleted and replaced by this new generic method.
4. CRUCIAL - line 659 in `entity_handler.py` fixes a bug that was preventing the export of pub IDs for props. The bug was detected by *Claude*.