### PR TITLE
feat(FTA-136): create anonymous Constructs + Cassettes for generic TI…

### DIFF
--- a/docs/FTA-179/plan.md
+++ b/docs/FTA-179/plan.md
@@ -1,0 +1,148 @@
+# FTA-179 — Submit generic-TI FBtps as obsolete constructs
+
+## Context
+
+Sub-task of FTA-136. Each "generic TI" FBtp identified by FTA-178 should still be
+submitted to the Alliance as a `ConstructDTO`, but flagged `obsolete=True` AND
+`internal=True`. This keeps them visible to curators while preventing them from
+leaking onto the Alliance website — the real user-facing constructs for each
+generic-TI insertion are the anonymous `<FBti>_con` constructs from FTA-180.
+
+Ticket text explicitly says "no special code" for the payload — the normal
+construct mapping (symbols, synonyms, data provider, pubs, timestamps) should
+still run; only `obsolete` and `internal` need to be forced true.
+
+## Current state
+
+**The core requirement is already implemented** on this branch, via the existing
+generic-TI plumbing:
+
+1. `construct_handler.py:1020` in `map_construct_basic()`:
+   ```python
+   agr_construct.obsolete = construct.chado_obj.is_obsolete or construct.is_generic_ti
+   ```
+   → forces `obsolete=True` on the `ConstructDTO` for every generic-TI FBtp.
+
+2. `handler.py:1009-1035` `flag_internal_fb_entities()` runs after mapping
+   (invoked at `construct_handler.py:1272` and `1278`):
+   ```python
+   if fb_data_entity.linkmldto.obsolete is True:
+       fb_data_entity.linkmldto.internal = True
+       fb_data_entity.internal_reasons.append('Obsolete')
+   ```
+   → auto-sets `internal=True` for any obsolete construct.
+
+Result: generic-TI FBtps are exported with their normal synonyms, data provider,
+pubs, and timestamps — but with `obsolete=True, internal=True`. That matches the
+ticket's "follow what normally happens for obsolete things" note.
+
+## Small consistency gap to close
+
+The downstream construct-scoped association DTOs check
+`construct.is_obsolete` (the raw chado `feature.is_obsolete` — False for a
+generic-TI FBtp whose underlying chado row is non-obsolete) rather than the
+effective-obsolete status. Affected call sites:
+
+| File:line | DTO | Current check |
+|---|---|---|
+| `construct_handler.py:1045` | `ConstructComponentSlotAnnotationDTO` | `self.feature_lookup[feature_id]['is_obsolete']` only |
+| `construct_handler.py:1102` | `ConstructGenomicEntityAssociationDTO` | `construct.is_obsolete or feature_lookup[...]['is_obsolete']` |
+| `construct_handler.py:1133` | `ConstructCassetteAssociationDTO` (marked_with) | same pattern |
+| `construct_handler.py:1173` | `ConstructCassetteAssociationDTO` (associated_with) | same pattern |
+| `construct_handler.py:1246` | `ConstructCassetteAssociationDTO` (FTA-183 anon marker) | uses `data['parent_is_obsolete']` set at line 913 from `construct.is_obsolete` |
+
+Because these use the chado flag directly, a generic-TI FBtp's associations are
+emitted with `obsolete=False, internal=False` even though the construct they
+reference is now hidden. Alliance would then surface associations pointing at an
+internal/obsolete construct, which is at minimum confusing.
+
+The ticket doesn't mandate flipping these, but the safe reading of "submit them
+as obsolete" is that anything downstream of the obsolete construct also gets
+flagged. Cost is small (5 one-line changes) and keeps Alliance output internally
+consistent.
+
+## Approach
+
+### 1. Add a computed helper on `FBConstruct` (or inline per callsite)
+
+Simplest: inline the same expression already used at `construct_handler.py:1020`
+— `construct.chado_obj.is_obsolete or construct.is_generic_ti` — at each
+callsite. Five one-line edits:
+
+```python
+# construct_handler.py:1045
+if (construct.chado_obj.is_obsolete or construct.is_generic_ti
+        or self.feature_lookup[feature_id]['is_obsolete']):
+    ...
+
+# construct_handler.py:1102, 1133, 1173  (same shape, same fix)
+
+# construct_handler.py:1246 (FTA-183 marker-on-anon path)
+# data['parent_is_obsolete'] already covers chado obsolete; need to also include is_generic_ti.
+```
+
+For line 1246, the simplest fix is to update line 913 in
+`get_generic_ti_anon_construct_data`:
+
+```python
+'parent_is_obsolete': construct.is_obsolete or construct.is_generic_ti,
+```
+
+That single change propagates the effective-obsolete status through `anon_data`
+without touching the downstream callsite.
+
+Note the anon `<FBti>_con` construct itself (emitted by
+`map_generic_ti_anon_constructs`) must remain non-obsolete — FTA-180 emits it as
+the *replacement* public face of the insertion. Don't touch
+`map_generic_ti_anon_constructs`.
+
+### 2. (Optional) Add `FBConstruct.is_effectively_obsolete` property
+
+Alternative to inline: add a computed property on `FBConstruct` in
+`fb_datatypes.py` that returns `self.is_obsolete or self.is_generic_ti`. Use it
+at the 5 callsites. Marginally cleaner but adds a new concept for a one-branch
+situation. Inline is fine.
+
+## Files modified
+
+- `src/construct_handler.py` — 5 one-line edits (or 4 + 1 via anon_data line 913).
+
+No changes to `cassette_handler.py`, schema, or new DTOs.
+
+## Verification
+
+1. Run the construct retrieval script on a dataset containing `FBtp0143312`
+   (the current generic-TI example):
+   ```
+   python src/AGR_data_retrieval_curation_construct.py
+   ```
+2. In the JSON output, find the `construct_ingest_set` entry for
+   `FB:FBtp0143312` and confirm:
+   ```json
+   {"primary_external_id": "FB:FBtp0143312",
+    "obsolete": true,
+    "internal": true,
+    "construct_symbol_dto": {...},   # still populated
+    "data_provider_dto": {...}}      # still populated
+   ```
+3. Find the cassette-association DTO(s) for FBtp0143312 in
+   `construct_cassette_association_ingest_set` (the marked_with → FBal0361621
+   link from FTA-139) and confirm it too has `obsolete: true, internal: true`
+   (after consistency fix).
+4. Confirm the anonymous `<FBti>_con` constructs for the same parent (e.g.
+   `FB:FBti0212460_con`) are emitted with `obsolete: false, internal: false`
+   (they are the public face).
+5. Confirm existing non-generic FBtp constructs are unchanged.
+6. Schema validation:
+   ```
+   python src/validate_agr_schema.py <output.json>
+   ```
+
+## Notes
+
+- No new chado queries.
+- No risk to the FTA-180/181/182/183 anon pipelines — those remain the public
+  surface. This only flips a flag on the already-obsolete parent.
+- This plan does NOT suppress the parent FBtp from any ingest_set, because
+  Alliance's obsolete+internal behavior already hides it from the website. The
+  ticket explicitly wants curators to still see the data.

--- a/docs/FTA-180/plan.md
+++ b/docs/FTA-180/plan.md
@@ -1,0 +1,234 @@
+# FTA-180 Part B — `AlleleConstructAssociationDTO` for anon `<FBti>_con` constructs
+
+## Context
+
+Part A of FTA-180 (create anonymous `<FBti>_con` ConstructDTOs per generic-TI
+insertion) shipped in commits `ccea8af`, `574d3bc`. Part B — emitting an
+`AlleleConstructAssociationDTO` linking each anon construct back to its FBti —
+was never implemented.
+
+Per the ticket:
+
+```
+allele_curie    = FB:<FBti>
+rel_type        = 'contains'
+construct_curie = FB:<FBti>_con
+pub_curies      = pubs on the producedby feature_relationship
+                  (FBti subject -> generic-TI FBtp object)
+```
+
+Expected shape (from `docs/FTA-180/FTA-180_anon_con_associations.tsv`, 5409 rows):
+
+```
+#allele_curie    rel_type   construct_curie       pub_curies
+FBti0167947      contains   FBti0167947_con       FBrf0225747
+...
+FBti0168382      contains   FBti0168382_con       FBrf0223447|FBrf0223769
+```
+
+Four rows have multiple producedby pubs; most have one.
+
+## Current state
+
+- `AlleleConstructAssociationDTO` class exists (`agr_datatypes.py:345-362`).
+- Ingest set `allele_construct_association_ingest_set` is already used (emitted
+  by the allele retrieval script at `AGR_data_retrieval_curation_allele.py:137-141`
+  from `allele_handlers.py:980-981`).
+- The anon-construct pipeline lives in `construct_handler.py` and is driven by the
+  cassette retrieval script (`AGR_data_retrieval_curation_cassette.py:225-235`).
+- `get_generic_ti_insertions()` (`construct_handler.py:632-675`) already
+  identifies the FBti↔FBtp producedby relationships but **doesn't collect the
+  pubs** on that rel — only `uniquename`, `feature_id`, `object_id`.
+
+## Approach
+
+Own the new DTOs inside `ConstructHandler` (adjacent to the anon pipeline),
+export them into `allele_construct_association_ingest_set` via the existing
+pipeline, and have the cassette retrieval script write a new output JSON file
+for the set. No cross-handler data handoff needed.
+
+### Files modified
+
+- `src/construct_handler.py` — new chado query for producedby pubs, new emitter
+  method, new instance list + attribute, wire into export.
+- `src/AGR_data_retrieval_curation_cassette.py` — write a new JSON file
+  containing the anon `allele_construct_association_ingest_set` entries.
+
+No change to `allele_handlers.py` (the FBal-construct associations it already
+emits are independent).
+
+### 1. Collect producedby pubs
+
+Extend `get_generic_ti_insertions()` (`construct_handler.py:632`) to also return
+`FeatureRelationship.feature_relationship_id` per row. The query shape is simple
+— add the column and pass it through to the insertion dict:
+
+```python
+session.query(
+    Feature.uniquename,
+    Feature.feature_id,
+    FeatureRelationship.object_id,
+    FeatureRelationship.feature_relationship_id,    # NEW
+)
+...
+insertions_by_construct[construct_fid].append({
+    'uniquename': ins_uname,
+    'feature_id': ins_fid,
+    'producedby_fr_id': fr_id,                      # NEW
+})
+```
+
+Add a new method `get_generic_ti_producedby_pubs(session)` that loads pubs for
+the collected `fr_id`s (drive off the FRs collected by the previous step). Store
+as `self.ti_producedby_pubs: {ti_feature_id: [pub_id, ...]}`.
+
+```python
+def get_generic_ti_producedby_pubs(self, session):
+    fr_ids = []
+    ti_by_fr = {}
+    for construct in self.fb_data_entities.values():
+        for ins in getattr(construct, 'generic_ti_insertions', []):
+            fr_ids.append(ins['producedby_fr_id'])
+            ti_by_fr[ins['producedby_fr_id']] = ins['feature_id']
+    if not fr_ids:
+        return
+    results = session.query(
+        FeatureRelationshipPub.feature_relationship_id,
+        FeatureRelationshipPub.pub_id,
+    ).filter(
+        FeatureRelationshipPub.feature_relationship_id.in_(fr_ids),
+    ).distinct()
+    for fr_id, pub_id in results:
+        ti_fid = ti_by_fr[fr_id]
+        self.ti_producedby_pubs.setdefault(ti_fid, []).append(pub_id)
+```
+
+Add `self.ti_producedby_pubs = {}` to `__init__`.
+
+### 2. Enrich `get_generic_ti_anon_construct_data`
+
+Add one field per anon_data entry:
+
+```python
+'producedby_pub_ids': list(self.ti_producedby_pubs.get(ti_fid, [])),
+```
+
+### 3. Add emitter method
+
+New instance list attribute: `self.anon_construct_allele_associations = []`.
+
+New method in construct_handler.py (after the FTA-183 marker associations
+method):
+
+```python
+def map_generic_ti_anon_construct_allele_associations(self, anon_data):
+    """Emit AlleleConstructAssociationDTOs linking each <FBti>_con to its FBti (FTA-180 Part B)."""
+    self.log.info('Map anon construct -> FBti AlleleConstructAssociationDTOs.')
+    counter = 0
+    for data in anon_data:
+        ins_uname = data['insertion_uniquename']
+        allele_curie = f'FB:{ins_uname}'
+        construct_curie = f'FB:{ins_uname}_con'
+        pub_curies = self.lookup_pub_curies(data['producedby_pub_ids'])
+        fb_rel = fb_datatypes.FBExportEntity()
+        rel_dto = agr_datatypes.AlleleConstructAssociationDTO(
+            allele_curie, 'contains', construct_curie, pub_curies)
+        # FTA-179: if parent is effectively obsolete, flag the association too.
+        if data['parent_is_obsolete']:
+            rel_dto.obsolete = True
+            rel_dto.internal = True
+        fb_rel.linkmldto = rel_dto
+        self.anon_construct_allele_associations.append(fb_rel)
+        counter += 1
+    self.log.info(f'Created {counter} anon AlleleConstructAssociationDTOs.')
+```
+
+Note: `parent_is_obsolete` already factors in `is_generic_ti` (from FTA-179
+commit `c611fa3`), so this inherits the "hidden parent → hidden association"
+rule automatically. Since the parent generic-TI FBtp is always obsolete+internal
+in our model, every new DTO will come out obsolete+internal — but the logic is
+correct regardless of future changes to `parent_is_obsolete`.
+
+### 4. Wire into `query_chado_and_export`
+
+Two additions inside the generic-TI block (after `map_generic_ti_anon_constructs`,
+adjacent to the FTA-183 marker-association call):
+
+```python
+self.get_generic_ti_producedby_pubs(session)
+...
+self.map_generic_ti_anon_construct_allele_associations(generic_ti_data)
+...
+self.flag_unexportable_entities(
+    self.anon_construct_allele_associations,
+    'allele_construct_association_ingest_set')
+self.generate_export_dict(
+    self.anon_construct_allele_associations,
+    'allele_construct_association_ingest_set')
+```
+
+Call `get_generic_ti_producedby_pubs(session)` right after
+`attach_generic_ti_insertions` (so the pubs are cached before
+`get_generic_ti_anon_construct_data` reads them).
+
+### 5. Write output file from cassette retrieval script
+
+`AGR_data_retrieval_curation_cassette.py` already builds an
+`association_export_dict` for cassette-* ingest sets (lines 260-288). Extend
+that block to also carry the anon allele-construct set and write a dedicated
+file:
+
+```python
+# FTA-180 Part B: anon construct -> FBti associations written by this script
+ingest_name = 'allele_construct_association_ingest_set'
+if cons_handler.export_data.get(ingest_name):
+    aca_export_dict = {
+        'linkml_version': linkml_release,
+        'alliance_member_release_version': database_release,
+        ingest_name: list(cons_handler.export_data[ingest_name]),
+    }
+    aca_output_filename = output_filename.replace('cassette', 'anon_allele_construct_association')
+    generate_export_file(aca_export_dict, log, aca_output_filename)
+```
+
+Guard on `get(...)` because this only runs when `ADD_CASS_TO_CONSTRUCT=YES`.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `src/construct_handler.py` | `__init__` adds `ti_producedby_pubs` + `anon_construct_allele_associations`; extend `get_generic_ti_insertions` with `feature_relationship_id`; new `get_generic_ti_producedby_pubs`; enrich `get_generic_ti_anon_construct_data` with `producedby_pub_ids`; new emitter method; export wiring in `query_chado_and_export`. |
+| `src/AGR_data_retrieval_curation_cassette.py` | After existing anon-cassette export, write `anon_allele_construct_association_*.json` with the new ingest set. |
+
+No new DTOs. No changes to `allele_handlers.py`.
+
+## Reused utilities
+
+- `AlleleConstructAssociationDTO` — `agr_datatypes.py:345`
+- `self.lookup_pub_curies(pub_ids)` — handler base
+- `FBExportEntity()` wrapper
+- `flag_unexportable_entities`, `generate_export_dict` — handler base
+- `FeatureRelationshipPub` model — already imported in construct_handler
+
+## Verification
+
+1. Run the cassette retrieval script with `ADD_CASS_TO_CONSTRUCT=YES`:
+   ```
+   ADD_CASS_TO_CONSTRUCT=YES python src/AGR_data_retrieval_curation_cassette.py ...
+   ```
+2. Confirm a new file `anon_allele_construct_association_*.json` is produced
+   with the `allele_construct_association_ingest_set` populated.
+3. Diff the extracted rows against `docs/FTA-180/FTA-180_anon_con_associations.tsv`:
+   - Same count (5409 rows for fb_2026_02_07).
+   - Same `allele_curie`, `relation_name='contains'`, `construct_curie` for
+     every row.
+   - Pub unions match (4 rows with `|`-separated FBrfs).
+4. Confirm every new DTO has `obsolete=true, internal=true` (parent is
+   effectively obsolete via FTA-179 logic).
+5. Schema validation:
+   ```
+   python src/validate_agr_schema.py <new-file.json>
+   ```
+6. Spot-check that the existing allele-side `allele_construct_association_ingest_set`
+   emitted by the allele script is unchanged (no overlap in keys — anon
+   constructs never appear in the allele side).

--- a/docs/FTA-181/plan.md
+++ b/docs/FTA-181/plan.md
@@ -1,0 +1,279 @@
+# FTA-181 — `ConstructCassetteAssociationDTO` linking anon `<FBti>_con` → anon `<FBti>_cas`
+
+## Context
+
+FTA-181 (sub-task of FTA-136, priority Highest, "Ready for work") asks for two
+things, per Gillian's writeup (ticket description edited 2026-04-17, with
+attachment `FTA-181_anon_con_anon_cas_associations.tsv`, 5409 rows):
+
+**A. Anonymous Cassette per anonymous Construct** — for each `<FBti>_con`
+Construct created by FTA-180, emit an anonymous Cassette with:
+
+- `placeholder = true`
+- `cassette_symbol_dto` symbol = `<FBti>_cas`
+- `primary_external_id = <FBti>_cas`
+- `obsolete = false`
+- timestamps "same as FTA-141"
+
+**B. `ConstructCassetteAssociationDTO`** linking the two anons:
+
+```
+relation_name   = 'has_component'
+cons_curie      = <FBti>_con
+cassette_curie  = <FBti>_cas
+pub_curies      = pubs on the `FBti producedby FBtp` feature_relationship
+                  (same set used in the FTA-180 AlleleConstructAssociationDTO
+                   for FBti contains FBti_con)
+```
+
+**Status of each part in the current code:**
+
+- **Part A is already done.** The cassette retrieval script routes generic-TI
+  anon data into the existing anon-cassette pipeline
+  (`AGR_data_retrieval_curation_cassette.py:228-233`), which calls
+  `CassetteHandler.map_anon_cassette_basic()` at `cassette_handler.py:619`.
+  That method already produces a `CassetteDTO` with
+  `primary_external_id = FB:{insertion_uniquename}_cas`, `placeholder=True`,
+  `obsolete=False`, plus `cassette_symbol_dto` and `data_provider_dto`, and
+  pushes it into `anon_cassettes` → `cassette_ingest_set`. No changes
+  required for A.
+
+- **Part B is missing.** No code currently emits
+  `ConstructCassetteAssociationDTO(FB:<FBti>_con, 'has_component', FB:<FBti>_cas, pubs)`.
+  - `map_anon_cassette_to_construct_association` (`construct_handler.py:1191`) only
+    runs for FBtp-derived anon cassettes (`construct.needs_anon_cassette`), not
+    generic-TI. Its relation_name branch is `has_functional_unit` / `has_component`
+    keyed off `tool_uses_data`, and it points at the FBtp's own curie, not the
+    `<FBti>_con` anon construct.
+  - `map_generic_ti_anon_marker_associations` (`construct_handler.py:1238`) is
+    FTA-183 (markers on the anon construct) — different DTOs,
+    `has_selectable_marker` / `has_transcriptional_unit`, no cassette.
+
+Part B is the only new work.
+
+## Recommended approach
+
+Mirror the existing `map_generic_ti_anon_marker_associations` pattern in
+`ConstructHandler`: one new emitter method, reusing
+`construct_cassette_associations` (the list that already drains into
+`construct_cassette_association_ingest_set` at `construct_handler.py:1313-1314`).
+
+Collect the `producedby` pubs inside `ConstructHandler` so the cassette
+retrieval script remains the single owner of generic-TI cassette plumbing —
+do **not** reach across to `AlleleHandler.map_generic_ti_anon_construct_associations`
+even though it already walks the same `FBti producedby FBtp` chain (different
+script, different handler instance).
+
+### Files modified
+
+| File | Change |
+|---|---|
+| `src/construct_handler.py` | Extend `get_generic_ti_insertions` to carry `feature_relationship_id`; new method `get_generic_ti_producedby_pubs(session)`; new `__init__` field `ti_producedby_pubs: {ti_fid: [pub_id, ...]}`; new emitter method `map_generic_ti_anon_con_cas_associations(anon_data)`; three wiring lines in `query_chado_and_export`. |
+
+No change to `cassette_handler.py`, `AGR_data_retrieval_curation_cassette.py`,
+`agr_datatypes.py`, or `allele_handlers.py`. `ConstructCassetteAssociationDTO`
+already exists (`agr_datatypes.py:345`).
+
+### 1. Extend `get_generic_ti_insertions` with `feature_relationship_id`
+
+At `construct_handler.py:644-687`, add one column to the query and one field to
+the dict:
+
+```python
+results = session.query(
+    Feature.uniquename,
+    Feature.feature_id,
+    FeatureRelationship.object_id,
+    FeatureRelationship.feature_relationship_id,   # NEW
+).\
+    ...
+for ins_uname, ins_fid, construct_fid, fr_id in results:
+    ...
+    insertions_by_construct[construct_fid].append({
+        'uniquename': ins_uname,
+        'feature_id': ins_fid,
+        'producedby_fr_id': fr_id,                  # NEW
+    })
+```
+
+### 2. New `__init__` attribute
+
+In `ConstructHandler.__init__` (alongside existing instance caches), add:
+
+```python
+self.ti_producedby_pubs = {}   # FTA-181: {ti_feature_id: [pub_id, ...]}
+```
+
+### 3. New method: collect pubs for the producedby FRs
+
+Add next to `attach_generic_ti_insertions` (after `construct_handler.py:697`):
+
+```python
+def get_generic_ti_producedby_pubs(self, session):
+    """Load pubs on each FBti producedby FBtp feature_relationship (FTA-181)."""
+    self.log.info('Get producedby pubs for generic TI insertions.')
+    ti_by_fr = {}
+    for construct in self.fb_data_entities.values():
+        if not construct.is_generic_ti:
+            continue
+        for insertion in getattr(construct, 'generic_ti_insertions', []):
+            ti_by_fr[insertion['producedby_fr_id']] = insertion['feature_id']
+    if not ti_by_fr:
+        return
+    results = session.query(
+        FeatureRelationshipPub.feature_relationship_id,
+        FeatureRelationshipPub.pub_id,
+    ).filter(
+        FeatureRelationshipPub.feature_relationship_id.in_(ti_by_fr.keys()),
+    ).distinct()
+    for fr_id, pub_id in results:
+        ti_fid = ti_by_fr[fr_id]
+        self.ti_producedby_pubs.setdefault(ti_fid, []).append(pub_id)
+    self.log.info(
+        f'Cached producedby pubs for {len(self.ti_producedby_pubs)} FBti.')
+```
+
+`FeatureRelationshipPub` must be added to the `harvdev_utils.reporting` import
+block at the top of `construct_handler.py`.
+
+### 4. Enrich `get_generic_ti_anon_construct_data`
+
+At `construct_handler.py:911-924`, add one field to the anon_data entry so the
+emitter does not need a second lookup:
+
+```python
+anon_data.append({
+    ...
+    'producedby_pub_ids': list(self.ti_producedby_pubs.get(ti_fid, [])),
+})
+```
+
+### 5. New emitter method
+
+Insert after `map_generic_ti_anon_marker_associations`
+(`construct_handler.py:1262`), before `map_fb_data_to_alliance`:
+
+```python
+def map_generic_ti_anon_con_cas_associations(self, anon_data):
+    """Emit ConstructCassetteAssociationDTOs linking <FBti>_con → <FBti>_cas (FTA-181)."""
+    self.log.info('Map anon construct to anon cassette associations.')
+    counter = 0
+    for data in anon_data:
+        ins_uname = data['insertion_uniquename']
+        cons_curie = f'FB:{ins_uname}_con'
+        cassette_curie = f'FB:{ins_uname}_cas'
+        pub_curies = self.lookup_pub_curies(data['producedby_pub_ids'])
+        fb_rel = fb_datatypes.FBExportEntity()
+        rel_dto = agr_datatypes.ConstructCassetteAssociationDTO(
+            cons_curie, 'has_component', cassette_curie, pub_curies)
+        # Parent FBtp is effectively obsolete for generic-TI (FTA-179).
+        if data['parent_is_obsolete']:
+            rel_dto.obsolete = True
+            rel_dto.internal = True
+        fb_rel.linkmldto = rel_dto
+        self.construct_cassette_associations.append(fb_rel)
+        counter += 1
+    self.log.info(f'Created {counter} anon con-cas ConstructCassetteAssociationDTOs.')
+```
+
+### 6. Wire into `query_chado_and_export`
+
+In the generic-TI block (`construct_handler.py:1300-1310`):
+
+```python
+# FTA-136: Create anonymous constructs for generic TI insertions.
+insertions_by_construct = self.get_generic_ti_insertions(session)
+self.attach_generic_ti_insertions(insertions_by_construct)
+self.get_generic_ti_producedby_pubs(session)           # NEW - before anon_data built
+# FTA-182: load associated-allele tool data before building anon_data.
+self.get_associated_allele_tool_data(session)
+generic_ti_data = self.get_generic_ti_anon_construct_data()
+if generic_ti_data:
+    self.map_generic_ti_anon_constructs(generic_ti_data)
+    self.map_generic_ti_anon_marker_associations(generic_ti_data)   # FTA-183
+    self.map_generic_ti_anon_con_cas_associations(generic_ti_data)  # NEW - FTA-181
+    self.export_generic_ti_anon_constructs()
+```
+
+The existing `flag_unexportable_entities` / `generate_export_dict` calls at
+`construct_handler.py:1313-1314` already drain `construct_cassette_associations`
+into `construct_cassette_association_ingest_set`, so the new DTOs ride out on
+that pipeline — no extra wiring.
+
+### 7. Obsolete/internal inheritance — decide
+
+Gillian's TSV spec does not ask for obsolete/internal flags, but the established
+pattern for every other generic-TI anon DTO (FTA-179 obsolete propagation —
+see construct `map_generic_ti_anon_constructs` not doing it, but
+`map_generic_ti_anon_marker_associations:1255-1257` does, and the FTA-180 Part B
+AlleleConstructAssociation does too) sets `obsolete=true, internal=true` when
+`parent_is_obsolete`. For a generic-TI FBtp, `parent_is_obsolete` is always true
+because `is_generic_ti` feeds into it (`construct_handler.py:919`).
+
+Decision: follow the pattern — set obsolete+internal when parent is
+effectively obsolete. The `<FBti>_con` construct and `<FBti>_cas` cassette are
+themselves `placeholder=True` so they're invisible on the web regardless; this
+just keeps the association metadata consistent with its endpoints.
+
+## Reused utilities
+
+- `ConstructCassetteAssociationDTO` — `agr_datatypes.py:345-372`
+- `self.lookup_pub_curies(pub_ids)` — handler base
+- `FBExportEntity()` wrapper — `fb_datatypes.py`
+- `FeatureRelationshipPub` model — `harvdev_utils.reporting`
+- `self.construct_cassette_associations` drain into
+  `construct_cassette_association_ingest_set` — already wired at
+  `construct_handler.py:1313-1314`
+
+## Verification
+
+1. Run the cassette retrieval script (same invocation used for FTA-136/180/182):
+   ```
+   python src/AGR_data_retrieval_curation_cassette.py ...
+   ```
+
+2. In the output `construct_cassette_association_ingest_set` file, extract the
+   subset with `relation_name == 'has_component'` where both ends start `FB:FBti`
+   and end `_con` / `_cas`, and diff vs
+   `docs/FTA-181/FTA-181_anon_con_anon_cas_associations.tsv`:
+   - Row count: **5409**.
+   - Same `(<FBti>_con, has_component, <FBti>_cas)` triples.
+   - `pub_curies` match (some rows expected to have multi-pub via `|`-list if
+     the producedby FR has multiple pubs — mirror of FTA-180 Part B which had 4
+     such rows).
+
+3. Cross-check the producedby pubs against the FTA-180 Part B file
+   `docs/FTA-180/FTA-180_anon_con_associations.tsv`: for each FBti, the
+   `pub_curies` column of the FTA-181 row must equal the `pub_curies` column of
+   the FTA-180 row. (Both ultimately come from `FBti producedby FBtp`
+   `feature_relationship_pub`.)
+
+4. Every new DTO has `obsolete=true, internal=true` (parent generic-TI is
+   effectively obsolete).
+
+5. Schema validation:
+   ```
+   python src/validate_agr_schema.py <new-file.json>
+   ```
+
+6. flake8 on the modified file:
+   ```
+   flake8 src/construct_handler.py
+   ```
+
+7. Spot-check: `FBti0167947_con has_component FBti0167947_cas FBrf0225747`
+   appears in the output (first row of Gillian's TSV).
+
+## Out of scope / noted
+
+- Timestamps ("do the same as FTA-141"): the existing
+  `map_anon_cassette_basic` doesn't set any timestamps on the anon Cassette
+  entities — `ConstructCassetteAssociationDTO` inherits from
+  `EvidenceAssociationDTO` and likewise has no timestamp slots the ticket would
+  apply to. Nothing to do unless Gillian clarifies otherwise.
+- `primary_external_id` question in the description ("is that
+  primary_external_id ??"): yes — the Cassette already uses
+  `primary_external_id = <FBti>_cas` in `map_anon_cassette_basic`, so this
+  question is resolved in the existing Part A code.
+- TSV attachment `FTA-181_anon_con_anon_cas_associations.tsv` is copied into
+  `docs/FTA-181/` so the verification diff is in-repo.

--- a/docs/FTA-182/FTA-182_output.v2.txt
+++ b/docs/FTA-182/FTA-182_output.v2.txt
@@ -1,0 +1,9857 @@
+#cassette	component type or tool_uses	tool or CV term	pub_curies	internal_note	where tool data came from
+FBti0167947_cas	tagged_with	FBto0000027	FBrf0225747		TOOL DATA from: FBal0302198
+FBti0167948_cas	carries_tool	FBto0000349	FBrf0227064|FBrf0227617		TOOL DATA from: FBal0301888
+FBti0167949_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0167949_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0167950_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0167950_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0167951_cas	carries_tool	FBto0000349	FBrf0227617		TOOL DATA from: FBal0302732
+FBti0167951_cas	carries_tool	FBto0000356	FBrf0227617		TOOL DATA from: FBal0302732
+FBti0167953_cas	carries_tool	FBto0000318	FBrf0206395		TOOL DATA from: FBal0219603
+FBti0167953_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219603
+FBti0167953_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219603
+FBti0167954_cas	carries_tool	FBto0000318	FBrf0206395		TOOL DATA from: FBal0219602
+FBti0167954_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219602
+FBti0167954_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219602
+FBti0168130_cas	tagged_with	FBto0000031	FBrf0227964		TOOL DATA from: FBal0304195
+FBti0168172_cas	encodes_tool	FBto0000159			TOOL DATA from: FBtp0099209
+FBti0168172_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099209
+FBti0168172_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304286
+FBti0168172_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304292
+FBti0168173_cas	encodes_tool	FBto0000159			TOOL DATA from: FBtp0099209
+FBti0168173_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099209
+FBti0168173_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304288
+FBti0168173_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304293
+FBti0168174_cas	encodes_tool	FBto0000159			TOOL DATA from: FBtp0099209
+FBti0168174_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099209
+FBti0168174_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304289
+FBti0168174_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304294
+FBti0168175_cas	encodes_tool	FBto0000159			TOOL DATA from: FBtp0099209
+FBti0168175_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099209
+FBti0168175_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304290
+FBti0168175_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304295
+FBti0168176_cas	encodes_tool	FBto0000159			TOOL DATA from: FBtp0099209
+FBti0168176_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099209
+FBti0168176_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304291
+FBti0168176_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0326391
+FBti0168177_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168177_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168177_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304287
+FBti0168177_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304297
+FBti0168251_cas	tagged_with	FBto0000079	FBrf0212671		TOOL DATA from: FBal0285816
+FBti0168252_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168252_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168254_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290697
+FBti0168255_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290693
+FBti0168256_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290696
+FBti0168257_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290691
+FBti0168257_cas	carries_tool	FBto0000356	FBrf0222897		TOOL DATA from: FBal0290691
+FBti0168258_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290692
+FBti0168258_cas	carries_tool	FBto0000356	FBrf0222897		TOOL DATA from: FBal0290692
+FBti0168259_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290700
+FBti0168260_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290698
+FBti0168261_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290699
+FBti0168262_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290694
+FBti0168263_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290695
+FBti0168264_cas	carries_tool	FBto0000349	FBrf0206292		TOOL DATA from: FBal0299596
+FBti0168265_cas	carries_tool	FBto0000349	FBrf0206292		TOOL DATA from: FBal0299597
+FBti0168266_cas	carries_tool	FBto0000349	FBrf0206292		TOOL DATA from: FBal0299598
+FBti0168271_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247443
+FBti0168272_cas	carries_tool	FBto0000356	FBrf0207169		TOOL DATA from: FBal0247440
+FBti0168272_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247440
+FBti0168273_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247445
+FBti0168274_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247444
+FBti0168275_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247441
+FBti0168276_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247442
+FBti0168281_cas	carries_tool	FBto0000318	FBrf0227185		TOOL DATA from: FBal0301552
+FBti0168281_cas	carries_tool	FBto0000356	FBrf0227185		TOOL DATA from: FBal0301552
+FBti0168282_cas	tagged_with	FBto0000077	FBrf0227185		TOOL DATA from: FBal0301551
+FBti0168283_cas	carries_tool	FBto0000318	FBrf0227185		TOOL DATA from: FBal0301553
+FBti0168283_cas	carries_tool	FBto0000356	FBrf0227185		TOOL DATA from: FBal0301553
+FBti0168286_cas				FTA: unable to add tool information from FBal0258331 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168288_cas	carries_tool	FBto0000349	FBrf0220990		TOOL DATA from: FBal0296113
+FBti0168289_cas				FTA: unable to add tool information from FBal0296114 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168290_cas	carries_tool	FBto0000349	FBrf0220990		TOOL DATA from: FBal0296115
+FBti0168293_cas	carries_tool	FBto0000349	FBrf0213095		TOOL DATA from: FBal0258132
+FBti0168294_cas	carries_tool	FBto0000349	FBrf0213095		TOOL DATA from: FBal0258131
+FBti0168296_cas	carries_tool	FBto0000349	FBrf0227107		TOOL DATA from: FBal0302850
+FBti0168297_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168297_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168297_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285936
+FBti0168297_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285936
+FBti0168297_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285940
+FBti0168297_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285940
+FBti0168298_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168298_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168298_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285934
+FBti0168298_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285934
+FBti0168298_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285939
+FBti0168298_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285939
+FBti0168299_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168299_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168299_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285938
+FBti0168299_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285938
+FBti0168299_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285942
+FBti0168299_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285942
+FBti0168300_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168300_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168300_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285937
+FBti0168300_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285937
+FBti0168300_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285941
+FBti0168300_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285941
+FBti0168301_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219599
+FBti0168301_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219599
+FBti0168302_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219600
+FBti0168302_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219600
+FBti0168303_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219597
+FBti0168303_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219597
+FBti0168304_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219595
+FBti0168304_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219595
+FBti0168305_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219598
+FBti0168305_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219598
+FBti0168306_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219596
+FBti0168306_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219596
+FBti0168307_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219601
+FBti0168307_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219601
+FBti0168308_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219609
+FBti0168309_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219605
+FBti0168310_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219607
+FBti0168311_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219606
+FBti0168312_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219608
+FBti0168313_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168313_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168314_cas	carries_tool	FBto0000356	FBrf0214460		TOOL DATA from: FBal0284721
+FBti0168321_cas				FTA: unable to add tool information from FBal0285379 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168324_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168324_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168325_cas	carries_tool	FBto0000349	FBrf0217785		TOOL DATA from: FBal0267901
+FBti0168325_cas	carries_tool	FBto0000356	FBrf0217785		TOOL DATA from: FBal0267901
+FBti0168326_cas	carries_tool	FBto0000349	FBrf0217785		TOOL DATA from: FBal0267900
+FBti0168326_cas	carries_tool	FBto0000356	FBrf0217785		TOOL DATA from: FBal0267900
+FBti0168329_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263893
+FBti0168329_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263893
+FBti0168330_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263889
+FBti0168330_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263889
+FBti0168331_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263894
+FBti0168331_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263894
+FBti0168332_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263891
+FBti0168332_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263891
+FBti0168333_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263887
+FBti0168333_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263887
+FBti0168334_cas	tagged_with	FBto0000077	FBrf0226803		TOOL DATA from: FBal0301091
+FBti0168335_cas	tagged_with	FBto0000077	FBrf0226803		TOOL DATA from: FBal0301090
+FBti0168336_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0168336_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0168336_cas	tagged_with	FBto0000291	FBrf0213278		TOOL DATA from: FBal0258329
+FBti0168337_cas	carries_tool	FBto0000349	FBrf0224710		TOOL DATA from: FBal0297980
+FBti0168338_cas	carries_tool	FBto0000349	FBrf0224710		TOOL DATA from: FBal0297978
+FBti0168339_cas	carries_tool	FBto0000349	FBrf0224710		TOOL DATA from: FBal0297979
+FBti0168340_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168340_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168343_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0215825
+FBti0168344_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0215824
+FBti0168345_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0215827
+FBti0168346_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0215826
+FBti0168347_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304355
+FBti0168348_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304356
+FBti0168349_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304357
+FBti0168350_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304358
+FBti0168351_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304359
+FBti0168364_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168364_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168364_cas	carries_tool	FBto0000318	FBrf0207727		TOOL DATA from: FBal0243962
+FBti0168364_cas	carries_tool	FBto0000318	FBrf0207727		TOOL DATA from: FBal0243964
+FBti0168365_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168365_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168367_cas	carries_tool	FBto0000356	FBrf0207727		TOOL DATA from: FBal0243958
+FBti0168368_cas	carries_tool	FBto0000345	FBrf0207727		TOOL DATA from: FBal0243961
+FBti0168375_cas				FTA: unable to add tool information from FBal0302628 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168378_cas	carries_tool	FBto0000318	FBrf0223447		TOOL DATA from: FBal0297878
+FBti0168378_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297878
+FBti0168378_cas	tagged_with	FBtoq0000081	FBrf0223447		TOOL DATA from: FBal0297878
+FBti0168379_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0168379_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0168379_cas	carries_tool	FBto0000320	FBrf0223447		TOOL DATA from: FBal0297877
+FBti0168379_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297877
+FBti0168379_cas	carries_tool	FBto0000356	FBrf0223447		TOOL DATA from: FBal0297877
+FBti0168379_cas	carries_tool	FBto0000320	FBrf0223447		TOOL DATA from: FBal0297880
+FBti0168379_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297880
+FBti0168379_cas	carries_tool	FBto0000356	FBrf0223447		TOOL DATA from: FBal0297880
+FBti0168379_cas	tagged_with	FBto0000205	FBrf0223447		TOOL DATA from: FBal0297880
+FBti0168380_cas	encodes_tool	FBto0000167			TOOL DATA from: FBtp0099206
+FBti0168380_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099206
+FBti0168380_cas	carries_tool	FBto0000318	FBrf0223447		TOOL DATA from: FBal0297879
+FBti0168380_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297879
+FBti0168380_cas	carries_tool	FBto0000318	FBrf0223447		TOOL DATA from: FBal0297885
+FBti0168380_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297885
+FBti0168381_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297882
+FBti0168381_cas	tagged_with	FBto0000077	FBrf0223447		TOOL DATA from: FBal0297882
+FBti0168382_cas	carries_tool	FBto0000318	FBrf0223447|FBrf0223769		TOOL DATA from: FBal0297883
+FBti0168382_cas	carries_tool	FBto0000349	FBrf0223447|FBrf0223769		TOOL DATA from: FBal0297883
+FBti0168383_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0297884
+FBti0168383_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0297884
+FBti0168383_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0297884
+FBti0168383_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0297884
+FBti0168384_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168384_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168384_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297874
+FBti0168384_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297876
+FBti0168385_cas	tagged_with	FBto0000065	FBrf0226212		TOOL DATA from: FBal0298753
+FBti0168393_cas	carries_tool	FBto0000349	FBrf0227448		TOOL DATA from: FBal0302651
+FBti0168394_cas	carries_tool	FBto0000349	FBrf0227448		TOOL DATA from: FBal0302650
+FBti0168395_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168395_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168396_cas	carries_tool	FBto0000349	FBrf0205704		TOOL DATA from: FBal0264684
+FBti0168397_cas	carries_tool	FBto0000349	FBrf0205704		TOOL DATA from: FBal0264686
+FBti0168399_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286279
+FBti0168400_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286277
+FBti0168401_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286278
+FBti0168402_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286274
+FBti0168403_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286275
+FBti0168404_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286276
+FBti0168405_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0191252
+FBti0168405_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0191252
+FBti0168406_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0189625
+FBti0168406_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0189625
+FBti0168407_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0190085
+FBti0168408_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0190371
+FBti0168408_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0190371
+FBti0168409_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0190295
+FBti0168409_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0190295
+FBti0168410_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0190109
+FBti0168411_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0191136
+FBti0168412_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0179807
+FBti0168413_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0189853
+FBti0168413_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0189853
+FBti0168422_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301947
+FBti0168423_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301921
+FBti0168424_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301910
+FBti0168425_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301946
+FBti0168426_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301926
+FBti0168427_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168427_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168427_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301935
+FBti0168428_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301943
+FBti0168428_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301943
+FBti0168429_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301922
+FBti0168429_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301922
+FBti0168430_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301902
+FBti0168431_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301952
+FBti0168432_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301951
+FBti0168432_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301951
+FBti0168433_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301924
+FBti0168434_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301895
+FBti0168434_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301895
+FBti0168434_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301896
+FBti0168434_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301896
+FBti0168435_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301901
+FBti0168435_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301901
+FBti0168436_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168436_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168436_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301927
+FBti0168437_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168437_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168437_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301905
+FBti0168438_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301907
+FBti0168439_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301925
+FBti0168439_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301925
+FBti0168440_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301950
+FBti0168441_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168441_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168441_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301948
+FBti0168442_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301945
+FBti0168443_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301915
+FBti0168444_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301908
+FBti0168444_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301908
+FBti0168445_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301912
+FBti0168447_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301932
+FBti0168448_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301918
+FBti0168448_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301918
+FBti0168449_cas				FTA: unable to add tool information from FBal0301939 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168450_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168450_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168450_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301936
+FBti0168451_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301929
+FBti0168452_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301889
+FBti0168453_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301937
+FBti0168453_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301937
+FBti0168454_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301914
+FBti0168454_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301914
+FBti0168455_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301938
+FBti0168455_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301938
+FBti0168456_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301934
+FBti0168457_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301892
+FBti0168457_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301893
+FBti0168458_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301928
+FBti0168459_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168459_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168459_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301944
+FBti0168460_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301933
+FBti0168461_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301903
+FBti0168462_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168462_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168462_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301906
+FBti0168463_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301899
+FBti0168463_cas	carries_tool	FBto0000349	FBrf0258709		TOOL DATA from: FBal0400742
+FBti0168464_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301953
+FBti0168465_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301911
+FBti0168466_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0287802
+FBti0168466_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0287802
+FBti0168467_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301909
+FBti0168468_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301894
+FBti0168469_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301920
+FBti0168470_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301904
+FBti0168471_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301890
+FBti0168471_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301891
+FBti0168472_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168472_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168472_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301887
+FBti0168473_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301916
+FBti0168474_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301949
+FBti0168474_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301949
+FBti0168475_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301917
+FBti0168476_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301930
+FBti0168477_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301940
+FBti0168478_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301941
+FBti0168479_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301897
+FBti0168479_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301898
+FBti0168480_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301913
+FBti0168480_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301913
+FBti0168481_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301900
+FBti0168482_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168482_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168482_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301942
+FBti0168483_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301919
+FBti0168484_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301923
+FBti0168485_cas	carries_tool	FBto0000349	FBrf0222578|FBrf0227064		TOOL DATA from: FBal0290289
+FBti0168497_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168497_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168498_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168498_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168499_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168499_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168500_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0299787
+FBti0168501_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0299788
+FBti0168502_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0299786
+FBti0168503_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0304361
+FBti0168504_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0304362
+FBti0168514_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168514_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168514_cas	carries_tool	FBto0000349	FBrf0219887		TOOL DATA from: FBal0290263
+FBti0168516_cas	carries_tool	FBto0000349	FBrf0204932		TOOL DATA from: FBal0301954
+FBti0168517_cas	carries_tool	FBto0000349	FBrf0225135		TOOL DATA from: FBal0296653
+FBti0168517_cas	carries_tool	FBto0000356	FBrf0225135		TOOL DATA from: FBal0296653
+FBti0168522_cas	encodes_tool	FBto0000309			TOOL DATA from: FBtp0127592
+FBti0168522_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0127592
+FBti0168523_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0168523_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0168532_cas	tagged_with	FBto0000079	FBrf0191277		TOOL DATA from: FBal0260875
+FBti0168533_cas	tagged_with	FBto0000079	FBrf0191277		TOOL DATA from: FBal0260876
+FBti0168533_cas	tagged_with	FBto0000093	FBrf0191277		TOOL DATA from: FBal0260876
+FBti0168533_cas	tagged_with	FBto0000217	FBrf0191277		TOOL DATA from: FBal0260876
+FBti0168534_cas	carries_tool	FBto0000904	FBrf0168031		TOOL DATA from: FBal0304363
+FBti0168535_cas	carries_tool	FBto0000904	FBrf0168031		TOOL DATA from: FBal0304364
+FBti0168536_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293689
+FBti0168537_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293693
+FBti0168538_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293691
+FBti0168539_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293687
+FBti0168540_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293698
+FBti0168541_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293697
+FBti0168542_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293695
+FBti0168543_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293696
+FBti0168544_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293688
+FBti0168545_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293699
+FBti0168546_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293690
+FBti0168547_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293692
+FBti0168548_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293694
+FBti0168550_cas	carries_tool	FBto0000349	FBrf0213236		TOOL DATA from: FBal0269848
+FBti0168551_cas	carries_tool	FBto0000349	FBrf0213236		TOOL DATA from: FBal0269849
+FBti0168552_cas	carries_tool	FBto0000349	FBrf0213236		TOOL DATA from: FBal0298344
+FBti0168552_cas	tagged_with	FBto0000077	FBrf0213236		TOOL DATA from: FBal0298344
+FBti0168560_cas				FTA: unable to add tool information from FBal0247903 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168561_cas				FTA: unable to add tool information from FBal0247917 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168562_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247918
+FBti0168562_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247918
+FBti0168563_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247921
+FBti0168563_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247921
+FBti0168564_cas				FTA: unable to add tool information from FBal0247920 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168565_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247908
+FBti0168565_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247908
+FBti0168566_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247909
+FBti0168566_cas	tagged_with	FBto0000057	FBrf0208027		TOOL DATA from: FBal0247909
+FBti0168567_cas	tagged_with	FBto0000118	FBrf0208027		TOOL DATA from: FBal0247911
+FBti0168568_cas				FTA: unable to add tool information from FBal0247906 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168569_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247907
+FBti0168569_cas	carries_tool	FBto0000356	FBrf0208027		TOOL DATA from: FBal0247907
+FBti0168570_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247910
+FBti0168570_cas	tagged_with	FBto0000121	FBrf0208027		TOOL DATA from: FBal0247910
+FBti0168571_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247915
+FBti0168571_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247915
+FBti0168572_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247913
+FBti0168572_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247913
+FBti0168573_cas				FTA: unable to add tool information from FBal0247912 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168574_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247914
+FBti0168574_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247914
+FBti0168575_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247905
+FBti0168575_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247905
+FBti0168576_cas				FTA: unable to add tool information from FBal0247904 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168581_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168581_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168582_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168582_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168582_cas	carries_tool	FBto0000349	FBrf0200334		TOOL DATA from: FBal0210949
+FBti0168583_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168583_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168583_cas	carries_tool	FBto0000349	FBrf0200334		TOOL DATA from: FBal0210948
+FBti0168589_cas				FTA: unable to add tool information from FBal0301001 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168592_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243800
+FBti0168593_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243798
+FBti0168594_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243810
+FBti0168595_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243822
+FBti0168596_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243802
+FBti0168597_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243824
+FBti0168598_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243818
+FBti0168599_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243812
+FBti0168600_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243838
+FBti0168601_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243840
+FBti0168602_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243807
+FBti0168605_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168605_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168606_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168606_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168608_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0168608_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0168609_cas				FTA: unable to add tool information from FBal0299770 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168610_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168610_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168616_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168616_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168616_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290239
+FBti0168616_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290247
+FBti0168617_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168617_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168617_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290240
+FBti0168617_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290248
+FBti0168618_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168618_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168618_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290241
+FBti0168618_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290249
+FBti0168619_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290242
+FBti0168620_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296337
+FBti0168621_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296338
+FBti0168622_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296340
+FBti0168623_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296341
+FBti0168624_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296339
+FBti0168628_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168628_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168630_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168630_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168630_cas	carries_tool	FBto0000349	FBrf0216517		TOOL DATA from: FBal0283188
+FBti0168630_cas	carries_tool	FBto0000349	FBrf0216517		TOOL DATA from: FBal0283192
+FBti0168635_cas	encodes_tool	FBto0000020			TOOL DATA from: FBtp0099208
+FBti0168635_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099208
+FBti0168638_cas				FTA: unable to add tool information from FBal0301058 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168639_cas				FTA: unable to add tool information from FBal0301059 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168640_cas	carries_tool	FBto0000349	FBrf0218332		TOOL DATA from: FBal0268456
+FBti0168641_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168641_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168641_cas	carries_tool	FBto0000318	FBrf0210397		TOOL DATA from: FBal0267700
+FBti0168641_cas	carries_tool	FBto0000318	FBrf0210397		TOOL DATA from: FBal0277019
+FBti0168644_cas	carries_tool	FBto0000349	FBrf0216958		TOOL DATA from: FBal0267506
+FBti0168645_cas	tagged_with	FBto0000031	FBrf0227091		TOOL DATA from: FBal0302059
+FBti0168645_cas	tagged_with	FBto0000076	FBrf0227091		TOOL DATA from: FBal0302059
+FBti0168646_cas	carries_tool	FBto0000356	FBrf0227091		TOOL DATA from: FBal0302056
+FBti0168647_cas	carries_tool	FBto0000356	FBrf0227091		TOOL DATA from: FBal0302055
+FBti0168648_cas	tagged_with	FBto0000092	FBrf0227091		TOOL DATA from: FBal0302057
+FBti0168648_cas	tagged_with	FBto0000093	FBrf0227091		TOOL DATA from: FBal0302057
+FBti0168649_cas	carries_tool	FBto0000318	FBrf0227091		TOOL DATA from: FBal0302058
+FBti0168649_cas	tagged_with	FBto0000092	FBrf0227091		TOOL DATA from: FBal0302058
+FBti0168649_cas	tagged_with	FBto0000093	FBrf0227091		TOOL DATA from: FBal0302058
+FBti0168650_cas	carries_tool	FBto0000356	FBrf0227091		TOOL DATA from: FBal0302054
+FBti0168651_cas	carries_tool	FBto0000356	FBrf0227091		TOOL DATA from: FBal0302060
+FBti0168652_cas	carries_tool	FBto0000349	FBrf0210726		TOOL DATA from: FBal0248458
+FBti0168653_cas	carries_tool	FBto0000349	FBrf0210726		TOOL DATA from: FBal0248457
+FBti0168654_cas	carries_tool	FBto0000349	FBrf0216391		TOOL DATA from: FBal0265170
+FBti0168655_cas	carries_tool	FBto0000349	FBrf0216391		TOOL DATA from: FBal0265172
+FBti0168656_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0168656_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0168656_cas	carries_tool	FBto0000320	FBrf0226155		TOOL DATA from: FBal0298265
+FBti0168656_cas	carries_tool	FBto0000349	FBrf0226155		TOOL DATA from: FBal0298265
+FBti0168656_cas	carries_tool	FBto0000356	FBrf0226155		TOOL DATA from: FBal0298265
+FBti0168656_cas	carries_tool	FBto0000320	FBrf0226155		TOOL DATA from: FBal0298271
+FBti0168656_cas	carries_tool	FBto0000349	FBrf0226155		TOOL DATA from: FBal0298271
+FBti0168656_cas	carries_tool	FBto0000356	FBrf0226155		TOOL DATA from: FBal0298271
+FBti0168656_cas	tagged_with	FBto0000205	FBrf0226155		TOOL DATA from: FBal0298271
+FBti0168657_cas	carries_tool	FBto0000349	FBrf0226155		TOOL DATA from: FBal0298266
+FBti0168657_cas	carries_tool	FBto0000356	FBrf0226155		TOOL DATA from: FBal0298266
+FBti0168658_cas	carries_tool	FBto0000349	FBrf0226155		TOOL DATA from: FBal0298267
+FBti0168659_cas	encodes_tool	FBto0000030			TOOL DATA from: FBtp0099202
+FBti0168659_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099202
+FBti0168661_cas	carries_tool	FBto0000318	FBrf0202837		TOOL DATA from: FBal0241951
+FBti0168662_cas	carries_tool	FBto0000349	FBrf0217508		TOOL DATA from: FBal0280288
+FBti0168663_cas	carries_tool	FBto0000349	FBrf0217508		TOOL DATA from: FBal0280289
+FBti0168664_cas	carries_tool	FBto0000349	FBrf0217508		TOOL DATA from: FBal0280287
+FBti0168665_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168665_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168665_cas	carries_tool	FBto0000349	FBrf0191488		TOOL DATA from: FBal0189843
+FBti0168665_cas	carries_tool	FBto0000349	FBrf0191488		TOOL DATA from: FBal0190445
+FBti0168666_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168666_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168666_cas	carries_tool	FBto0000349	FBrf0191488		TOOL DATA from: FBal0179808
+FBti0168666_cas	carries_tool	FBto0000349	FBrf0191488		TOOL DATA from: FBal0276838
+FBti0168668_cas	carries_tool	FBto0000318	FBrf0187655		TOOL DATA from: FBal0191200
+FBti0168668_cas	carries_tool	FBto0000904	FBrf0187655		TOOL DATA from: FBal0191200
+FBti0168669_cas				FTA: unable to add tool information from FBal0192050 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168671_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0168671_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0168673_cas				FTA: unable to add tool information from FBal0302938 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168674_cas				FTA: unable to add tool information from FBal0298847 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168676_cas	encodes_tool	FBto0000159			TOOL DATA from: FBtp0099209
+FBti0168676_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099209
+FBti0168677_cas	carries_tool	FBto0000349	FBrf0201956		TOOL DATA from: FBal0219056
+FBti0168678_cas	tagged_with	FBto0000027	FBrf0224269		TOOL DATA from: FBal0295033
+FBti0168681_cas	tagged_with	FBto0000077	FBrf0210736		TOOL DATA from: FBal0246663
+FBti0168682_cas	carries_tool	FBto0000349	FBrf0226802		TOOL DATA from: FBal0302045
+FBti0168683_cas				FTA: unable to add tool information from FBal0302044 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168684_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293729
+FBti0168685_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293726
+FBti0168686_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293727
+FBti0168686_cas	tagged_with	FBto0000009	FBrf0222114		TOOL DATA from: FBal0293727
+FBti0168687_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293728
+FBti0168688_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0297274
+FBti0168688_cas	carries_tool	FBto0000356	FBrf0222114		TOOL DATA from: FBal0297274
+FBti0168689_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293730
+FBti0168689_cas	tagged_with	FBto0000009	FBrf0222114		TOOL DATA from: FBal0293730
+FBti0168690_cas	encodes_tool	FBto0000167			TOOL DATA from: FBtp0099206
+FBti0168690_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099206
+FBti0168690_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298328
+FBti0168690_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298328
+FBti0168690_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298331
+FBti0168690_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298331
+FBti0168691_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168691_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168691_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298272
+FBti0168691_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298326
+FBti0168692_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298327
+FBti0168692_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298327
+FBti0168693_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298325
+FBti0168693_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298325
+FBti0168693_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298325
+FBti0168693_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298325
+FBti0168694_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298329
+FBti0168694_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298329
+FBti0168694_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298329
+FBti0168694_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298329
+FBti0168695_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298330
+FBti0168695_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298330
+FBti0168695_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298330
+FBti0168696_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298269
+FBti0168696_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298269
+FBti0168696_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298269
+FBti0168696_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298269
+FBti0168697_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298270
+FBti0168697_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298270
+FBti0168698_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298268
+FBti0168698_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298268
+FBti0168698_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298268
+FBti0168700_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168700_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168704_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0302679
+FBti0168704_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0302682
+FBti0168705_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168705_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168705_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0302672
+FBti0168705_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0302678
+FBti0168706_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0168706_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0168706_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0304368
+FBti0168708_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168708_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168710_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182427
+FBti0168711_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182425
+FBti0168712_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182424
+FBti0168713_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182426
+FBti0168714_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182423
+FBti0168715_cas				FTA: unable to add tool information from FBal0277644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168716_cas				FTA: unable to add tool information from FBal0277643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168717_cas	carries_tool	FBto0000349	FBrf0218141		TOOL DATA from: FBal0277645
+FBti0168717_cas	tagged_with	FBto0000077	FBrf0218141		TOOL DATA from: FBal0277645
+FBti0168718_cas	carries_tool	FBto0000349	FBrf0218141		TOOL DATA from: FBal0277646
+FBti0168718_cas	tagged_with	FBto0000077	FBrf0218141		TOOL DATA from: FBal0277646
+FBti0168720_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280511
+FBti0168720_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280511
+FBti0168721_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280508
+FBti0168721_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280508
+FBti0168722_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280506
+FBti0168722_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280506
+FBti0168723_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280507
+FBti0168723_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280507
+FBti0168724_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280505
+FBti0168724_cas	carries_tool	FBto0000356	FBrf0219767		TOOL DATA from: FBal0280505
+FBti0168725_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280512
+FBti0168725_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280512
+FBti0168726_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280513
+FBti0168726_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280513
+FBti0168727_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280510
+FBti0168727_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280510
+FBti0168728_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280509
+FBti0168728_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280509
+FBti0168729_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280516
+FBti0168729_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280516
+FBti0168730_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280517
+FBti0168730_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280517
+FBti0168731_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168731_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168732_cas	carries_tool	FBto0000349	FBrf0225809		TOOL DATA from: FBal0298308
+FBti0168736_cas	carries_tool	FBto0000349	FBrf0217965		TOOL DATA from: FBal0268277
+FBti0168736_cas	carries_tool	FBto0000356	FBrf0217965		TOOL DATA from: FBal0268277
+FBti0168736_cas	carries_tool	FBto0000349	FBrf0217965		TOOL DATA from: FBal0268280
+FBti0168736_cas	carries_tool	FBto0000356	FBrf0217965		TOOL DATA from: FBal0268280
+FBti0168738_cas	carries_tool	FBto0000349	FBrf0217965		TOOL DATA from: FBal0268278
+FBti0168738_cas	carries_tool	FBto0000356	FBrf0217965		TOOL DATA from: FBal0268278
+FBti0168739_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0099203
+FBti0168739_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099203
+FBti0168742_cas	tagged_with	FBto0000027	FBrf0222325		TOOL DATA from: FBal0288693
+FBti0168743_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168743_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168743_cas	carries_tool	FBto0000349	FBrf0222578		TOOL DATA from: FBal0290287
+FBti0168743_cas	carries_tool	FBto0000349	FBrf0222578		TOOL DATA from: FBal0290291
+FBti0168744_cas	carries_tool	FBto0000349	FBrf0201071		TOOL DATA from: FBal0240504
+FBti0168745_cas	carries_tool	FBto0000349	FBrf0201071		TOOL DATA from: FBal0240509
+FBti0168746_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168746_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168749_cas	tagged_with	FBto0000077	FBrf0200445		TOOL DATA from: FBal0242694
+FBti0168750_cas				FTA: unable to add tool information from FBal0219059 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168751_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168751_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168752_cas	carries_tool	FBto0000349	FBrf0225717		TOOL DATA from: FBal0297886
+FBti0168753_cas	carries_tool	FBto0000349	FBrf0227399		TOOL DATA from: FBal0257044
+FBti0168755_cas	carries_tool	FBto0000318	FBrf0218347		TOOL DATA from: FBal0269902
+FBti0168757_cas	carries_tool	FBto0000349	FBrf0212221		TOOL DATA from: FBal0260619
+FBti0168761_cas	carries_tool	FBto0000318	FBrf0211655		TOOL DATA from: FBal0175408
+FBti0168762_cas	carries_tool	FBto0000318	FBrf0211655		TOOL DATA from: FBal0175409
+FBti0168763_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168763_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168764_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168764_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168765_cas				FTA: unable to add tool information from FBal0283278 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168766_cas	carries_tool	FBto0000319	FBrf0219398		TOOL DATA from: FBal0283280
+FBti0168766_cas	carries_tool	FBto0000356	FBrf0219398		TOOL DATA from: FBal0283280
+FBti0168773_cas				FTA: unable to add tool information from FBal0283248 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168778_cas	carries_tool	FBto0000349	FBrf0218054		TOOL DATA from: FBal0270281
+FBti0168780_cas	carries_tool	FBto0000318	FBrf0205458		TOOL DATA from: FBal0304370
+FBti0168780_cas	carries_tool	FBto0000904	FBrf0205458		TOOL DATA from: FBal0304370
+FBti0168787_cas	carries_tool	FBto0000318	FBrf0167414		TOOL DATA from: FBal0304377
+FBti0168788_cas	carries_tool	FBto0000318	FBrf0160936		TOOL DATA from: FBal0304378
+FBti0168789_cas	carries_tool	FBto0000318	FBrf0160936		TOOL DATA from: FBal0304379
+FBti0168790_cas	carries_tool	FBto0000318	FBrf0160936		TOOL DATA from: FBal0304380
+FBti0168791_cas	carries_tool	FBto0000318	FBrf0160936		TOOL DATA from: FBal0304381
+FBti0168792_cas	carries_tool	FBto0000318	FBrf0198770		TOOL DATA from: FBal0304382
+FBti0168793_cas	carries_tool	FBto0000318	FBrf0159299		TOOL DATA from: FBal0304383
+FBti0168794_cas	carries_tool	FBto0000318	FBrf0205189		TOOL DATA from: FBal0304384
+FBti0168796_cas	carries_tool	FBto0000318	FBrf0179131		TOOL DATA from: FBal0304386
+FBti0168796_cas	carries_tool	FBto0000904	FBrf0179131		TOOL DATA from: FBal0304386
+FBti0168834_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0168834_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0168920_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0168920_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0169380_cas				FTA: unable to add tool information from FBal0291053 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0178258_cas	carries_tool	FBto0000349	FBrf0208945		TOOL DATA from: FBal0247973
+FBti0178258_cas	carries_tool	FBto0000356	FBrf0208945		TOOL DATA from: FBal0247973
+FBti0178263_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314192
+FBti0178263_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314192
+FBti0178264_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314193
+FBti0178264_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314193
+FBti0178265_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314194
+FBti0178265_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314194
+FBti0178266_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314195
+FBti0178266_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314195
+FBti0178267_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314196
+FBti0178267_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314196
+FBti0178268_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314197
+FBti0178268_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314197
+FBti0178269_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314198
+FBti0178269_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314198
+FBti0178270_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314199
+FBti0178270_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314199
+FBti0178271_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314200
+FBti0178271_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314200
+FBti0178272_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314201
+FBti0178272_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314201
+FBti0178273_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314202
+FBti0178273_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314202
+FBti0178274_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314203
+FBti0178274_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314203
+FBti0178275_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314204
+FBti0178275_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314204
+FBti0178276_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314205
+FBti0178276_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314205
+FBti0178277_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314206
+FBti0178277_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314206
+FBti0178278_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314207
+FBti0178278_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314207
+FBti0178279_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314208
+FBti0178279_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314208
+FBti0178280_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314209
+FBti0178280_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314209
+FBti0178281_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314210
+FBti0178281_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314210
+FBti0178282_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314211
+FBti0178282_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314211
+FBti0178283_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314212
+FBti0178283_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314212
+FBti0178284_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314213
+FBti0178284_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314213
+FBti0178285_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314214
+FBti0178285_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314214
+FBti0178286_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314215
+FBti0178286_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314215
+FBti0178287_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314216
+FBti0178287_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314216
+FBti0178288_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314217
+FBti0178288_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314217
+FBti0178289_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314218
+FBti0178289_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314218
+FBti0180187_cas				FTA: unable to add tool information from FBal0316238 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0180251_cas	carries_tool	FBto0000349	FBrf0229366		TOOL DATA from: FBal0316501
+FBti0180251_cas	carries_tool	FBto0000356	FBrf0229366		TOOL DATA from: FBal0316501
+FBti0180381_cas				FTA: unable to add tool information from FBal0267202 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0180395_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304937
+FBti0180396_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304936
+FBti0180397_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304938
+FBti0180398_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304939
+FBti0180399_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304940
+FBti0180401_cas	carries_tool	FBto0000318	FBrf0228676		TOOL DATA from: FBal0304944
+FBti0180401_cas	carries_tool	FBto0000349	FBrf0228676		TOOL DATA from: FBal0304944
+FBti0180401_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304944
+FBti0180403_cas	carries_tool	FBto0000318	FBrf0228676		TOOL DATA from: FBal0304942
+FBti0180403_cas	carries_tool	FBto0000349	FBrf0228676		TOOL DATA from: FBal0304942
+FBti0180531_cas				FTA: unable to add tool information from FBal0317120 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0180533_cas	carries_tool	FBto0000356	FBrf0229921		TOOL DATA from: FBal0317128
+FBti0180537_cas	carries_tool	FBto0000318	FBrf0229921		TOOL DATA from: FBal0317151
+FBti0180537_cas	carries_tool	FBto0000349	FBrf0229921		TOOL DATA from: FBal0317151
+FBti0180537_cas	carries_tool	FBto0000356	FBrf0229921		TOOL DATA from: FBal0317151
+FBti0181543_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0181543_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0181768_cas	carries_tool	FBto0000349	FBrf0227817		TOOL DATA from: FBal0318359
+FBti0181769_cas	carries_tool	FBto0000349	FBrf0227817		TOOL DATA from: FBal0318360
+FBti0181770_cas	carries_tool	FBto0000349	FBrf0227817		TOOL DATA from: FBal0318361
+FBti0181772_cas	carries_tool	FBto0000349	FBrf0229617		TOOL DATA from: FBal0318382
+FBti0181787_cas	carries_tool	FBto0000349	FBrf0221975		TOOL DATA from: FBal0318439
+FBti0181793_cas	carries_tool	FBto0000318	FBrf0228676		TOOL DATA from: FBal0304943
+FBti0181793_cas	carries_tool	FBto0000349	FBrf0228676		TOOL DATA from: FBal0304943
+FBti0181793_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304943
+FBti0181810_cas	tagged_with	FBto0000121	FBrf0230786		TOOL DATA from: FBal0318490
+FBti0181813_cas	tagged_with	FBto0000031	FBrf0227332		TOOL DATA from: FBal0318505
+FBti0181883_cas	carries_tool	FBto0000349	FBrf0230589		TOOL DATA from: FBal0318727
+FBti0181883_cas	carries_tool	FBto0000356	FBrf0230589		TOOL DATA from: FBal0318727
+FBti0181884_cas	carries_tool	FBto0000349	FBrf0230589		TOOL DATA from: FBal0318728
+FBti0181884_cas	carries_tool	FBto0000356	FBrf0230589		TOOL DATA from: FBal0318728
+FBti0181885_cas	carries_tool	FBto0000349	FBrf0230589		TOOL DATA from: FBal0318730
+FBti0181885_cas	tagged_with	FBto0000076	FBrf0230589		TOOL DATA from: FBal0318730
+FBti0181887_cas				FTA: unable to add tool information from FBal0318747 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0181896_cas				FTA: unable to add tool information from FBal0318789 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0181897_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0181897_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0182057_cas	carries_tool	FBto0000318	FBrf0194622		TOOL DATA from: FBal0219236
+FBti0182101_cas	carries_tool	FBto0000349	FBrf0222842		TOOL DATA from: FBal0319123
+FBti0182131_cas	tagged_with	FBto0000031	FBrf0231866		TOOL DATA from: FBal0319206
+FBti0182150_cas	carries_tool	FBto0000349	FBrf0229285		TOOL DATA from: FBal0319257
+FBti0182157_cas	carries_tool	FBto0000349	FBrf0232113		TOOL DATA from: FBal0319276
+FBti0182157_cas	tagged_with	FBto0000093	FBrf0232113		TOOL DATA from: FBal0319276
+FBti0182249_cas	tagged_with	FBto0000031	FBrf0232306		TOOL DATA from: FBal0319445
+FBti0182250_cas	tagged_with	FBto0000118	FBrf0232306		TOOL DATA from: FBal0319452
+FBti0182581_cas	tagged_with	FBto0000027	FBrf0232493		TOOL DATA from: FBal0319665
+FBti0182663_cas	carries_tool	FBto0000349	FBrf0232358		TOOL DATA from: FBal0319858
+FBti0182663_cas	carries_tool	FBto0000356	FBrf0232358		TOOL DATA from: FBal0319858
+FBti0182701_cas	encodes_tool	FBto0000063			TOOL DATA from: FBtp0112818
+FBti0182701_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0112818
+FBti0182701_cas	carries_tool	FBto0000349	FBrf0232045		TOOL DATA from: FBal0320004
+FBti0182712_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0182712_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0182713_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0182713_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0183176_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0183176_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0183608_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0183608_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0184517_cas	carries_tool	FBto0000318	FBrf0233338		TOOL DATA from: FBal0322593
+FBti0184517_cas	carries_tool	FBto0000356	FBrf0233338		TOOL DATA from: FBal0322593
+FBti0184518_cas	carries_tool	FBto0000318	FBrf0233338		TOOL DATA from: FBal0322594
+FBti0184518_cas	carries_tool	FBto0000356	FBrf0233338		TOOL DATA from: FBal0322594
+FBti0184519_cas				FTA: unable to add tool information from FBal0322596 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184520_cas				FTA: unable to add tool information from FBal0322597 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184522_cas				FTA: unable to add tool information from FBal0322599 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184523_cas				FTA: unable to add tool information from FBal0322600 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184524_cas				FTA: unable to add tool information from FBal0322601 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184525_cas				FTA: unable to add tool information from FBal0322602 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184526_cas				FTA: unable to add tool information from FBal0322603 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184527_cas				FTA: unable to add tool information from FBal0322604 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184528_cas				FTA: unable to add tool information from FBal0322605 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184529_cas				FTA: unable to add tool information from FBal0322606 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184530_cas				FTA: unable to add tool information from FBal0322607 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184531_cas				FTA: unable to add tool information from FBal0322608 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184532_cas				FTA: unable to add tool information from FBal0322609 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184533_cas				FTA: unable to add tool information from FBal0322610 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184534_cas				FTA: unable to add tool information from FBal0322611 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184535_cas				FTA: unable to add tool information from FBal0322612 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184536_cas				FTA: unable to add tool information from FBal0322613 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184537_cas				FTA: unable to add tool information from FBal0322614 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184538_cas				FTA: unable to add tool information from FBal0322615 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184539_cas				FTA: unable to add tool information from FBal0322616 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184540_cas				FTA: unable to add tool information from FBal0322617 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184541_cas				FTA: unable to add tool information from FBal0322618 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184542_cas				FTA: unable to add tool information from FBal0322619 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184543_cas				FTA: unable to add tool information from FBal0322620 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184544_cas				FTA: unable to add tool information from FBal0322621 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184545_cas				FTA: unable to add tool information from FBal0322622 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184546_cas				FTA: unable to add tool information from FBal0322623 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184547_cas				FTA: unable to add tool information from FBal0322624 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184548_cas				FTA: unable to add tool information from FBal0322625 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184549_cas				FTA: unable to add tool information from FBal0322626 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184550_cas				FTA: unable to add tool information from FBal0322627 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184551_cas				FTA: unable to add tool information from FBal0322628 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184552_cas				FTA: unable to add tool information from FBal0322629 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184553_cas				FTA: unable to add tool information from FBal0322630 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184554_cas				FTA: unable to add tool information from FBal0322631 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184555_cas				FTA: unable to add tool information from FBal0322632 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184556_cas				FTA: unable to add tool information from FBal0322633 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184557_cas				FTA: unable to add tool information from FBal0322634 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184558_cas				FTA: unable to add tool information from FBal0322635 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184559_cas				FTA: unable to add tool information from FBal0322636 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184560_cas				FTA: unable to add tool information from FBal0322637 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184561_cas				FTA: unable to add tool information from FBal0322638 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184562_cas				FTA: unable to add tool information from FBal0322639 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184563_cas				FTA: unable to add tool information from FBal0322640 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184564_cas				FTA: unable to add tool information from FBal0322641 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184565_cas				FTA: unable to add tool information from FBal0322642 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184566_cas				FTA: unable to add tool information from FBal0322643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184567_cas				FTA: unable to add tool information from FBal0322644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184568_cas				FTA: unable to add tool information from FBal0322645 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184569_cas				FTA: unable to add tool information from FBal0322646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184570_cas				FTA: unable to add tool information from FBal0322647 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184571_cas				FTA: unable to add tool information from FBal0322648 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184572_cas				FTA: unable to add tool information from FBal0322649 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184574_cas				FTA: unable to add tool information from FBal0322651 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184575_cas				FTA: unable to add tool information from FBal0322652 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184576_cas				FTA: unable to add tool information from FBal0322653 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184577_cas				FTA: unable to add tool information from FBal0322654 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184578_cas				FTA: unable to add tool information from FBal0322655 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184581_cas	encodes_tool	FBto0000027	FBrf0233338		TOOL DATA from: FBal0322658
+FBti0184582_cas				FTA: unable to add tool information from FBal0322659 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184583_cas				FTA: unable to add tool information from FBal0322660 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184585_cas				FTA: unable to add tool information from FBal0322662 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184587_cas				FTA: unable to add tool information from FBal0322664 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184588_cas				FTA: unable to add tool information from FBal0322665 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184589_cas				FTA: unable to add tool information from FBal0322666 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184590_cas				FTA: unable to add tool information from FBal0322667 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184591_cas				FTA: unable to add tool information from FBal0322668 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184592_cas				FTA: unable to add tool information from FBal0322669 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184594_cas	carries_tool	FBto0000318	FBrf0233338		TOOL DATA from: FBal0322671
+FBti0184594_cas	carries_tool	FBto0000356	FBrf0233338		TOOL DATA from: FBal0322671
+FBti0184595_cas				FTA: unable to add tool information from FBal0322672 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184596_cas				FTA: unable to add tool information from FBal0322673 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184597_cas				FTA: unable to add tool information from FBal0322674 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184598_cas				FTA: unable to add tool information from FBal0322675 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184599_cas				FTA: unable to add tool information from FBal0322676 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184600_cas				FTA: unable to add tool information from FBal0322677 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184601_cas				FTA: unable to add tool information from FBal0322678 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184602_cas				FTA: unable to add tool information from FBal0322679 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184603_cas				FTA: unable to add tool information from FBal0322680 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184604_cas				FTA: unable to add tool information from FBal0322681 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184605_cas				FTA: unable to add tool information from FBal0322682 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184606_cas				FTA: unable to add tool information from FBal0322683 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184607_cas				FTA: unable to add tool information from FBal0322684 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184608_cas				FTA: unable to add tool information from FBal0322685 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184609_cas				FTA: unable to add tool information from FBal0322686 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184610_cas				FTA: unable to add tool information from FBal0322687 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184611_cas				FTA: unable to add tool information from FBal0322688 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184612_cas				FTA: unable to add tool information from FBal0322689 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184613_cas				FTA: unable to add tool information from FBal0322690 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184614_cas				FTA: unable to add tool information from FBal0322691 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184615_cas				FTA: unable to add tool information from FBal0322692 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184616_cas				FTA: unable to add tool information from FBal0322693 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184617_cas				FTA: unable to add tool information from FBal0322694 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184618_cas				FTA: unable to add tool information from FBal0322695 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184619_cas				FTA: unable to add tool information from FBal0322696 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184620_cas				FTA: unable to add tool information from FBal0322697 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184621_cas				FTA: unable to add tool information from FBal0322698 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184622_cas				FTA: unable to add tool information from FBal0322699 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184623_cas				FTA: unable to add tool information from FBal0322700 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184630_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322738
+FBti0184630_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322738
+FBti0184631_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322741
+FBti0184631_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322741
+FBti0184632_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322745
+FBti0184632_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322745
+FBti0184633_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322746
+FBti0184633_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322746
+FBti0184634_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322747
+FBti0184634_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322747
+FBti0184635_cas	tagged_with	FBto0000077	FBrf0233126		TOOL DATA from: FBal0322748
+FBti0184635_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322748
+FBti0184655_cas	tagged_with	FBto0000102	FBrf0232696		TOOL DATA from: FBal0322765
+FBti0184967_cas	tagged_with	FBto0000079	FBrf0233328		TOOL DATA from: FBal0322954
+FBti0184969_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0184969_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0185073_cas				FTA: unable to add tool information from FBal0323134 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185074_cas	carries_tool	FBto0000349	FBrf0227831		TOOL DATA from: FBal0323135
+FBti0185075_cas	carries_tool	FBto0000318	FBrf0227831		TOOL DATA from: FBal0323136
+FBti0185077_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0185077_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0185118_cas				FTA: unable to add tool information from FBal0323340 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185119_cas	carries_tool	FBto0000349	FBrf0232350		TOOL DATA from: FBal0323341
+FBti0185120_cas				FTA: unable to add tool information from FBal0323342 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185121_cas				FTA: unable to add tool information from FBal0323343 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185122_cas				FTA: unable to add tool information from FBal0323344 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185281_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0185281_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0185282_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0185282_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0185284_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0185284_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0185285_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0185285_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0185296_cas	tagged_with	FBto0000063	FBrf0230069		TOOL DATA from: FBal0323559
+FBti0185297_cas				FTA: unable to add tool information from FBal0323560 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185298_cas				FTA: unable to add tool information from FBal0323561 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185299_cas				FTA: unable to add tool information from FBal0323562 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185300_cas				FTA: unable to add tool information from FBal0323563 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185691_cas	carries_tool	FBto0000318	FBrf0230209		TOOL DATA from: FBal0324293
+FBti0185691_cas	carries_tool	FBto0000349	FBrf0230209		TOOL DATA from: FBal0324293
+FBti0185692_cas	carries_tool	FBto0000318	FBrf0230209		TOOL DATA from: FBal0324294
+FBti0185692_cas	carries_tool	FBto0000349	FBrf0230209		TOOL DATA from: FBal0324294
+FBti0186070_cas	tagged_with	FBto0000027	FBrf0233964		TOOL DATA from: FBal0324692
+FBti0186071_cas	tagged_with	FBto0000027	FBrf0233964		TOOL DATA from: FBal0324693
+FBti0186072_cas	tagged_with	FBto0000027	FBrf0233964		TOOL DATA from: FBal0324694
+FBti0186126_cas	carries_tool	FBto0000349	FBrf0215219		TOOL DATA from: FBal0324807
+FBti0186126_cas	carries_tool	FBto0000358	FBrf0215219		TOOL DATA from: FBal0324807
+FBti0186127_cas	carries_tool	FBto0000349	FBrf0215219		TOOL DATA from: FBal0324808
+FBti0186127_cas	carries_tool	FBto0000358	FBrf0215219		TOOL DATA from: FBal0324808
+FBti0186128_cas	carries_tool	FBto0000349	FBrf0215219		TOOL DATA from: FBal0324809
+FBti0186128_cas	carries_tool	FBto0000356	FBrf0215219		TOOL DATA from: FBal0324809
+FBti0186129_cas	carries_tool	FBto0000349	FBrf0215219		TOOL DATA from: FBal0324810
+FBti0186139_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0186139_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0186161_cas	tagged_with	FBto0000027	FBrf0230384		TOOL DATA from: FBal0324929
+FBti0186162_cas	tagged_with	FBto0000076	FBrf0230384		TOOL DATA from: FBal0324930
+FBti0186163_cas	tagged_with	FBto0000076	FBrf0230384		TOOL DATA from: FBal0324931
+FBti0186164_cas	tagged_with	FBto0000027	FBrf0230384		TOOL DATA from: FBal0324932
+FBti0186198_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0186198_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0186204_cas	carries_tool	FBto0000349	FBrf0234054		TOOL DATA from: FBal0325082
+FBti0186204_cas	carries_tool	FBto0000356	FBrf0234054		TOOL DATA from: FBal0325082
+FBti0186205_cas	carries_tool	FBto0000349	FBrf0234054		TOOL DATA from: FBal0325083
+FBti0186205_cas	carries_tool	FBto0000356	FBrf0234054		TOOL DATA from: FBal0325083
+FBti0186210_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0186210_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0186210_cas	tagged_with	FBto0000118	FBrf0234010		TOOL DATA from: FBal0325092
+FBti0186250_cas	tagged_with	FBto0000076	FBrf0234262		TOOL DATA from: FBal0325187
+FBti0186468_cas	tagged_with	FBto0000031	FBrf0234377		TOOL DATA from: FBal0325423
+FBti0186469_cas	tagged_with	FBto0000077	FBrf0234377		TOOL DATA from: FBal0325424
+FBti0186500_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0186500_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0186500_cas	tagged_with	FBto0000118	FBrf0234489		TOOL DATA from: FBal0325517
+FBti0186503_cas	tagged_with	FBto0000118	FBrf0234661		TOOL DATA from: FBal0325533
+FBti0186504_cas	tagged_with	FBto0000335	FBrf0234661		TOOL DATA from: FBal0325536
+FBti0186505_cas	carries_tool	FBto0000349	FBrf0234661		TOOL DATA from: FBal0325537
+FBti0186505_cas	tool_uses	enhancer trap	FBrf0234661		TOOL DATA from: FBal0325537
+FBti0186505_cas	carries_tool	FBto0000349	FBrf0234661		TOOL DATA from: FBal0325538
+FBti0186505_cas	encodes_tool	FBto0000027	FBrf0234661		TOOL DATA from: FBal0325538
+FBti0186505_cas	tool_uses	enhancer trap	FBrf0234661		TOOL DATA from: FBal0325538
+FBti0186509_cas				FTA: unable to add tool information from FBal0325572 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0186510_cas	carries_tool	FBto0000349	FBrf0234669		TOOL DATA from: FBal0325573
+FBti0186510_cas	carries_tool	FBto0000906	FBrf0234669		TOOL DATA from: FBal0325573
+FBti0186511_cas	carries_tool	FBto0000349	FBrf0234669		TOOL DATA from: FBal0325574
+FBti0186511_cas	carries_tool	FBto0000906	FBrf0234669		TOOL DATA from: FBal0325574
+FBti0186514_cas	carries_tool	FBto0000349	FBrf0234758		TOOL DATA from: FBal0325576
+FBti0186514_cas	carries_tool	FBto0000356	FBrf0234758		TOOL DATA from: FBal0325576
+FBti0186515_cas	carries_tool	FBto0000349	FBrf0234758		TOOL DATA from: FBal0325577
+FBti0186515_cas	carries_tool	FBto0000356	FBrf0234758		TOOL DATA from: FBal0325577
+FBti0186540_cas				FTA: unable to add tool information from FBal0325646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0186555_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0186555_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0186555_cas				FTA: unable to add tool information from FBal0290246 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0186559_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0186559_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0186559_cas				FTA: unable to add tool information from FBal0325667 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0186561_cas	carries_tool	FBto0000356	FBrf0233649		TOOL DATA from: FBal0325675
+FBti0186571_cas	tagged_with	FBto0000102	FBrf0232854		TOOL DATA from: FBal0325770
+FBti0186572_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0116623
+FBti0186572_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0116623
+FBti0186857_cas	tagged_with	FBto0000076	FBrf0234011		TOOL DATA from: FBal0326180
+FBti0186857_cas	tagged_with	FBto0000118	FBrf0234011		TOOL DATA from: FBal0326180
+FBti0186933_cas	tagged_with	FBto0000076	FBrf0235527		TOOL DATA from: FBal0326318
+FBti0186933_cas	tagged_with	FBto0000102	FBrf0235527		TOOL DATA from: FBal0326318
+FBti0186934_cas	tagged_with	FBto0000102	FBrf0235527		TOOL DATA from: FBal0326320
+FBti0186935_cas	carries_tool	FBto0000349	FBrf0235210		TOOL DATA from: FBal0326334
+FBti0186936_cas	carries_tool	FBto0000349	FBrf0235210		TOOL DATA from: FBal0326335
+FBti0186936_cas	tagged_with	FBto0000050	FBrf0235210		TOOL DATA from: FBal0326335
+FBti0186937_cas	carries_tool	FBto0000349	FBrf0235210		TOOL DATA from: FBal0326338
+FBti0186937_cas	tagged_with	FBto0000126	FBrf0235210		TOOL DATA from: FBal0326338
+FBti0187205_cas	tagged_with	FBto0000079	FBrf0231243		TOOL DATA from: FBal0326557
+FBti0187205_cas	tagged_with	FBto0000104	FBrf0231243		TOOL DATA from: FBal0326557
+FBti0187206_cas	carries_tool	FBto0000349	FBrf0235936		TOOL DATA from: FBal0326563
+FBti0187206_cas	tagged_with	FBto0000126	FBrf0235936		TOOL DATA from: FBal0326563
+FBti0187207_cas	carries_tool	FBto0000349	FBrf0235936		TOOL DATA from: FBal0326564
+FBti0187208_cas	carries_tool	FBto0000349	FBrf0235936		TOOL DATA from: FBal0326565
+FBti0187208_cas	tagged_with	FBto0000050	FBrf0235936		TOOL DATA from: FBal0326565
+FBti0187209_cas	carries_tool	FBto0000349	FBrf0235590		TOOL DATA from: FBal0323541
+FBti0187210_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326569
+FBti0187210_cas	carries_tool	FBto0000356	FBrf0229826		TOOL DATA from: FBal0326569
+FBti0187211_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326570
+FBti0187211_cas	carries_tool	FBto0000356	FBrf0229826		TOOL DATA from: FBal0326570
+FBti0187212_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326571
+FBti0187213_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326572
+FBti0187214_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326573
+FBti0187215_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326574
+FBti0187216_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326575
+FBti0187230_cas	tagged_with	FBto0000027	FBrf0231133		TOOL DATA from: FBal0326609
+FBti0187233_cas	tagged_with	FBto0000031	FBrf0230799		TOOL DATA from: FBal0326612
+FBti0187234_cas	carries_tool	FBto0000349	FBrf0235055		TOOL DATA from: FBal0326664
+FBti0187234_cas	tagged_with	FBto0000031	FBrf0235055		TOOL DATA from: FBal0326664
+FBti0187235_cas				FTA: unable to add tool information from FBal0326665 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0187236_cas				FTA: unable to add tool information from FBal0326684 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0187237_cas	tagged_with	FBto0000031	FBrf0230432		TOOL DATA from: FBal0326685
+FBti0187240_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128005
+FBti0187240_cas	tool_uses	gene trap			TOOL DATA from: FBtp0128005
+FBti0187287_cas				FTA: unable to add tool information from FBal0326705 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0187298_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326723
+FBti0187298_cas	carries_tool	FBto0000356	FBrf0235648		TOOL DATA from: FBal0326723
+FBti0187299_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326724
+FBti0187299_cas	carries_tool	FBto0000356	FBrf0235648		TOOL DATA from: FBal0326724
+FBti0187300_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326725
+FBti0187301_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326726
+FBti0187302_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326727
+FBti0187303_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326728
+FBti0187304_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326729
+FBti0187305_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326730
+FBti0187306_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326731
+FBti0187307_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326732
+FBti0187307_cas	tagged_with	FBto0000118	FBrf0235648		TOOL DATA from: FBal0326732
+FBti0187308_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326733
+FBti0187308_cas	tagged_with	FBto0000118	FBrf0235648		TOOL DATA from: FBal0326733
+FBti0187309_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326734
+FBti0187309_cas	tagged_with	FBto0000118	FBrf0235648		TOOL DATA from: FBal0326734
+FBti0187310_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326741
+FBti0187311_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326742
+FBti0187312_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326743
+FBti0187313_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326744
+FBti0187314_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326745
+FBti0187315_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326746
+FBti0187316_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326747
+FBti0187317_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326748
+FBti0187318_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326749
+FBti0187319_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326750
+FBti0187320_cas	has_reg_region	FBto0000180			TOOL DATA from: FBtp0117267
+FBti0187320_cas	tool_uses	misexpression element			TOOL DATA from: FBtp0117267
+FBti0187320_cas	carries_tool	FBto0000349	FBrf0235396		TOOL DATA from: FBal0326765
+FBti0187321_cas	carries_tool	FBto0000349	FBrf0235396		TOOL DATA from: FBal0326766
+FBti0187332_cas				FTA: unable to add tool information from FBal0326958 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0187333_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0187333_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0187365_cas	carries_tool	FBto0000318	FBrf0235353		TOOL DATA from: FBal0327010
+FBti0187365_cas	tagged_with	FBto0000077	FBrf0235353		TOOL DATA from: FBal0327010
+FBti0187369_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0187369_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0187374_cas	tagged_with	FBto0000009	FBrf0233082		TOOL DATA from: FBal0327048
+FBti0187375_cas	tagged_with	FBto0000009	FBrf0233082		TOOL DATA from: FBal0327049
+FBti0187376_cas	tagged_with	FBto0000009	FBrf0233082		TOOL DATA from: FBal0327050
+FBti0187401_cas	tagged_with	FBto0000027	FBrf0235933		TOOL DATA from: FBal0327217
+FBti0187478_cas	tagged_with	FBto0000079	FBrf0210059		TOOL DATA from: FBal0242713
+FBti0187483_cas	carries_tool	FBto0000349	FBrf0223774		TOOL DATA from: FBal0327577
+FBti0187483_cas	tagged_with	FBto0000093	FBrf0223774		TOOL DATA from: FBal0327577
+FBti0187484_cas	carries_tool	FBto0000349	FBrf0223774		TOOL DATA from: FBal0327578
+FBti0187484_cas	tagged_with	FBto0000093	FBrf0223774		TOOL DATA from: FBal0327578
+FBti0187492_cas	carries_tool	FBto0000349	FBrf0235096		TOOL DATA from: FBal0327603
+FBti0187492_cas	tagged_with	FBto0000027	FBrf0235096		TOOL DATA from: FBal0327603
+FBti0187492_cas	tagged_with	FBto0000307	FBrf0235096		TOOL DATA from: FBal0327603
+FBti0187606_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0187606_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0194879_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335391
+FBti0194879_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335391
+FBti0194879_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335391
+FBti0194880_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335394
+FBti0194880_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335394
+FBti0194880_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335394
+FBti0194881_cas				FTA: unable to add tool information from FBal0335395 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194882_cas				FTA: unable to add tool information from FBal0335397 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194884_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335400
+FBti0194884_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335400
+FBti0194884_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335400
+FBti0194885_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335402
+FBti0194885_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335402
+FBti0194885_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335402
+FBti0194886_cas				FTA: unable to add tool information from FBal0335403 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194887_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335405
+FBti0194887_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335405
+FBti0194887_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335405
+FBti0194888_cas				FTA: unable to add tool information from FBal0335406 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194889_cas				FTA: unable to add tool information from FBal0335407 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194890_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335408
+FBti0194890_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335408
+FBti0194890_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335408
+FBti0194891_cas				FTA: unable to add tool information from FBal0335409 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194892_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335410
+FBti0194892_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335410
+FBti0194892_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335410
+FBti0194893_cas				FTA: unable to add tool information from FBal0335412 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194894_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335414
+FBti0194894_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335414
+FBti0194894_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335414
+FBti0194895_cas				FTA: unable to add tool information from FBal0335415 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194896_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335417
+FBti0194896_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335417
+FBti0194896_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335417
+FBti0194897_cas				FTA: unable to add tool information from FBal0335418 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194898_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335420
+FBti0194898_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335420
+FBti0194898_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335420
+FBti0195115_cas				FTA: unable to add tool information from FBal0335646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195143_cas				FTA: unable to add tool information from FBal0335708 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195148_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335733
+FBti0195148_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335737
+FBti0195148_cas	tagged_with	FBto0000076	FBrf0236011		TOOL DATA from: FBal0335737
+FBti0195149_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335734
+FBti0195149_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335738
+FBti0195149_cas	tagged_with	FBto0000076	FBrf0236011		TOOL DATA from: FBal0335738
+FBti0195150_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335735
+FBti0195150_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335739
+FBti0195150_cas	tagged_with	FBto0000076	FBrf0236011		TOOL DATA from: FBal0335739
+FBti0195151_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335736
+FBti0195151_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335740
+FBti0195151_cas	tagged_with	FBto0000076	FBrf0236011		TOOL DATA from: FBal0335740
+FBti0195509_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0195509_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0195509_cas	carries_tool	FBto0000349	FBrf0236381		TOOL DATA from: FBal0336285
+FBti0195509_cas	carries_tool	FBto0000349	FBrf0236381		TOOL DATA from: FBal0338392
+FBti0195675_cas				FTA: unable to add tool information from FBal0336599 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195677_cas	carries_tool	FBto0000349	FBrf0228397		TOOL DATA from: FBal0336602
+FBti0195677_cas	carries_tool	FBto0000356	FBrf0228397		TOOL DATA from: FBal0336602
+FBti0195678_cas	encodes_tool	FBto0000140			TOOL DATA from: FBtp0128008
+FBti0195678_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128008
+FBti0195689_cas				FTA: unable to add tool information from FBal0336630 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195700_cas	tagged_with	FBto0000048	FBrf0236304		TOOL DATA from: FBal0336671
+FBti0195703_cas	tagged_with	FBto0000093	FBrf0236304		TOOL DATA from: FBal0336674
+FBti0195704_cas	tagged_with	FBto0000077	FBrf0236304		TOOL DATA from: FBal0336675
+FBti0195705_cas	tagged_with	FBto0000048	FBrf0236304		TOOL DATA from: FBal0336676
+FBti0195706_cas	tagged_with	FBto0000048	FBrf0236304		TOOL DATA from: FBal0336677
+FBti0195739_cas	tagged_with	FBto0000031	FBrf0237362		TOOL DATA from: FBal0336721
+FBti0195937_cas	carries_tool	FBto0000349	FBrf0237099		TOOL DATA from: FBal0336933
+FBti0195938_cas	carries_tool	FBto0000349	FBrf0237099		TOOL DATA from: FBal0325865
+FBti0195939_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0195939_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0195939_cas	carries_tool	FBto0000349	FBrf0237308		TOOL DATA from: FBal0336935
+FBti0195939_cas	carries_tool	FBto0000349	FBrf0237308		TOOL DATA from: FBal0336938
+FBti0195940_cas	carries_tool	FBto0000349	FBrf0237308		TOOL DATA from: FBal0336936
+FBti0195950_cas				FTA: unable to add tool information from FBal0305166 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195951_cas	carries_tool	FBto0000349	FBrf0221715		TOOL DATA from: FBal0305165
+FBti0195951_cas	carries_tool	FBto0000356	FBrf0221715		TOOL DATA from: FBal0305165
+FBti0195955_cas	carries_tool	FBto0000356	FBrf0229921		TOOL DATA from: FBal0317152
+FBti0195959_cas	carries_tool	FBto0000349	FBrf0205704		TOOL DATA from: FBal0264687
+FBti0196133_cas	tagged_with	FBto0000076	FBrf0237868		TOOL DATA from: FBal0337130
+FBti0196134_cas	tagged_with	FBto0000093	FBrf0237868		TOOL DATA from: FBal0337131
+FBti0196135_cas	tagged_with	FBto0000076	FBrf0237869		TOOL DATA from: FBal0337132
+FBti0196565_cas	tagged_with	FBto0000093	FBrf0237716		TOOL DATA from: FBal0337832
+FBti0196566_cas				FTA: unable to add tool information from FBal0337839 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0196567_cas	carries_tool	FBto0000349	FBrf0237630		TOOL DATA from: FBal0337847
+FBti0196567_cas	tagged_with	FBto0000063	FBrf0237630		TOOL DATA from: FBal0337847
+FBti0196568_cas	carries_tool	FBto0000349	FBrf0237630		TOOL DATA from: FBal0337848
+FBti0196568_cas	tagged_with	FBto0000118	FBrf0237630		TOOL DATA from: FBal0337848
+FBti0196569_cas	carries_tool	FBto0000349	FBrf0237630		TOOL DATA from: FBal0337849
+FBti0196569_cas	tagged_with	FBto0000118	FBrf0237630		TOOL DATA from: FBal0337849
+FBti0196589_cas	carries_tool	FBto0000349	FBrf0237104		TOOL DATA from: FBal0337891
+FBti0196590_cas	carries_tool	FBto0000349	FBrf0237104		TOOL DATA from: FBal0337892
+FBti0196634_cas	tagged_with	FBto0000027	FBrf0236131		TOOL DATA from: FBal0337945
+FBti0196641_cas	tagged_with	FBto0000031	FBrf0235878		TOOL DATA from: FBal0337951
+FBti0196646_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0196646_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0196658_cas	carries_tool	FBto0000349	FBrf0237501		TOOL DATA from: FBal0338001
+FBti0196659_cas	tagged_with	FBto0000063	FBrf0237501		TOOL DATA from: FBal0338002
+FBti0196693_cas				FTA: unable to add tool information from FBal0338099 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0197170_cas				FTA: unable to add tool information from FBal0338153 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0197292_cas	carries_tool	FBto0000349	FBrf0232176		TOOL DATA from: FBal0338155
+FBti0197292_cas	tagged_with	FBto0000102	FBrf0232176		TOOL DATA from: FBal0338155
+FBti0197293_cas	carries_tool	FBto0000349	FBrf0232176		TOOL DATA from: FBal0338156
+FBti0197293_cas	tagged_with	FBto0000102	FBrf0232176		TOOL DATA from: FBal0338156
+FBti0199344_cas	tagged_with	FBto0000027	FBrf0238107		TOOL DATA from: FBal0340475
+FBti0199344_cas	tagged_with	FBto0000087	FBrf0238107		TOOL DATA from: FBal0340475
+FBti0199344_cas	tagged_with	FBto0000299	FBrf0238107		TOOL DATA from: FBal0340475
+FBti0199345_cas	tagged_with	FBto0000027	FBrf0238107		TOOL DATA from: FBal0340479
+FBti0199345_cas	tagged_with	FBto0000087	FBrf0238107		TOOL DATA from: FBal0340479
+FBti0199345_cas	tagged_with	FBto0000299	FBrf0238107		TOOL DATA from: FBal0340479
+FBti0199346_cas	tagged_with	FBto0000027	FBrf0238107		TOOL DATA from: FBal0340494
+FBti0199346_cas	tagged_with	FBto0000087	FBrf0238107		TOOL DATA from: FBal0340494
+FBti0199346_cas	tagged_with	FBto0000299	FBrf0238107		TOOL DATA from: FBal0340494
+FBti0199347_cas	tagged_with	FBto0000027	FBrf0238107		TOOL DATA from: FBal0340496
+FBti0199347_cas	tagged_with	FBto0000087	FBrf0238107		TOOL DATA from: FBal0340496
+FBti0199347_cas	tagged_with	FBto0000299	FBrf0238107		TOOL DATA from: FBal0340496
+FBti0199495_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0199495_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0199496_cas	encodes_tool	FBto0000063			TOOL DATA from: FBtp0112818
+FBti0199496_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0112818
+FBti0199500_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0199500_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0199536_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0199536_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0199536_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0340857
+FBti0199536_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0340858
+FBti0199537_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0340859
+FBti0199537_cas	tagged_with	FBto0000031	FBrf0239978		TOOL DATA from: FBal0340859
+FBti0199701_cas	tagged_with	FBto0000076	FBrf0238411		TOOL DATA from: FBal0341184
+FBti0200064_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341589
+FBti0200065_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341590
+FBti0200066_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341591
+FBti0200067_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341592
+FBti0200069_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341594
+FBti0200075_cas	tagged_with	FBto0000076	FBrf0239826		TOOL DATA from: FBal0341600
+FBti0200077_cas	tagged_with	FBto0000076	FBrf0239826		TOOL DATA from: FBal0341602
+FBti0200079_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341604
+FBti0200124_cas				FTA: unable to add tool information from FBal0341667 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0200149_cas	tagged_with	FBto0000027	FBrf0238077		TOOL DATA from: FBal0341720
+FBti0200436_cas	carries_tool	FBto0000349	FBrf0168001		TOOL DATA from: FBal0151319
+FBti0200437_cas	carries_tool	FBto0000349	FBrf0168001		TOOL DATA from: FBal0151318
+FBti0200438_cas	carries_tool	FBto0000349	FBrf0168001		TOOL DATA from: FBal0151317
+FBti0200439_cas	carries_tool	FBto0000349	FBrf0168001		TOOL DATA from: FBal0151316
+FBti0200474_cas	carries_tool	FBto0000349	FBrf0195007		TOOL DATA from: FBal0193352
+FBti0200475_cas	carries_tool	FBto0000349	FBrf0195007		TOOL DATA from: FBal0193354
+FBti0200476_cas	carries_tool	FBto0000349	FBrf0195007		TOOL DATA from: FBal0193353
+FBti0200485_cas	carries_tool	FBto0000349	FBrf0205704		TOOL DATA from: FBal0264685
+FBti0200494_cas	tagged_with	FBto0000093	FBrf0239943		TOOL DATA from: FBal0342156
+FBti0201288_cas	tagged_with	FBto0000063	FBrf0239562		TOOL DATA from: FBal0343279
+FBti0201289_cas	tagged_with	FBto0000099	FBrf0239562		TOOL DATA from: FBal0343281
+FBti0201290_cas	tagged_with	FBto0000063	FBrf0239562		TOOL DATA from: FBal0343282
+FBti0201291_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0201291_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0201293_cas	tagged_with	FBto0000027	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201293_cas	tagged_with	FBto0000076	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201293_cas	tagged_with	FBto0000088	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201293_cas	tagged_with	FBto0000287	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201293_cas	tagged_with	FBto0000341	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201400_cas	tagged_with	FBto0000027	FBrf0239362		TOOL DATA from: FBal0343422
+FBti0201401_cas	tagged_with	FBto0000031	FBrf0238947		TOOL DATA from: FBal0343435
+FBti0201402_cas	tagged_with	FBto0000031	FBrf0238947		TOOL DATA from: FBal0343436
+FBti0201403_cas	tagged_with	FBto0000031	FBrf0238947		TOOL DATA from: FBal0343437
+FBti0201418_cas	tagged_with	FBto0000079	FBrf0238295		TOOL DATA from: FBal0343477
+FBti0201419_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0201419_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0201419_cas	carries_tool	FBto0000349	FBrf0238110		TOOL DATA from: FBal0343484
+FBti0201423_cas	tagged_with	FBto0000118	FBrf0238554		TOOL DATA from: FBal0343494
+FBti0201424_cas	tagged_with	FBto0000031	FBrf0238554		TOOL DATA from: FBal0343495
+FBti0201616_cas				FTA: unable to add tool information from FBal0343772 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0201617_cas				FTA: unable to add tool information from FBal0343773 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0201620_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0201620_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0201620_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0343779
+FBti0201620_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0343780
+FBti0201620_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0343780
+FBti0201624_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0201624_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0201625_cas	tagged_with	FBto0000118	FBrf0233664		TOOL DATA from: FBal0343784
+FBti0201627_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0201627_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0201675_cas	carries_tool	FBto0000349	FBrf0235164		TOOL DATA from: FBal0343834
+FBti0201676_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0201676_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0201762_cas	tagged_with	FBto0000093	FBrf0240113		TOOL DATA from: FBal0343993
+FBti0201817_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0116623
+FBti0201817_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0116623
+FBti0201834_cas	tagged_with	FBto0000031	FBrf0238979		TOOL DATA from: FBal0344142
+FBti0201835_cas	carries_tool	FBto0000349	FBrf0238979		TOOL DATA from: FBal0344143
+FBti0201835_cas	tagged_with	FBto0000375	FBrf0238979		TOOL DATA from: FBal0344143
+FBti0201847_cas				FTA: unable to add tool information from FBal0344213 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0201848_cas	tagged_with	FBto0000027	FBrf0239135		TOOL DATA from: FBal0344225
+FBti0201849_cas	tagged_with	FBto0000027	FBrf0239006		TOOL DATA from: FBal0344227
+FBti0201850_cas	tagged_with	FBto0000027	FBrf0239006		TOOL DATA from: FBal0344228
+FBti0202051_cas	tagged_with	FBto0000079	FBrf0238006		TOOL DATA from: FBal0344449
+FBti0202058_cas	tagged_with	FBto0000375	FBrf0238867		TOOL DATA from: FBal0344479
+FBti0202074_cas	tagged_with	FBto0000027	FBrf0219618		TOOL DATA from: FBal0344517
+FBti0202076_cas				FTA: unable to add tool information from FBal0344556 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202095_cas				FTA: unable to add tool information from FBal0344599 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202096_cas	tagged_with	FBto0000118	FBrf0238804		TOOL DATA from: FBal0344600
+FBti0202099_cas	tagged_with	FBto0000063	FBrf0240552		TOOL DATA from: FBal0344640
+FBti0202100_cas	tagged_with	FBto0000076	FBrf0240552		TOOL DATA from: FBal0344641
+FBti0202102_cas				FTA: unable to add tool information from FBal0344650 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202113_cas	tagged_with	FBto0000070	FBrf0239381		TOOL DATA from: FBal0344708
+FBti0202114_cas	tagged_with	FBto0000070	FBrf0239381		TOOL DATA from: FBal0344709
+FBti0202123_cas	tagged_with	FBto0000070	FBrf0239381		TOOL DATA from: FBal0344718
+FBti0202141_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0202141_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0202206_cas	carries_tool	FBto0000349	FBrf0235475		TOOL DATA from: FBal0344892
+FBti0202206_cas	tagged_with	FBto0000063	FBrf0235475		TOOL DATA from: FBal0344892
+FBti0202207_cas	carries_tool	FBto0000349	FBrf0235475		TOOL DATA from: FBal0344893
+FBti0202207_cas	tagged_with	FBto0000063	FBrf0235475		TOOL DATA from: FBal0344893
+FBti0202224_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0202224_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0202224_cas	carries_tool	FBto0000349	FBrf0240803		TOOL DATA from: FBal0344966
+FBti0202224_cas	carries_tool	FBto0000349	FBrf0240803		TOOL DATA from: FBal0344970
+FBti0202225_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0202225_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0202225_cas	carries_tool	FBto0000349	FBrf0240803		TOOL DATA from: FBal0344967
+FBti0202225_cas	carries_tool	FBto0000349	FBrf0240803		TOOL DATA from: FBal0344968
+FBti0202231_cas				FTA: unable to add tool information from FBal0345003 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202232_cas				FTA: unable to add tool information from FBal0345004 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202236_cas	tagged_with	FBto0000063	FBrf0240615		TOOL DATA from: FBal0345011
+FBti0202237_cas	tagged_with	FBto0000118	FBrf0240615		TOOL DATA from: FBal0345014
+FBti0202241_cas				FTA: unable to add tool information from FBal0345026 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202242_cas	carries_tool	FBto0000349	FBrf0237568		TOOL DATA from: FBal0345027
+FBti0202243_cas	carries_tool	FBto0000349	FBrf0237568		TOOL DATA from: FBal0345028
+FBti0202243_cas	tagged_with	FBto0000031	FBrf0237568		TOOL DATA from: FBal0345028
+FBti0202244_cas				FTA: unable to add tool information from FBal0345029 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202245_cas				FTA: unable to add tool information from FBal0345030 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202246_cas				FTA: unable to add tool information from FBal0345031 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202247_cas	carries_tool	FBto0000349	FBrf0237568		TOOL DATA from: FBal0345032
+FBti0202248_cas				FTA: unable to add tool information from FBal0345033 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202249_cas				FTA: unable to add tool information from FBal0345034 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202251_cas	carries_tool	FBto0000356	FBrf0240135		TOOL DATA from: FBal0345042
+FBti0202267_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0202267_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0202267_cas	carries_tool	FBto0000320	FBrf0238358		TOOL DATA from: FBal0345092
+FBti0202267_cas	carries_tool	FBto0000349	FBrf0238358		TOOL DATA from: FBal0345092
+FBti0202267_cas	carries_tool	FBto0000356	FBrf0238358		TOOL DATA from: FBal0345092
+FBti0202267_cas	carries_tool	FBto0000320	FBrf0238358		TOOL DATA from: FBal0345094
+FBti0202267_cas	carries_tool	FBto0000349	FBrf0238358		TOOL DATA from: FBal0345094
+FBti0202267_cas	carries_tool	FBto0000356	FBrf0238358		TOOL DATA from: FBal0345094
+FBti0202267_cas	tagged_with	FBto0000205	FBrf0238358		TOOL DATA from: FBal0345094
+FBti0202270_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0202270_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0202270_cas	carries_tool	FBto0000349	FBrf0240566		TOOL DATA from: FBal0345145
+FBti0202270_cas	carries_tool	FBto0000356	FBrf0240566		TOOL DATA from: FBal0345145
+FBti0202270_cas	carries_tool	FBto0000349	FBrf0240566		TOOL DATA from: FBal0345148
+FBti0202270_cas	carries_tool	FBto0000356	FBrf0240566		TOOL DATA from: FBal0345148
+FBti0202271_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0202271_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0202272_cas	carries_tool	FBto0000349	FBrf0240422		TOOL DATA from: FBal0345149
+FBti0202273_cas	carries_tool	FBto0000349	FBrf0240422		TOOL DATA from: FBal0345150
+FBti0202273_cas	tagged_with	FBto0000031	FBrf0240422		TOOL DATA from: FBal0345150
+FBti0202276_cas	tagged_with	FBto0000093	FBrf0238737		TOOL DATA from: FBal0345155
+FBti0202277_cas	tagged_with	FBto0000093	FBrf0238737		TOOL DATA from: FBal0345156
+FBti0202278_cas				FTA: unable to add tool information from FBal0345159 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202588_cas				FTA: unable to add tool information from FBal0345503 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202599_cas	tagged_with	FBto0000031	FBrf0241227		TOOL DATA from: FBal0345526
+FBti0202625_cas	carries_tool	FBto0000349	FBrf0241173		TOOL DATA from: FBal0345565
+FBti0202626_cas	carries_tool	FBto0000349	FBrf0241173		TOOL DATA from: FBal0345568
+FBti0202626_cas	carries_tool	FBto0000356	FBrf0241173		TOOL DATA from: FBal0345568
+FBti0202627_cas	carries_tool	FBto0000349	FBrf0241173		TOOL DATA from: FBal0345569
+FBti0202627_cas	tagged_with	FBto0000118	FBrf0241173		TOOL DATA from: FBal0345569
+FBti0202629_cas	tagged_with	FBto0000027	FBrf0240126		TOOL DATA from: FBal0345598
+FBti0202649_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345672
+FBti0202649_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345672
+FBti0202649_cas	carries_tool	FBto0000356	FBrf0229738		TOOL DATA from: FBal0345672
+FBti0202650_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345673
+FBti0202650_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345673
+FBti0202651_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345674
+FBti0202651_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345674
+FBti0202652_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345675
+FBti0202652_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345675
+FBti0202653_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345676
+FBti0202653_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345676
+FBti0202938_cas				FTA: unable to add tool information from FBal0346048 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202946_cas				FTA: unable to add tool information from FBal0346063 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202947_cas				FTA: unable to add tool information from FBal0346064 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202948_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0202948_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0202972_cas	carries_tool	FBto0000356	FBrf0226270		TOOL DATA from: FBal0346121
+FBti0202974_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0202974_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0202976_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0202976_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0202979_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346130
+FBti0202979_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346130
+FBti0202980_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346131
+FBti0202980_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346131
+FBti0202981_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346132
+FBti0202981_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346132
+FBti0202982_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346133
+FBti0202982_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346133
+FBti0202983_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346134
+FBti0202983_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346134
+FBti0202984_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346135
+FBti0202984_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346135
+FBti0202985_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346136
+FBti0202985_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346136
+FBti0202986_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346137
+FBti0202986_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346137
+FBti0202987_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0202987_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0202987_cas				FTA: unable to add tool information from FBal0346145 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203001_cas	carries_tool	FBto0000318	FBrf0241011		TOOL DATA from: FBal0346216
+FBti0203001_cas	carries_tool	FBto0000349	FBrf0241011		TOOL DATA from: FBal0346216
+FBti0203015_cas				FTA: unable to add tool information from FBal0346245 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203021_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0203021_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0203026_cas				FTA: unable to add tool information from FBal0346268 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203027_cas	carries_tool	FBto0000349	FBrf0241193		TOOL DATA from: FBal0346271
+FBti0203027_cas	carries_tool	FBto0000356	FBrf0241193		TOOL DATA from: FBal0346271
+FBti0203031_cas				FTA: unable to add tool information from FBal0346301 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203032_cas				FTA: unable to add tool information from FBal0346304 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203033_cas	carries_tool	FBto0000349	FBrf0241758		TOOL DATA from: FBal0346308
+FBti0203034_cas	carries_tool	FBto0000349	FBrf0231596		TOOL DATA from: FBal0346317
+FBti0203034_cas	tagged_with	FBto0000027	FBrf0231596		TOOL DATA from: FBal0346317
+FBti0203073_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0203073_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0203297_cas				FTA: unable to add tool information from FBal0346658 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203303_cas	tagged_with	FBto0000031	FBrf0236602		TOOL DATA from: FBal0346674
+FBti0203331_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0203331_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0203343_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346789
+FBti0203343_cas	tagged_with	FBto0000077	FBrf0241707		TOOL DATA from: FBal0346789
+FBti0203344_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346790
+FBti0203345_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346791
+FBti0203345_cas	tagged_with	FBto0000031	FBrf0241707		TOOL DATA from: FBal0346791
+FBti0203346_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346792
+FBti0203347_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346793
+FBti0203347_cas	tagged_with	FBto0000118	FBrf0241707		TOOL DATA from: FBal0346793
+FBti0203348_cas	carries_tool	FBto0000318	FBrf0241707		TOOL DATA from: FBal0346794
+FBti0203348_cas	carries_tool	FBto0000345	FBrf0241707		TOOL DATA from: FBal0346794
+FBti0203349_cas	carries_tool	FBto0000318	FBrf0241707		TOOL DATA from: FBal0346795
+FBti0203349_cas	carries_tool	FBto0000345	FBrf0241707		TOOL DATA from: FBal0346795
+FBti0203349_cas	tagged_with	FBto0000077	FBrf0241707		TOOL DATA from: FBal0346795
+FBti0203350_cas	carries_tool	FBto0000318	FBrf0241707		TOOL DATA from: FBal0346796
+FBti0203350_cas	carries_tool	FBto0000345	FBrf0241707		TOOL DATA from: FBal0346796
+FBti0203351_cas	carries_tool	FBto0000318	FBrf0241707		TOOL DATA from: FBal0346797
+FBti0203351_cas	carries_tool	FBto0000345	FBrf0241707		TOOL DATA from: FBal0346797
+FBti0203351_cas	tagged_with	FBto0000076	FBrf0241707		TOOL DATA from: FBal0346797
+FBti0203370_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0203370_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0203370_cas	carries_tool	FBto0000320	FBrf0241288		TOOL DATA from: FBal0346822
+FBti0203370_cas	carries_tool	FBto0000349	FBrf0241288		TOOL DATA from: FBal0346822
+FBti0203370_cas	carries_tool	FBto0000356	FBrf0241288		TOOL DATA from: FBal0346822
+FBti0203370_cas	carries_tool	FBto0000320	FBrf0241288		TOOL DATA from: FBal0346823
+FBti0203370_cas	carries_tool	FBto0000349	FBrf0241288		TOOL DATA from: FBal0346823
+FBti0203370_cas	carries_tool	FBto0000356	FBrf0241288		TOOL DATA from: FBal0346823
+FBti0203370_cas	tagged_with	FBto0000205	FBrf0241288		TOOL DATA from: FBal0346823
+FBti0203385_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0203385_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0203386_cas				FTA: unable to add tool information from FBal0346866 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203387_cas	tagged_with	FBto0000063	FBrf0241405		TOOL DATA from: FBal0346867
+FBti0203394_cas	carries_tool	FBto0000349	FBrf0241753		TOOL DATA from: FBal0346876
+FBti0203395_cas				FTA: unable to add tool information from FBal0346877 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203396_cas				FTA: unable to add tool information from FBal0346880 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203397_cas	carries_tool	FBto0000349	FBrf0241739		TOOL DATA from: FBal0346881
+FBti0203397_cas	carries_tool	FBto0000356	FBrf0241739		TOOL DATA from: FBal0346881
+FBti0203414_cas				FTA: unable to add tool information from FBal0302673 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203415_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0203415_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0203416_cas	carries_tool	FBto0000349	FBrf0241819		TOOL DATA from: FBal0346908
+FBti0203416_cas	carries_tool	FBto0000356	FBrf0241819		TOOL DATA from: FBal0346908
+FBti0203417_cas	carries_tool	FBto0000349	FBrf0241819		TOOL DATA from: FBal0346909
+FBti0203417_cas	carries_tool	FBto0000356	FBrf0241819		TOOL DATA from: FBal0346909
+FBti0203418_cas	carries_tool	FBto0000349	FBrf0241819		TOOL DATA from: FBal0346910
+FBti0203418_cas	carries_tool	FBto0000356	FBrf0241819		TOOL DATA from: FBal0346910
+FBti0203420_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0203420_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0203420_cas	carries_tool	FBto0000349	FBrf0241661		TOOL DATA from: FBal0346914
+FBti0203420_cas	carries_tool	FBto0000349	FBrf0241661		TOOL DATA from: FBal0346916
+FBti0203421_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0203421_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0203421_cas	carries_tool	FBto0000349	FBrf0241661		TOOL DATA from: FBal0346917
+FBti0203421_cas	carries_tool	FBto0000349	FBrf0241661		TOOL DATA from: FBal0346919
+FBti0203646_cas	tagged_with	FBto0000014	FBrf0241249		TOOL DATA from: FBal0347211
+FBti0203850_cas	tagged_with	FBto0000031	FBrf0241857		TOOL DATA from: FBal0347457
+FBti0203851_cas	tagged_with	FBto0000031	FBrf0241857		TOOL DATA from: FBal0347459
+FBti0203864_cas	carries_tool	FBto0000349	FBrf0241779		TOOL DATA from: FBal0347472
+FBti0203864_cas	tagged_with	FBto0000031	FBrf0241779		TOOL DATA from: FBal0347472
+FBti0203866_cas				FTA: unable to add tool information from FBal0347482 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203867_cas	carries_tool	FBto0000349	FBrf0241769		TOOL DATA from: FBal0347483
+FBti0203912_cas	tagged_with	FBto0000063	FBrf0241908		TOOL DATA from: FBal0347551
+FBti0203913_cas	tagged_with	FBto0000063	FBrf0241908		TOOL DATA from: FBal0347553
+FBti0203914_cas	tagged_with	FBto0000522	FBrf0241908		TOOL DATA from: FBal0347554
+FBti0203915_cas	tagged_with	FBto0000027	FBrf0241908		TOOL DATA from: FBal0347555
+FBti0203916_cas	tagged_with	FBto0000077	FBrf0241858		TOOL DATA from: FBal0347557
+FBti0203917_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347558
+FBti0203918_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347559
+FBti0203919_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347560
+FBti0203920_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347561
+FBti0203921_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347562
+FBti0203922_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347563
+FBti0203923_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347564
+FBti0203986_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0203986_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0204000_cas	tagged_with	FBto0000063	FBrf0241918		TOOL DATA from: FBal0348179
+FBti0204001_cas	tagged_with	FBto0000099	FBrf0241918		TOOL DATA from: FBal0348180
+FBti0204004_cas	tagged_with	FBto0000027	FBrf0241149		TOOL DATA from: FBal0348186
+FBti0204006_cas	carries_tool	FBto0000318	FBrf0240826		TOOL DATA from: FBal0348204
+FBti0204006_cas	tagged_with	FBto0000027	FBrf0240826		TOOL DATA from: FBal0348204
+FBti0204675_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0204675_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0204675_cas	carries_tool	FBto0000320	FBrf0230098		TOOL DATA from: FBal0349045
+FBti0204675_cas	carries_tool	FBto0000349	FBrf0230098		TOOL DATA from: FBal0349045
+FBti0204675_cas	carries_tool	FBto0000320	FBrf0230098		TOOL DATA from: FBal0349047
+FBti0204675_cas	carries_tool	FBto0000349	FBrf0230098		TOOL DATA from: FBal0349047
+FBti0204676_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0204676_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0204676_cas	carries_tool	FBto0000320	FBrf0230098		TOOL DATA from: FBal0349046
+FBti0204676_cas	carries_tool	FBto0000349	FBrf0230098		TOOL DATA from: FBal0349046
+FBti0204676_cas	carries_tool	FBto0000356	FBrf0230098		TOOL DATA from: FBal0349046
+FBti0204692_cas	tagged_with	FBto0000031	FBrf0239995		TOOL DATA from: FBal0349082
+FBti0204720_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0204720_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0204740_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0204740_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0204741_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0204741_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0204742_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0099203
+FBti0204742_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099203
+FBti0204762_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0204762_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0204762_cas	carries_tool	FBto0000320	FBrf0239741		TOOL DATA from: FBal0349248
+FBti0204762_cas	carries_tool	FBto0000349	FBrf0239741		TOOL DATA from: FBal0349248
+FBti0204762_cas	carries_tool	FBto0000356	FBrf0239741		TOOL DATA from: FBal0349248
+FBti0204766_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0204766_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0204767_cas	tagged_with	FBto0000077	FBrf0240603		TOOL DATA from: FBal0349269
+FBti0204799_cas	carries_tool	FBto0000349	FBrf0242560		TOOL DATA from: FBal0349321
+FBti0204800_cas	carries_tool	FBto0000349	FBrf0242560		TOOL DATA from: FBal0349322
+FBti0204801_cas	carries_tool	FBto0000349	FBrf0242560		TOOL DATA from: FBal0349323
+FBti0204802_cas				FTA: unable to add tool information from FBal0408254 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0204803_cas				FTA: unable to add tool information from FBal0349325 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0204805_cas	tagged_with	FBto0000076	FBrf0241107		TOOL DATA from: FBal0349331
+FBti0204805_cas	tagged_with	FBto0000126	FBrf0241107		TOOL DATA from: FBal0349331
+FBti0204806_cas	tagged_with	FBto0000044	FBrf0241107		TOOL DATA from: FBal0349332
+FBti0204806_cas	tagged_with	FBto0000076	FBrf0241107		TOOL DATA from: FBal0349332
+FBti0204807_cas	tagged_with	FBto0000044	FBrf0241107		TOOL DATA from: FBal0349333
+FBti0204807_cas	tagged_with	FBto0000076	FBrf0241107		TOOL DATA from: FBal0349333
+FBti0204971_cas	carries_tool	FBto0000318	FBrf0241626		TOOL DATA from: FBal0349509
+FBti0204974_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0140111
+FBti0204974_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140111
+FBti0204974_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349527
+FBti0204974_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0367427
+FBti0204975_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0204975_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0204975_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349526
+FBti0204975_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349544
+FBti0204976_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0204976_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0204976_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349537
+FBti0204976_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349545
+FBti0204977_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0204977_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0204977_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349522
+FBti0204977_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349539
+FBti0204978_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0204978_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0204978_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349529
+FBti0204978_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349540
+FBti0204979_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0204979_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0204979_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349533
+FBti0204979_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349541
+FBti0204980_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0204980_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0204980_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349536
+FBti0204980_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349542
+FBti0204981_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0204981_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0204981_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349538
+FBti0204981_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349543
+FBti0204982_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0204982_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0204982_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349530
+FBti0204982_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349546
+FBti0205017_cas				FTA: unable to add tool information from FBal0349586 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0205017_cas				FTA: unable to add tool information from FBal0349588 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0205257_cas	tagged_with	FBto0000027	FBrf0240858		TOOL DATA from: FBal0349885
+FBti0205257_cas	tagged_with	FBto0000307	FBrf0240858		TOOL DATA from: FBal0349885
+FBti0205258_cas	carries_tool	FBto0000349	FBrf0242466		TOOL DATA from: FBal0349888
+FBti0205259_cas	carries_tool	FBto0000349	FBrf0242466		TOOL DATA from: FBal0349889
+FBti0205260_cas	carries_tool	FBto0000349	FBrf0242466		TOOL DATA from: FBal0349890
+FBti0205550_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0205550_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0205580_cas				FTA: unable to add tool information from FBal0350400 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0206387_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351249
+FBti0206388_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351250
+FBti0206389_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351251
+FBti0206390_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351252
+FBti0206391_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351253
+FBti0206392_cas	tagged_with	FBto0000077	FBrf0242345		TOOL DATA from: FBal0351254
+FBti0206392_cas	tagged_with	FBto0000118	FBrf0242345		TOOL DATA from: FBal0351254
+FBti0206393_cas	tagged_with	FBto0000077	FBrf0242345		TOOL DATA from: FBal0351255
+FBti0206393_cas	tagged_with	FBto0000542	FBrf0242345		TOOL DATA from: FBal0351255
+FBti0206394_cas	tagged_with	FBto0000077	FBrf0242345		TOOL DATA from: FBal0351256
+FBti0206394_cas	tagged_with	FBto0000121	FBrf0242345		TOOL DATA from: FBal0351256
+FBti0206395_cas	tagged_with	FBto0000044	FBrf0242345		TOOL DATA from: FBal0351257
+FBti0206396_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351258
+FBti0206397_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351259
+FBti0206398_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351260
+FBti0206398_cas	tagged_with	FBto0000077	FBrf0242345		TOOL DATA from: FBal0351260
+FBti0206406_cas	tagged_with	FBto0000063	FBrf0242229		TOOL DATA from: FBal0351300
+FBti0206406_cas	tagged_with	FBto0000077	FBrf0242229		TOOL DATA from: FBal0351300
+FBti0206407_cas	tagged_with	FBto0000063	FBrf0242229		TOOL DATA from: FBal0351301
+FBti0206407_cas	tagged_with	FBto0000077	FBrf0242229		TOOL DATA from: FBal0351301
+FBti0206411_cas	carries_tool	FBto0000349	FBrf0241998		TOOL DATA from: FBal0351316
+FBti0206411_cas	carries_tool	FBto0000356	FBrf0241998		TOOL DATA from: FBal0351316
+FBti0206415_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0206415_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0206624_cas				FTA: unable to add tool information from FBal0351594 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0206631_cas				FTA: unable to add tool information from FBal0351610 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0206669_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0206669_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0206669_cas	carries_tool	FBto0000349	FBrf0242072		TOOL DATA from: FBal0351665
+FBti0206669_cas	carries_tool	FBto0000349	FBrf0242072		TOOL DATA from: FBal0351676
+FBti0206685_cas	carries_tool	FBto0000349	FBrf0242991		TOOL DATA from: FBal0351692
+FBti0206685_cas	carries_tool	FBto0000356	FBrf0242991		TOOL DATA from: FBal0351692
+FBti0206708_cas	tagged_with	FBto0000079	FBrf0242779		TOOL DATA from: FBal0351805
+FBti0206720_cas	carries_tool	FBto0000349	FBrf0241968		TOOL DATA from: FBal0351833
+FBti0206720_cas	carries_tool	FBto0000356	FBrf0241968		TOOL DATA from: FBal0351833
+FBti0206720_cas	carries_tool	FBto0000906	FBrf0241968		TOOL DATA from: FBal0351833
+FBti0206721_cas	tagged_with	FBto0000077	FBrf0241968		TOOL DATA from: FBal0351834
+FBti0206755_cas	tagged_with	FBto0000076	FBrf0242616		TOOL DATA from: FBal0351878
+FBti0206756_cas	tagged_with	FBto0000076	FBrf0242616		TOOL DATA from: FBal0351879
+FBti0206965_cas	tagged_with	FBto0000027	FBrf0242498		TOOL DATA from: FBal0352225
+FBti0206966_cas	tagged_with	FBto0000099	FBrf0242498		TOOL DATA from: FBal0352226
+FBti0206967_cas	carries_tool	FBto0000349	FBrf0237330		TOOL DATA from: FBal0352227
+FBti0206967_cas	tagged_with	FBto0000027	FBrf0237330		TOOL DATA from: FBal0352227
+FBti0206968_cas	carries_tool	FBto0000349	FBrf0237330		TOOL DATA from: FBal0352229
+FBti0206968_cas	tagged_with	FBto0000027	FBrf0237330		TOOL DATA from: FBal0352229
+FBti0206969_cas	carries_tool	FBto0000349	FBrf0237330		TOOL DATA from: FBal0352233
+FBti0206969_cas	tagged_with	FBto0000027	FBrf0237330		TOOL DATA from: FBal0352233
+FBti0206977_cas	carries_tool	FBto0000349	FBrf0242623		TOOL DATA from: FBal0352238
+FBti0206977_cas	tagged_with	FBto0000102	FBrf0242623		TOOL DATA from: FBal0352238
+FBti0206978_cas	carries_tool	FBto0000349	FBrf0242623		TOOL DATA from: FBal0352242
+FBti0206978_cas	tagged_with	FBto0000098	FBrf0242623		TOOL DATA from: FBal0352242
+FBti0207003_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0207003_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0207007_cas	carries_tool	FBto0000356	FBrf0243030		TOOL DATA from: FBal0352281
+FBti0207008_cas	tagged_with	FBto0000031	FBrf0243030		TOOL DATA from: FBal0352282
+FBti0207009_cas	carries_tool	FBto0000356	FBrf0243030		TOOL DATA from: FBal0352285
+FBti0207010_cas	tagged_with	FBto0000118	FBrf0243030		TOOL DATA from: FBal0352286
+FBti0207144_cas	carries_tool	FBto0000349	FBrf0243221		TOOL DATA from: FBal0352434
+FBti0207144_cas	carries_tool	FBto0000356	FBrf0243221		TOOL DATA from: FBal0352434
+FBti0207145_cas	tagged_with	FBto0000076	FBrf0243221		TOOL DATA from: FBal0352435
+FBti0207145_cas	tagged_with	FBto0000126	FBrf0243221		TOOL DATA from: FBal0352435
+FBti0207146_cas	carries_tool	FBto0000318	FBrf0243221		TOOL DATA from: FBal0352436
+FBti0207146_cas	tagged_with	FBto0000076	FBrf0243221		TOOL DATA from: FBal0352436
+FBti0207146_cas	tagged_with	FBto0000126	FBrf0243221		TOOL DATA from: FBal0352436
+FBti0207147_cas	carries_tool	FBto0000318	FBrf0243221		TOOL DATA from: FBal0352437
+FBti0207524_cas	tagged_with	FBto0000031	FBrf0243126		TOOL DATA from: FBal0353029
+FBti0207524_cas	tagged_with	FBto0000076	FBrf0243126		TOOL DATA from: FBal0353029
+FBti0207524_cas	tagged_with	FBto0000093	FBrf0243126		TOOL DATA from: FBal0353029
+FBti0207525_cas	tagged_with	FBto0000031	FBrf0243126		TOOL DATA from: FBal0353030
+FBti0207525_cas	tagged_with	FBto0000076	FBrf0243126		TOOL DATA from: FBal0353030
+FBti0207525_cas	tagged_with	FBto0000093	FBrf0243126		TOOL DATA from: FBal0353030
+FBti0207526_cas	tagged_with	FBto0000077	FBrf0243126		TOOL DATA from: FBal0353038
+FBti0207526_cas	tagged_with	FBto0000079	FBrf0243126		TOOL DATA from: FBal0353038
+FBti0207526_cas	tagged_with	FBto0000121	FBrf0243126		TOOL DATA from: FBal0353038
+FBti0207527_cas	tagged_with	FBto0000031	FBrf0243126		TOOL DATA from: FBal0353047
+FBti0207527_cas	tagged_with	FBto0000076	FBrf0243126		TOOL DATA from: FBal0353047
+FBti0207527_cas	tagged_with	FBto0000093	FBrf0243126		TOOL DATA from: FBal0353047
+FBti0207548_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0207548_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0207549_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0207549_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0207551_cas	tagged_with	FBto0000027	FBrf0243353		TOOL DATA from: FBal0353057
+FBti0207552_cas	tagged_with	FBto0000077	FBrf0243353		TOOL DATA from: FBal0353058
+FBti0207554_cas				FTA: unable to add tool information from FBal0353069 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0207555_cas	carries_tool	FBto0000349	FBrf0243149		TOOL DATA from: FBal0353070
+FBti0207556_cas	tagged_with	FBto0000031	FBrf0243169		TOOL DATA from: FBal0353071
+FBti0207559_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0207559_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0207559_cas				FTA: unable to add tool information from FBal0353075 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0207560_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0207560_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0207560_cas				FTA: unable to add tool information from FBal0353077 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0207607_cas				FTA: unable to add tool information from FBal0353149 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0207638_cas	tagged_with	FBto0000031	FBrf0243113		TOOL DATA from: FBal0353201
+FBti0207640_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353218
+FBti0207641_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353219
+FBti0207642_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353220
+FBti0207643_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353221
+FBti0207644_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353222
+FBti0207645_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353223
+FBti0207699_cas	tagged_with	FBto0000077	FBrf0243279		TOOL DATA from: FBal0353302
+FBti0207703_cas	carries_tool	FBto0000349	FBrf0242749		TOOL DATA from: FBal0353304
+FBti0207704_cas	carries_tool	FBto0000349	FBrf0243536		TOOL DATA from: FBal0353319
+FBti0207708_cas	tagged_with	FBto0000031	FBrf0242585		TOOL DATA from: FBal0353343
+FBti0207709_cas	tagged_with	FBto0000076	FBrf0243130		TOOL DATA from: FBal0353346
+FBti0207709_cas	tagged_with	FBto0000077	FBrf0243130		TOOL DATA from: FBal0353346
+FBti0207897_cas	tagged_with	FBto0000077	FBrf0242899		TOOL DATA from: FBal0353540
+FBti0207902_cas	tagged_with	FBto0000582	FBrf0242057		TOOL DATA from: FBal0353551
+FBti0207912_cas	tagged_with	FBto0000118	FBrf0243742		TOOL DATA from: FBal0353580
+FBti0209576_cas	tagged_with	FBto0000031	FBrf0222281		TOOL DATA from: FBal0287834
+FBti0209587_cas	carries_tool	FBto0000349	FBrf0236234		TOOL DATA from: FBal0355290
+FBti0209587_cas	tagged_with	FBto0000063	FBrf0236234		TOOL DATA from: FBal0355290
+FBti0209588_cas	carries_tool	FBto0000349	FBrf0236234		TOOL DATA from: FBal0355291
+FBti0209588_cas	tagged_with	FBto0000334	FBrf0236234		TOOL DATA from: FBal0355291
+FBti0209624_cas				FTA: unable to add tool information from FBal0355350 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209625_cas				FTA: unable to add tool information from FBal0355351 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209626_cas				FTA: unable to add tool information from FBal0355352 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209627_cas				FTA: unable to add tool information from FBal0355353 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209628_cas				FTA: unable to add tool information from FBal0355354 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209629_cas				FTA: unable to add tool information from FBal0355355 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209630_cas				FTA: unable to add tool information from FBal0355356 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209631_cas				FTA: unable to add tool information from FBal0355357 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209632_cas				FTA: unable to add tool information from FBal0355358 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209633_cas				FTA: unable to add tool information from FBal0355359 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209634_cas				FTA: unable to add tool information from FBal0355360 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209635_cas				FTA: unable to add tool information from FBal0355361 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209636_cas				FTA: unable to add tool information from FBal0355362 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209637_cas				FTA: unable to add tool information from FBal0355363 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209638_cas				FTA: unable to add tool information from FBal0355364 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209639_cas				FTA: unable to add tool information from FBal0355365 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209640_cas				FTA: unable to add tool information from FBal0355366 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209641_cas				FTA: unable to add tool information from FBal0355367 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209642_cas				FTA: unable to add tool information from FBal0355368 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209643_cas				FTA: unable to add tool information from FBal0355369 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209644_cas				FTA: unable to add tool information from FBal0355370 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209645_cas				FTA: unable to add tool information from FBal0355371 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209646_cas				FTA: unable to add tool information from FBal0355372 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209647_cas				FTA: unable to add tool information from FBal0355373 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209648_cas				FTA: unable to add tool information from FBal0355374 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209649_cas				FTA: unable to add tool information from FBal0355375 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209650_cas				FTA: unable to add tool information from FBal0355376 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209651_cas				FTA: unable to add tool information from FBal0355377 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209652_cas				FTA: unable to add tool information from FBal0355378 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209653_cas				FTA: unable to add tool information from FBal0355379 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209654_cas				FTA: unable to add tool information from FBal0355380 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209655_cas				FTA: unable to add tool information from FBal0355381 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209656_cas				FTA: unable to add tool information from FBal0355382 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209657_cas				FTA: unable to add tool information from FBal0355383 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209658_cas				FTA: unable to add tool information from FBal0355384 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209659_cas				FTA: unable to add tool information from FBal0355385 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209660_cas				FTA: unable to add tool information from FBal0355386 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209661_cas				FTA: unable to add tool information from FBal0355387 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209662_cas				FTA: unable to add tool information from FBal0355388 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209663_cas				FTA: unable to add tool information from FBal0355389 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209664_cas				FTA: unable to add tool information from FBal0355390 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209665_cas				FTA: unable to add tool information from FBal0355391 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209666_cas				FTA: unable to add tool information from FBal0355392 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209667_cas				FTA: unable to add tool information from FBal0355393 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209668_cas				FTA: unable to add tool information from FBal0355394 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209669_cas				FTA: unable to add tool information from FBal0355395 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209670_cas				FTA: unable to add tool information from FBal0355396 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209671_cas				FTA: unable to add tool information from FBal0355397 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209672_cas				FTA: unable to add tool information from FBal0355398 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209673_cas				FTA: unable to add tool information from FBal0355399 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209674_cas				FTA: unable to add tool information from FBal0355400 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209675_cas				FTA: unable to add tool information from FBal0355401 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209676_cas				FTA: unable to add tool information from FBal0355402 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209677_cas				FTA: unable to add tool information from FBal0355403 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209678_cas				FTA: unable to add tool information from FBal0355404 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209679_cas				FTA: unable to add tool information from FBal0355405 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209680_cas				FTA: unable to add tool information from FBal0355406 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209681_cas				FTA: unable to add tool information from FBal0355407 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209682_cas				FTA: unable to add tool information from FBal0355408 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209683_cas				FTA: unable to add tool information from FBal0355409 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209684_cas				FTA: unable to add tool information from FBal0355410 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209685_cas				FTA: unable to add tool information from FBal0355411 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209686_cas				FTA: unable to add tool information from FBal0355412 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209687_cas				FTA: unable to add tool information from FBal0355413 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209688_cas				FTA: unable to add tool information from FBal0355414 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209689_cas				FTA: unable to add tool information from FBal0355415 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209690_cas				FTA: unable to add tool information from FBal0355416 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209691_cas				FTA: unable to add tool information from FBal0355417 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209692_cas				FTA: unable to add tool information from FBal0355418 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209693_cas				FTA: unable to add tool information from FBal0355419 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209694_cas				FTA: unable to add tool information from FBal0355420 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209695_cas				FTA: unable to add tool information from FBal0355421 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209696_cas				FTA: unable to add tool information from FBal0355422 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209697_cas				FTA: unable to add tool information from FBal0355423 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209698_cas				FTA: unable to add tool information from FBal0355424 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209699_cas				FTA: unable to add tool information from FBal0355425 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209700_cas				FTA: unable to add tool information from FBal0355426 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209701_cas				FTA: unable to add tool information from FBal0355427 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209702_cas				FTA: unable to add tool information from FBal0355428 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209703_cas				FTA: unable to add tool information from FBal0355429 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209704_cas				FTA: unable to add tool information from FBal0355430 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209705_cas				FTA: unable to add tool information from FBal0355431 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209706_cas				FTA: unable to add tool information from FBal0355432 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209707_cas				FTA: unable to add tool information from FBal0355433 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209708_cas				FTA: unable to add tool information from FBal0355435 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209709_cas				FTA: unable to add tool information from FBal0355436 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209710_cas				FTA: unable to add tool information from FBal0355437 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209711_cas				FTA: unable to add tool information from FBal0355438 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209712_cas				FTA: unable to add tool information from FBal0355439 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209713_cas				FTA: unable to add tool information from FBal0355440 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209714_cas				FTA: unable to add tool information from FBal0355441 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209715_cas				FTA: unable to add tool information from FBal0355442 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209716_cas				FTA: unable to add tool information from FBal0355443 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209717_cas				FTA: unable to add tool information from FBal0355444 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209718_cas				FTA: unable to add tool information from FBal0355445 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209719_cas				FTA: unable to add tool information from FBal0355446 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209720_cas				FTA: unable to add tool information from FBal0355447 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209721_cas				FTA: unable to add tool information from FBal0355448 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209722_cas				FTA: unable to add tool information from FBal0355449 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209723_cas				FTA: unable to add tool information from FBal0355450 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209724_cas				FTA: unable to add tool information from FBal0355451 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209725_cas				FTA: unable to add tool information from FBal0355452 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209726_cas				FTA: unable to add tool information from FBal0355453 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209727_cas				FTA: unable to add tool information from FBal0355454 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209728_cas				FTA: unable to add tool information from FBal0355455 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209729_cas				FTA: unable to add tool information from FBal0355456 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209730_cas				FTA: unable to add tool information from FBal0355457 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209731_cas				FTA: unable to add tool information from FBal0355458 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209732_cas				FTA: unable to add tool information from FBal0355459 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209733_cas				FTA: unable to add tool information from FBal0355460 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209734_cas				FTA: unable to add tool information from FBal0355461 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209735_cas				FTA: unable to add tool information from FBal0355462 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209736_cas				FTA: unable to add tool information from FBal0355463 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209737_cas				FTA: unable to add tool information from FBal0355464 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209738_cas				FTA: unable to add tool information from FBal0355465 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209739_cas				FTA: unable to add tool information from FBal0355466 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209740_cas				FTA: unable to add tool information from FBal0355467 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209741_cas				FTA: unable to add tool information from FBal0355468 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209742_cas				FTA: unable to add tool information from FBal0355469 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209743_cas				FTA: unable to add tool information from FBal0355470 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209744_cas				FTA: unable to add tool information from FBal0355471 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209745_cas				FTA: unable to add tool information from FBal0355472 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209746_cas				FTA: unable to add tool information from FBal0355473 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209747_cas				FTA: unable to add tool information from FBal0355474 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209748_cas				FTA: unable to add tool information from FBal0355475 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209749_cas				FTA: unable to add tool information from FBal0355476 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209750_cas				FTA: unable to add tool information from FBal0355477 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209751_cas				FTA: unable to add tool information from FBal0355478 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209752_cas				FTA: unable to add tool information from FBal0355479 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209753_cas				FTA: unable to add tool information from FBal0355480 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209754_cas				FTA: unable to add tool information from FBal0355481 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209755_cas				FTA: unable to add tool information from FBal0355482 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209756_cas				FTA: unable to add tool information from FBal0355483 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209757_cas				FTA: unable to add tool information from FBal0355484 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209758_cas				FTA: unable to add tool information from FBal0355485 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209759_cas				FTA: unable to add tool information from FBal0355486 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209760_cas				FTA: unable to add tool information from FBal0355487 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209761_cas				FTA: unable to add tool information from FBal0355488 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209762_cas				FTA: unable to add tool information from FBal0355489 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209763_cas				FTA: unable to add tool information from FBal0355490 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209764_cas				FTA: unable to add tool information from FBal0355491 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209765_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355434
+FBti0209765_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355434
+FBti0209765_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355492
+FBti0209765_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355492
+FBti0209766_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355493
+FBti0209766_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355493
+FBti0209767_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355495
+FBti0209767_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355495
+FBti0209767_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355496
+FBti0209767_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355496
+FBti0209768_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355497
+FBti0209768_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355497
+FBti0209768_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355498
+FBti0209768_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355498
+FBti0209769_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355499
+FBti0209769_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355499
+FBti0209769_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355500
+FBti0209769_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355500
+FBti0209770_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355501
+FBti0209770_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355501
+FBti0209770_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355502
+FBti0209770_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355502
+FBti0209770_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355503
+FBti0209770_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355503
+FBti0209771_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355504
+FBti0209771_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355504
+FBti0209771_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355505
+FBti0209771_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355505
+FBti0209772_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355507
+FBti0209772_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355507
+FBti0209772_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355508
+FBti0209772_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355508
+FBti0209773_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355509
+FBti0209773_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355509
+FBti0209773_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355510
+FBti0209773_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355510
+FBti0209774_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355511
+FBti0209774_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355511
+FBti0209774_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355512
+FBti0209774_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355512
+FBti0209775_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355513
+FBti0209775_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355513
+FBti0209775_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355514
+FBti0209775_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355514
+FBti0209775_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355515
+FBti0209775_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355515
+FBti0209776_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355506
+FBti0209776_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355506
+FBti0209776_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355516
+FBti0209776_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355516
+FBti0209777_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355517
+FBti0209777_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355517
+FBti0209777_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355518
+FBti0209777_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355518
+FBti0209778_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355519
+FBti0209778_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355519
+FBti0209778_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355520
+FBti0209778_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355520
+FBti0209779_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355521
+FBti0209779_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355521
+FBti0209779_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355522
+FBti0209779_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355522
+FBti0209780_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355523
+FBti0209780_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355523
+FBti0209780_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355524
+FBti0209780_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355524
+FBti0209781_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355525
+FBti0209781_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355525
+FBti0209781_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355526
+FBti0209781_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355526
+FBti0209782_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355527
+FBti0209782_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355527
+FBti0209782_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355528
+FBti0209782_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355528
+FBti0209783_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355529
+FBti0209783_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355529
+FBti0209783_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355530
+FBti0209783_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355530
+FBti0209784_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355531
+FBti0209784_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355531
+FBti0209784_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355532
+FBti0209784_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355532
+FBti0209784_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355533
+FBti0209784_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355533
+FBti0209785_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355534
+FBti0209785_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355534
+FBti0209785_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355535
+FBti0209785_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355535
+FBti0209788_cas				FTA: unable to add tool information from FBal0355581 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209790_cas				FTA: unable to add tool information from FBal0355588 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209800_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0209800_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0209801_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209801_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209801_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355630
+FBti0209801_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355630
+FBti0209801_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355961
+FBti0209802_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209802_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209802_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355631
+FBti0209802_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355631
+FBti0209802_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355855
+FBti0209803_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209803_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209803_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355632
+FBti0209803_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355632
+FBti0209803_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355962
+FBti0209804_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209804_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209804_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355633
+FBti0209804_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355633
+FBti0209804_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355856
+FBti0209805_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209805_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209805_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355634
+FBti0209805_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355634
+FBti0209805_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355963
+FBti0209806_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209806_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209806_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355635
+FBti0209806_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355635
+FBti0209806_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355857
+FBti0209807_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209807_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209807_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355636
+FBti0209807_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355636
+FBti0209807_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355964
+FBti0209808_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209808_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209808_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355637
+FBti0209808_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355637
+FBti0209808_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355858
+FBti0209809_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209809_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209809_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355638
+FBti0209809_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355638
+FBti0209809_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355965
+FBti0209810_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209810_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209810_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355639
+FBti0209810_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355639
+FBti0209810_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355859
+FBti0209811_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209811_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209811_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355640
+FBti0209811_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355640
+FBti0209811_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355966
+FBti0209812_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209812_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209812_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355641
+FBti0209812_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355641
+FBti0209812_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355860
+FBti0209813_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209813_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209813_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355642
+FBti0209813_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355642
+FBti0209813_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355967
+FBti0209814_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209814_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209814_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355643
+FBti0209814_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355643
+FBti0209814_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355861
+FBti0209815_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209815_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209815_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355644
+FBti0209815_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355644
+FBti0209815_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355956
+FBti0209816_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209816_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209816_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355645
+FBti0209816_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355645
+FBti0209816_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355862
+FBti0209817_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209817_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209817_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355646
+FBti0209817_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355646
+FBti0209817_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355968
+FBti0209818_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209818_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209818_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355647
+FBti0209818_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355647
+FBti0209818_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355969
+FBti0209819_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209819_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209819_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355648
+FBti0209819_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355648
+FBti0209819_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355970
+FBti0209820_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209820_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209820_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355649
+FBti0209820_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355649
+FBti0209820_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355971
+FBti0209821_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209821_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209821_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355650
+FBti0209821_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355650
+FBti0209821_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355863
+FBti0209822_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209822_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209822_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355651
+FBti0209822_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355651
+FBti0209822_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355864
+FBti0209823_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209823_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209823_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355652
+FBti0209823_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355652
+FBti0209823_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355972
+FBti0209824_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209824_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209824_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355653
+FBti0209824_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355653
+FBti0209824_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355865
+FBti0209825_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209825_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209825_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355654
+FBti0209825_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355654
+FBti0209825_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355973
+FBti0209826_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209826_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209826_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355655
+FBti0209826_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355655
+FBti0209826_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355866
+FBti0209827_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209827_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209827_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355656
+FBti0209827_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355656
+FBti0209827_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355974
+FBti0209828_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209828_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209828_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355657
+FBti0209828_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355657
+FBti0209828_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355867
+FBti0209829_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209829_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209829_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355658
+FBti0209829_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355658
+FBti0209829_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355975
+FBti0209830_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209830_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209830_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355659
+FBti0209830_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355659
+FBti0209830_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355976
+FBti0209831_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209831_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209831_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355660
+FBti0209831_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355660
+FBti0209831_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355868
+FBti0209832_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209832_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209832_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355661
+FBti0209832_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355661
+FBti0209832_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355869
+FBti0209833_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209833_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209833_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355662
+FBti0209833_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355662
+FBti0209833_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355977
+FBti0209834_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209834_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209834_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355663
+FBti0209834_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355663
+FBti0209834_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355870
+FBti0209835_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209835_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209835_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355664
+FBti0209835_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355664
+FBti0209835_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355978
+FBti0209836_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209836_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209836_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355665
+FBti0209836_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355665
+FBti0209836_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355979
+FBti0209837_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209837_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209837_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355666
+FBti0209837_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355666
+FBti0209837_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355871
+FBti0209838_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209838_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209838_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355667
+FBti0209838_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355667
+FBti0209838_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355980
+FBti0209839_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209839_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209839_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355668
+FBti0209839_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355668
+FBti0209839_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355872
+FBti0209840_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209840_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209840_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355669
+FBti0209840_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355669
+FBti0209840_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355981
+FBti0209841_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209841_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209841_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355670
+FBti0209841_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355670
+FBti0209841_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355873
+FBti0209842_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209842_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209842_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355671
+FBti0209842_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355671
+FBti0209842_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355874
+FBti0209843_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209843_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209843_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355672
+FBti0209843_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355672
+FBti0209843_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355982
+FBti0209844_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209844_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209844_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355673
+FBti0209844_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355673
+FBti0209844_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355875
+FBti0209845_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209845_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209845_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355674
+FBti0209845_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355674
+FBti0209845_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355983
+FBti0209846_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209846_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209846_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355675
+FBti0209846_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355675
+FBti0209846_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355876
+FBti0209847_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209847_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209847_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355676
+FBti0209847_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355676
+FBti0209847_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355984
+FBti0209848_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209848_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209848_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355677
+FBti0209848_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355677
+FBti0209848_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355877
+FBti0209849_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209849_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209849_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355678
+FBti0209849_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355678
+FBti0209849_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355985
+FBti0209850_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209850_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209850_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355679
+FBti0209850_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355679
+FBti0209850_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355878
+FBti0209851_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209851_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209851_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355680
+FBti0209851_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355680
+FBti0209851_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355986
+FBti0209852_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209852_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209852_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355681
+FBti0209852_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355681
+FBti0209852_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355879
+FBti0209853_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209853_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209853_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355682
+FBti0209853_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355682
+FBti0209853_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355880
+FBti0209854_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209854_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209854_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355683
+FBti0209854_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355683
+FBti0209854_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355987
+FBti0209855_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209855_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209855_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355684
+FBti0209855_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355684
+FBti0209855_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355988
+FBti0209856_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209856_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209856_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355685
+FBti0209856_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355685
+FBti0209856_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355989
+FBti0209857_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209857_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209857_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355686
+FBti0209857_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355686
+FBti0209857_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355881
+FBti0209858_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209858_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209858_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355687
+FBti0209858_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355687
+FBti0209858_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355990
+FBti0209859_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209859_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209859_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355688
+FBti0209859_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355688
+FBti0209859_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355882
+FBti0209860_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209860_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209860_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355689
+FBti0209860_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355689
+FBti0209860_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355991
+FBti0209861_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209861_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209861_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355690
+FBti0209861_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355690
+FBti0209861_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355992
+FBti0209862_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209862_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209862_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355691
+FBti0209862_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355691
+FBti0209862_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355883
+FBti0209863_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209863_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209863_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355692
+FBti0209863_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355692
+FBti0209863_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355993
+FBti0209864_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209864_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209864_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355693
+FBti0209864_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355693
+FBti0209864_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355994
+FBti0209865_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209865_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209865_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355694
+FBti0209865_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355694
+FBti0209865_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355884
+FBti0209866_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209866_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209866_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355695
+FBti0209866_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355695
+FBti0209866_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355995
+FBti0209867_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209867_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209867_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355696
+FBti0209867_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355696
+FBti0209867_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355885
+FBti0209868_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209868_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209868_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355697
+FBti0209868_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355697
+FBti0209868_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355996
+FBti0209869_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209869_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209869_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355698
+FBti0209869_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355698
+FBti0209869_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355997
+FBti0209870_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209870_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209870_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355699
+FBti0209870_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355699
+FBti0209870_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355998
+FBti0209871_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209871_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209871_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355700
+FBti0209871_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355700
+FBti0209871_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355886
+FBti0209872_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209872_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209872_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355701
+FBti0209872_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355701
+FBti0209872_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355999
+FBti0209873_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209873_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209873_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355702
+FBti0209873_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355702
+FBti0209873_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355887
+FBti0209874_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209874_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209874_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355703
+FBti0209874_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355703
+FBti0209874_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355957
+FBti0209875_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209875_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209875_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355704
+FBti0209875_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355704
+FBti0209875_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355958
+FBti0209876_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209876_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209876_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355705
+FBti0209876_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355705
+FBti0209876_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355888
+FBti0209877_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0209877_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0209877_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0355706
+FBti0209877_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0355706
+FBti0209877_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0355954
+FBti0209877_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0355954
+FBti0209880_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0209880_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0209880_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0355709
+FBti0209880_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0355709
+FBti0209880_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0355955
+FBti0209880_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0355955
+FBti0209881_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209881_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209881_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355710
+FBti0209881_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355710
+FBti0209881_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356000
+FBti0209882_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209882_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209882_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355711
+FBti0209882_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355711
+FBti0209882_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355889
+FBti0209883_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209883_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209883_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355712
+FBti0209883_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355712
+FBti0209883_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356001
+FBti0209884_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0209884_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0209885_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209885_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209885_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355714
+FBti0209885_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355714
+FBti0209885_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356002
+FBti0209886_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209886_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209886_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355715
+FBti0209886_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355715
+FBti0209886_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355890
+FBti0209887_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209887_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209887_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355716
+FBti0209887_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355716
+FBti0209887_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355891
+FBti0209888_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209888_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209888_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355717
+FBti0209888_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355717
+FBti0209888_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356003
+FBti0209889_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209889_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209889_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355718
+FBti0209889_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355718
+FBti0209889_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356004
+FBti0209890_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209890_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209890_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355719
+FBti0209890_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355719
+FBti0209890_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355892
+FBti0209891_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209891_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209891_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355720
+FBti0209891_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355720
+FBti0209891_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356005
+FBti0209892_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209892_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209892_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355721
+FBti0209892_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355721
+FBti0209892_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355893
+FBti0209893_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209893_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209893_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355722
+FBti0209893_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355722
+FBti0209893_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356006
+FBti0209894_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209894_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209894_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355723
+FBti0209894_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355723
+FBti0209894_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355894
+FBti0209895_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209895_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209895_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355724
+FBti0209895_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355724
+FBti0209895_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356007
+FBti0209896_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209896_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209896_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355725
+FBti0209896_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355725
+FBti0209896_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356008
+FBti0209897_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209897_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209897_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355726
+FBti0209897_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355726
+FBti0209897_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355895
+FBti0209898_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209898_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209898_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355727
+FBti0209898_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355727
+FBti0209898_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356009
+FBti0209899_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209899_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209899_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355728
+FBti0209899_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355728
+FBti0209899_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355896
+FBti0209900_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209900_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209900_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355729
+FBti0209900_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355729
+FBti0209900_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355897
+FBti0209901_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209901_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209901_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355730
+FBti0209901_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355730
+FBti0209901_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356010
+FBti0209902_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209902_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209902_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355731
+FBti0209902_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355731
+FBti0209902_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356011
+FBti0209903_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209903_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209903_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355732
+FBti0209903_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355732
+FBti0209903_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355898
+FBti0209904_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209904_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209904_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355733
+FBti0209904_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355733
+FBti0209904_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355899
+FBti0209905_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209905_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209905_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355734
+FBti0209905_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355734
+FBti0209905_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356012
+FBti0209906_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209906_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209906_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355735
+FBti0209906_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355735
+FBti0209906_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355900
+FBti0209907_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209907_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209907_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355736
+FBti0209907_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355736
+FBti0209907_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356013
+FBti0209908_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209908_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209908_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355737
+FBti0209908_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355737
+FBti0209908_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356014
+FBti0209909_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209909_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209909_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355738
+FBti0209909_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355738
+FBti0209909_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356015
+FBti0209910_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209910_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209910_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355739
+FBti0209910_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355739
+FBti0209910_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356016
+FBti0209911_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209911_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209911_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355740
+FBti0209911_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355740
+FBti0209911_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356017
+FBti0209912_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209912_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209912_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355741
+FBti0209912_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355741
+FBti0209912_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356018
+FBti0209913_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209913_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209913_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355742
+FBti0209913_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355742
+FBti0209913_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356019
+FBti0209914_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209914_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209914_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355743
+FBti0209914_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355743
+FBti0209914_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355901
+FBti0209915_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209915_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209915_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355744
+FBti0209915_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355744
+FBti0209915_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356020
+FBti0209916_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209916_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209916_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355745
+FBti0209916_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355745
+FBti0209916_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355902
+FBti0209917_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209917_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209917_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355746
+FBti0209917_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355746
+FBti0209917_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356021
+FBti0209918_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209918_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209918_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355747
+FBti0209918_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355747
+FBti0209918_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355903
+FBti0209919_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209919_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209919_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355748
+FBti0209919_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355748
+FBti0209919_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356022
+FBti0209920_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209920_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209920_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355749
+FBti0209920_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355749
+FBti0209920_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355904
+FBti0209921_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209921_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209921_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355750
+FBti0209921_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355750
+FBti0209921_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356023
+FBti0209922_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209922_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209922_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355751
+FBti0209922_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355751
+FBti0209922_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355905
+FBti0209923_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209923_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209923_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355752
+FBti0209923_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355752
+FBti0209923_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356024
+FBti0209924_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209924_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209924_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355753
+FBti0209924_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355753
+FBti0209924_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355906
+FBti0209925_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209925_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209925_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355754
+FBti0209925_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355754
+FBti0209925_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356025
+FBti0209926_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209926_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209926_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355755
+FBti0209926_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355755
+FBti0209926_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355907
+FBti0209927_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209927_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209927_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355756
+FBti0209927_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355756
+FBti0209927_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356026
+FBti0209928_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209928_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209928_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355757
+FBti0209928_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355757
+FBti0209928_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355908
+FBti0209929_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209929_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209929_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355758
+FBti0209929_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355758
+FBti0209929_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356027
+FBti0209930_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209930_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209930_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355759
+FBti0209930_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355759
+FBti0209930_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355909
+FBti0209931_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209931_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209931_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355760
+FBti0209931_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355760
+FBti0209931_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356028
+FBti0209932_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209932_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209932_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355761
+FBti0209932_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355761
+FBti0209932_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355910
+FBti0209933_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209933_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209933_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355762
+FBti0209933_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355762
+FBti0209933_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356029
+FBti0209934_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209934_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209934_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355763
+FBti0209934_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355763
+FBti0209934_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356030
+FBti0209935_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209935_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209935_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355764
+FBti0209935_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355764
+FBti0209935_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355911
+FBti0209936_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209936_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209936_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355765
+FBti0209936_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355765
+FBti0209936_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356031
+FBti0209937_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209937_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209937_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355766
+FBti0209937_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355766
+FBti0209937_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355912
+FBti0209938_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209938_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209938_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355767
+FBti0209938_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355767
+FBti0209938_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356032
+FBti0209939_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209939_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209939_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355769
+FBti0209939_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355769
+FBti0209939_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356033
+FBti0209940_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209940_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209940_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355770
+FBti0209940_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355770
+FBti0209940_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355913
+FBti0209941_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209941_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209941_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355771
+FBti0209941_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355771
+FBti0209941_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356034
+FBti0209942_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209942_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209942_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355772
+FBti0209942_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355772
+FBti0209942_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356035
+FBti0209943_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209943_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209943_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355773
+FBti0209943_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355773
+FBti0209943_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356036
+FBti0209944_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209944_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209944_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355774
+FBti0209944_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355774
+FBti0209944_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355914
+FBti0209945_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209945_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209945_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355775
+FBti0209945_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355775
+FBti0209945_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355915
+FBti0209946_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209946_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209946_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355776
+FBti0209946_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355776
+FBti0209946_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356037
+FBti0209947_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209947_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209947_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355777
+FBti0209947_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355777
+FBti0209947_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356038
+FBti0209948_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209948_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209948_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355778
+FBti0209948_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355778
+FBti0209948_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355916
+FBti0209949_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209949_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209949_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355779
+FBti0209949_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355779
+FBti0209949_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356039
+FBti0209950_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209950_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209950_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355780
+FBti0209950_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355780
+FBti0209950_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355917
+FBti0209951_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209951_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209951_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355781
+FBti0209951_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355781
+FBti0209951_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356040
+FBti0209952_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209952_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209952_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355782
+FBti0209952_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355782
+FBti0209952_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356041
+FBti0209953_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209953_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209953_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355783
+FBti0209953_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355783
+FBti0209953_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356042
+FBti0209954_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209954_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209954_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355784
+FBti0209954_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355784
+FBti0209954_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355918
+FBti0209955_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209955_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209955_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355785
+FBti0209955_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355785
+FBti0209955_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356043
+FBti0209956_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209956_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209956_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355786
+FBti0209956_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355786
+FBti0209956_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356044
+FBti0209957_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209957_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209957_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355787
+FBti0209957_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355787
+FBti0209957_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355919
+FBti0209958_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209958_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209958_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355788
+FBti0209958_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355788
+FBti0209958_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356045
+FBti0209959_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209959_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209959_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355789
+FBti0209959_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355789
+FBti0209959_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355920
+FBti0209960_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209960_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209960_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355790
+FBti0209960_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355790
+FBti0209960_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355959
+FBti0209961_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209961_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209961_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355791
+FBti0209961_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355791
+FBti0209961_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355921
+FBti0209962_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209962_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209962_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355792
+FBti0209962_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355792
+FBti0209962_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355922
+FBti0209963_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209963_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209963_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355793
+FBti0209963_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355793
+FBti0209963_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356046
+FBti0209964_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209964_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209964_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355794
+FBti0209964_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355794
+FBti0209964_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355923
+FBti0209965_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209965_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209965_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355795
+FBti0209965_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355795
+FBti0209965_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356047
+FBti0209966_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209966_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209966_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355796
+FBti0209966_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355796
+FBti0209966_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356048
+FBti0209967_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209967_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209967_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355797
+FBti0209967_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355797
+FBti0209967_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355924
+FBti0209968_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209968_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209968_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355798
+FBti0209968_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355798
+FBti0209968_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356049
+FBti0209969_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209969_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209969_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355799
+FBti0209969_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355799
+FBti0209969_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355925
+FBti0209970_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209970_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209970_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355800
+FBti0209970_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355800
+FBti0209970_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355926
+FBti0209971_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209971_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209971_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355801
+FBti0209971_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355801
+FBti0209971_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356050
+FBti0209972_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209972_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209972_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355802
+FBti0209972_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355802
+FBti0209972_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355927
+FBti0209973_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209973_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209973_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355803
+FBti0209973_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355803
+FBti0209973_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356051
+FBti0209974_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209974_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209974_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355804
+FBti0209974_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355804
+FBti0209974_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355928
+FBti0209975_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209975_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209975_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355805
+FBti0209975_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355805
+FBti0209975_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356052
+FBti0209976_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209976_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209976_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355806
+FBti0209976_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355806
+FBti0209976_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355929
+FBti0209977_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209977_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209977_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355807
+FBti0209977_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355807
+FBti0209977_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356053
+FBti0209978_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209978_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209978_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355808
+FBti0209978_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355808
+FBti0209978_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355930
+FBti0209979_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0140111
+FBti0209979_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140111
+FBti0209979_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355809
+FBti0209979_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355809
+FBti0209979_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356079
+FBti0209980_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0209980_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0209980_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355810
+FBti0209980_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356077
+FBti0209981_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209981_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209981_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355811
+FBti0209981_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355811
+FBti0209981_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356054
+FBti0209982_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209982_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209982_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355812
+FBti0209982_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355812
+FBti0209982_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355931
+FBti0209983_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209983_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209983_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355813
+FBti0209983_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355813
+FBti0209983_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356055
+FBti0209984_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209984_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209984_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355814
+FBti0209984_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355814
+FBti0209984_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356056
+FBti0209985_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209985_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209985_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355815
+FBti0209985_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355815
+FBti0209985_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355932
+FBti0209986_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209986_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209986_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355816
+FBti0209986_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355816
+FBti0209986_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356057
+FBti0209987_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209987_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209987_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355817
+FBti0209987_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355817
+FBti0209987_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356058
+FBti0209988_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209988_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209988_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355818
+FBti0209988_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355818
+FBti0209988_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356059
+FBti0209989_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209989_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209989_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355819
+FBti0209989_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355819
+FBti0209989_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355933
+FBti0209990_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209990_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209990_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355820
+FBti0209990_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355820
+FBti0209990_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356060
+FBti0209991_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209991_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209991_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355821
+FBti0209991_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355821
+FBti0209991_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356061
+FBti0209992_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209992_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209992_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355822
+FBti0209992_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355822
+FBti0209992_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355934
+FBti0209993_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209993_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209993_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355823
+FBti0209993_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355823
+FBti0209993_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356062
+FBti0209994_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209994_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209994_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355824
+FBti0209994_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355824
+FBti0209994_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355935
+FBti0209995_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209995_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209995_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355825
+FBti0209995_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355825
+FBti0209995_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355936
+FBti0209996_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209996_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209996_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355826
+FBti0209996_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355826
+FBti0209996_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356063
+FBti0209997_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0209997_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0209997_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355827
+FBti0209997_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355827
+FBti0209997_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355937
+FBti0209998_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0209998_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0209998_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355828
+FBti0209998_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355828
+FBti0209998_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356064
+FBti0209999_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0209999_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0209999_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355829
+FBti0209999_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355829
+FBti0209999_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355938
+FBti0210000_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210000_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210000_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355830
+FBti0210000_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355830
+FBti0210000_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356065
+FBti0210001_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0210001_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0210001_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355831
+FBti0210001_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355831
+FBti0210001_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355939
+FBti0210002_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210002_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210002_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355832
+FBti0210002_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355832
+FBti0210002_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356066
+FBti0210003_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210003_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210003_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355833
+FBti0210003_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355833
+FBti0210003_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355940
+FBti0210004_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210004_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210004_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355834
+FBti0210004_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355834
+FBti0210004_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356067
+FBti0210005_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210005_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210005_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355835
+FBti0210005_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355835
+FBti0210005_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356068
+FBti0210006_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0210006_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0210006_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355836
+FBti0210006_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355836
+FBti0210006_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355941
+FBti0210007_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210007_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210007_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355837
+FBti0210007_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355837
+FBti0210007_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356069
+FBti0210008_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210008_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210008_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355838
+FBti0210008_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355838
+FBti0210008_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355942
+FBti0210009_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210009_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210009_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355839
+FBti0210009_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355839
+FBti0210009_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355943
+FBti0210010_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210010_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210010_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355840
+FBti0210010_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355840
+FBti0210010_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356070
+FBti0210011_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210011_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210011_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355841
+FBti0210011_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355841
+FBti0210011_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355944
+FBti0210012_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210012_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210012_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355842
+FBti0210012_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355842
+FBti0210012_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356071
+FBti0210013_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0210013_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0210013_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355843
+FBti0210013_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355843
+FBti0210013_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355945
+FBti0210014_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210014_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210014_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355844
+FBti0210014_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355844
+FBti0210014_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356072
+FBti0210015_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0210015_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0210015_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355845
+FBti0210015_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355845
+FBti0210015_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355946
+FBti0210016_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210016_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210016_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355846
+FBti0210016_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355846
+FBti0210016_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356073
+FBti0210017_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0210017_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0210017_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355847
+FBti0210017_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355847
+FBti0210017_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355947
+FBti0210018_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210018_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210018_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355848
+FBti0210018_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355848
+FBti0210018_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356074
+FBti0210019_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210019_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210019_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355849
+FBti0210019_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355849
+FBti0210019_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355948
+FBti0210020_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210020_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210020_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355850
+FBti0210020_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355850
+FBti0210020_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355949
+FBti0210021_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210021_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210021_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355851
+FBti0210021_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355851
+FBti0210021_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355960
+FBti0210022_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210022_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210022_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355852
+FBti0210022_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355852
+FBti0210022_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356075
+FBti0210023_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210023_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210023_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355853
+FBti0210023_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355853
+FBti0210023_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356076
+FBti0210024_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0210024_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0210024_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355854
+FBti0210024_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355854
+FBti0210024_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355950
+FBti0210025_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0210025_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0210026_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0210026_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0210026_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356078
+FBti0210026_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356080
+FBti0210033_cas	carries_tool	FBto0000318	FBrf0243881		TOOL DATA from: FBal0356089
+FBti0210033_cas	tagged_with	FBto0000027	FBrf0243881		TOOL DATA from: FBal0356089
+FBti0210035_cas				FTA: unable to add tool information from FBal0356105 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210036_cas	carries_tool	FBto0000349	FBrf0243754		TOOL DATA from: FBal0356106
+FBti0210036_cas	carries_tool	FBto0000356	FBrf0243754		TOOL DATA from: FBal0356106
+FBti0210038_cas	tagged_with	FBto0000076	FBrf0242308		TOOL DATA from: FBal0356129
+FBti0210039_cas	carries_tool	FBto0000349	FBrf0243775		TOOL DATA from: FBal0356141
+FBti0210039_cas	tagged_with	FBto0000028	FBrf0243775		TOOL DATA from: FBal0356141
+FBti0210040_cas	tagged_with	FBto0000031	FBrf0243162		TOOL DATA from: FBal0356168
+FBti0210040_cas	tagged_with	FBto0000076	FBrf0243162		TOOL DATA from: FBal0356168
+FBti0210040_cas	tagged_with	FBto0000093	FBrf0243162		TOOL DATA from: FBal0356168
+FBti0210041_cas	tagged_with	FBto0000031	FBrf0243162		TOOL DATA from: FBal0356173
+FBti0210041_cas	tagged_with	FBto0000076	FBrf0243162		TOOL DATA from: FBal0356173
+FBti0210041_cas	tagged_with	FBto0000093	FBrf0243162		TOOL DATA from: FBal0356173
+FBti0210052_cas				FTA: unable to add tool information from FBal0356212 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210053_cas	carries_tool	FBto0000349	FBrf0240702		TOOL DATA from: FBal0356230
+FBti0210054_cas				FTA: unable to add tool information from FBal0356231 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210055_cas				FTA: unable to add tool information from FBal0356232 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210061_cas	tagged_with	FBto0000093	FBrf0243748		TOOL DATA from: FBal0356243
+FBti0210061_cas	tagged_with	FBto0000589	FBrf0243748		TOOL DATA from: FBal0356243
+FBti0210062_cas	tagged_with	FBto0000093	FBrf0243748		TOOL DATA from: FBal0356244
+FBti0210062_cas	tagged_with	FBto0000589	FBrf0243748		TOOL DATA from: FBal0356244
+FBti0210063_cas	tagged_with	FBto0000093	FBrf0243748		TOOL DATA from: FBal0356245
+FBti0210063_cas	tagged_with	FBto0000589	FBrf0243748		TOOL DATA from: FBal0356245
+FBti0210065_cas	tagged_with	FBto0000166	FBrf0243173		TOOL DATA from: FBal0356253
+FBti0210096_cas	carries_tool	FBto0000349	FBrf0244173		TOOL DATA from: FBal0356314
+FBti0210096_cas	tagged_with	FBto0000027	FBrf0244173		TOOL DATA from: FBal0356314
+FBti0210097_cas	carries_tool	FBto0000349	FBrf0244175		TOOL DATA from: FBal0356320
+FBti0210097_cas	tagged_with	FBto0000126	FBrf0244175		TOOL DATA from: FBal0356320
+FBti0210098_cas	carries_tool	FBto0000349	FBrf0244175		TOOL DATA from: FBal0356321
+FBti0210098_cas	tagged_with	FBto0000126	FBrf0244175		TOOL DATA from: FBal0356321
+FBti0210099_cas	carries_tool	FBto0000349	FBrf0244175		TOOL DATA from: FBal0356322
+FBti0210099_cas	tagged_with	FBto0000031	FBrf0244175		TOOL DATA from: FBal0356322
+FBti0210099_cas	tagged_with	FBto0000077	FBrf0244175		TOOL DATA from: FBal0356322
+FBti0210213_cas	carries_tool	FBto0000356	FBrf0243785		TOOL DATA from: FBal0356483
+FBti0210214_cas	carries_tool	FBto0000356	FBrf0243785		TOOL DATA from: FBal0356484
+FBti0210236_cas	has_reg_region	FBto0000180			TOOL DATA from: FBtp0117267
+FBti0210236_cas	tool_uses	misexpression element			TOOL DATA from: FBtp0117267
+FBti0210237_cas	tagged_with	FBto0000077	FBrf0244320		TOOL DATA from: FBal0356523
+FBti0210238_cas	tagged_with	FBto0000031	FBrf0244320		TOOL DATA from: FBal0356524
+FBti0210241_cas	tagged_with	FBto0000077	FBrf0244320		TOOL DATA from: FBal0356527
+FBti0210242_cas	tagged_with	FBto0000031	FBrf0244320		TOOL DATA from: FBal0356528
+FBti0210542_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210542_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210543_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210543_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210544_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210544_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210545_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0357038
+FBti0210546_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210546_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210547_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210547_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210548_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0210548_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0210548_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0357044
+FBti0210548_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0357044
+FBti0210548_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0357047
+FBti0210548_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0357047
+FBti0210551_cas				FTA: unable to add tool information from FBal0357051 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210553_cas				FTA: unable to add tool information from FBal0357073 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210584_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210584_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210585_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210585_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210586_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210586_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210587_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210587_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210588_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210588_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210589_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210589_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210590_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210590_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210591_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210591_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210592_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210592_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210593_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210593_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210594_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210594_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210595_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210595_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210596_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210596_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210597_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210597_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210598_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210598_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210599_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210599_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210600_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210600_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210601_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210601_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210602_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210602_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210603_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210603_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210604_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0210604_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0210609_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0210609_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0210610_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0210610_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0210611_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0210611_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0210612_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0210612_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0210613_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0210613_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0210614_cas	tagged_with	FBto0000027	FBrf0243879		TOOL DATA from: FBal0357203
+FBti0210632_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357261
+FBti0210632_cas	tagged_with	FBto0000063	FBrf0241737		TOOL DATA from: FBal0357261
+FBti0210633_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0140111
+FBti0210633_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140111
+FBti0210633_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357262
+FBti0210633_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357262
+FBti0210633_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357303
+FBti0210634_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0210634_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0210634_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357263
+FBti0210634_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357307
+FBti0210635_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0210635_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0210635_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357265
+FBti0210635_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0357265
+FBti0210635_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357298
+FBti0210635_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0357298
+FBti0210636_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210636_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210636_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357266
+FBti0210636_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357266
+FBti0210636_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357302
+FBti0210637_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210637_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210637_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357267
+FBti0210637_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357267
+FBti0210637_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357299
+FBti0210637_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357299
+FBti0210638_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0140111
+FBti0210638_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140111
+FBti0210638_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357268
+FBti0210638_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357268
+FBti0210638_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357304
+FBti0210639_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0210639_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0210639_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357269
+FBti0210639_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357308
+FBti0210640_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210640_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210640_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357271
+FBti0210640_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357271
+FBti0210640_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357301
+FBti0210641_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0140111
+FBti0210641_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140111
+FBti0210641_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357272
+FBti0210641_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357272
+FBti0210641_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357305
+FBti0210642_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0210642_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0210642_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357273
+FBti0210642_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357309
+FBti0210643_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0140111
+FBti0210643_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140111
+FBti0210643_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357274
+FBti0210643_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357274
+FBti0210643_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357306
+FBti0210644_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210644_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210644_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357275
+FBti0210644_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357275
+FBti0210644_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357295
+FBti0210644_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357295
+FBti0210645_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210645_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210645_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357276
+FBti0210645_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357276
+FBti0210645_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357296
+FBti0210645_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357296
+FBti0210646_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0210646_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0210646_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357277
+FBti0210646_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0357277
+FBti0210646_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357297
+FBti0210646_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0357297
+FBti0210647_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357278
+FBti0210647_cas	tagged_with	FBto0000063	FBrf0241737		TOOL DATA from: FBal0357278
+FBti0210648_cas				FTA: unable to add tool information from FBal0357279 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210649_cas				FTA: unable to add tool information from FBal0357280 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210650_cas				FTA: unable to add tool information from FBal0357281 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210651_cas				FTA: unable to add tool information from FBal0357282 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210652_cas				FTA: unable to add tool information from FBal0357283 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210653_cas				FTA: unable to add tool information from FBal0357284 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210654_cas				FTA: unable to add tool information from FBal0357285 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210655_cas				FTA: unable to add tool information from FBal0357286 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210656_cas				FTA: unable to add tool information from FBal0357287 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210657_cas				FTA: unable to add tool information from FBal0357288 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210658_cas				FTA: unable to add tool information from FBal0357289 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210659_cas				FTA: unable to add tool information from FBal0357290 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210660_cas				FTA: unable to add tool information from FBal0357291 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210661_cas				FTA: unable to add tool information from FBal0357292 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210662_cas				FTA: unable to add tool information from FBal0357293 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210663_cas				FTA: unable to add tool information from FBal0357294 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210664_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0210664_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0210664_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357300
+FBti0210664_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357300
+FBti0210664_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357310
+FBti0210664_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357310
+FBti0210780_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358022
+FBti0210780_cas	carries_tool	FBto0000356	FBrf0243398		TOOL DATA from: FBal0358022
+FBti0210781_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358023
+FBti0210782_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358024
+FBti0210783_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358025
+FBti0210784_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358026
+FBti0210785_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358027
+FBti0210786_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358028
+FBti0210787_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358029
+FBti0210788_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358030
+FBti0210789_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358031
+FBti0210790_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358032
+FBti0210791_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358033
+FBti0210792_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358034
+FBti0210793_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358035
+FBti0210794_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358036
+FBti0210795_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358037
+FBti0211003_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358297
+FBti0211004_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358299
+FBti0211005_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358300
+FBti0211006_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358302
+FBti0211007_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358304
+FBti0211008_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358305
+FBti0211017_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211017_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211017_cas	carries_tool	FBto0000349	FBrf0244507		TOOL DATA from: FBal0358315
+FBti0211017_cas	carries_tool	FBto0000349	FBrf0244507		TOOL DATA from: FBal0358329
+FBti0211037_cas				FTA: unable to add tool information from FBal0358346 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211040_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358351
+FBti0211040_cas	carries_tool	FBto0000356	FBrf0239358		TOOL DATA from: FBal0358351
+FBti0211041_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358352
+FBti0211042_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358353
+FBti0211042_cas	tagged_with	FBto0000077	FBrf0239358		TOOL DATA from: FBal0358353
+FBti0211043_cas	tagged_with	FBto0000077	FBrf0239358		TOOL DATA from: FBal0358354
+FBti0211044_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358355
+FBti0211044_cas	carries_tool	FBto0000356	FBrf0239358		TOOL DATA from: FBal0358355
+FBti0211045_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358356
+FBti0211045_cas	tagged_with	FBto0000031	FBrf0239358		TOOL DATA from: FBal0358356
+FBti0211046_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358358
+FBti0211046_cas	tagged_with	FBto0000031	FBrf0239358		TOOL DATA from: FBal0358358
+FBti0211048_cas	carries_tool	FBto0000356	FBrf0242094		TOOL DATA from: FBal0358360
+FBti0211049_cas	carries_tool	FBto0000356	FBrf0242094		TOOL DATA from: FBal0358361
+FBti0211049_cas	carries_tool	FBto0000356	FBrf0242094		TOOL DATA from: FBal0358372
+FBti0211050_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358362
+FBti0211050_cas	tool_uses	mechanical force sensor	FBrf0242094		TOOL DATA from: FBal0358362
+FBti0211051_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358363
+FBti0211051_cas	tool_uses	mechanical force sensor	FBrf0242094		TOOL DATA from: FBal0358363
+FBti0211052_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358364
+FBti0211052_cas	tool_uses	mechanical force sensor	FBrf0242094		TOOL DATA from: FBal0358364
+FBti0211053_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358365
+FBti0211054_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358366
+FBti0211055_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358367
+FBti0211056_cas	tagged_with	FBto0000105	FBrf0242094		TOOL DATA from: FBal0358368
+FBti0211057_cas	tagged_with	FBto0000118	FBrf0242094		TOOL DATA from: FBal0358369
+FBti0211058_cas	tagged_with	FBto0000105	FBrf0242094		TOOL DATA from: FBal0358370
+FBti0211059_cas	tagged_with	FBto0000118	FBrf0242094		TOOL DATA from: FBal0358371
+FBti0211086_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358420
+FBti0211086_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358425
+FBti0211087_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358421
+FBti0211087_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358426
+FBti0211088_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358422
+FBti0211088_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358427
+FBti0211089_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358423
+FBti0211089_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358428
+FBti0211090_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358424
+FBti0211090_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358429
+FBti0211092_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0211092_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0211093_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0211093_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0211112_cas	carries_tool	FBto0000318	FBrf0243031		TOOL DATA from: FBal0358484
+FBti0211112_cas	carries_tool	FBto0000349	FBrf0243031		TOOL DATA from: FBal0358484
+FBti0211112_cas	tagged_with	FBto0000031	FBrf0243031		TOOL DATA from: FBal0358484
+FBti0211113_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0099203
+FBti0211113_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099203
+FBti0211113_cas	has_reg_region	FBgn0001235	FBrf0243031		TOOL DATA from: FBal0358482
+FBti0211114_cas	carries_tool	FBto0000318	FBrf0243031		TOOL DATA from: FBal0358483
+FBti0211114_cas	carries_tool	FBto0000349	FBrf0243031		TOOL DATA from: FBal0358483
+FBti0211115_cas	tagged_with	FBto0000031	FBrf0242987		TOOL DATA from: FBal0358491
+FBti0211116_cas	tagged_with	FBto0000093	FBrf0242987		TOOL DATA from: FBal0358492
+FBti0211125_cas	has_reg_region	FBto0000180			TOOL DATA from: FBtp0117267
+FBti0211125_cas	tool_uses	misexpression element			TOOL DATA from: FBtp0117267
+FBti0211125_cas	carries_tool	FBto0000349	FBrf0244085		TOOL DATA from: FBal0358515
+FBti0211127_cas	carries_tool	FBto0000349	FBrf0243083		TOOL DATA from: FBal0358521
+FBti0211127_cas	carries_tool	FBto0000356	FBrf0243083		TOOL DATA from: FBal0358521
+FBti0211128_cas	carries_tool	FBto0000349	FBrf0243083		TOOL DATA from: FBal0358522
+FBti0211129_cas	carries_tool	FBto0000349	FBrf0243083		TOOL DATA from: FBal0358523
+FBti0211130_cas	carries_tool	FBto0000349	FBrf0243083		TOOL DATA from: FBal0358524
+FBti0211172_cas	carries_tool	FBto0000349	FBrf0244557		TOOL DATA from: FBal0358600
+FBti0211172_cas	carries_tool	FBto0000356	FBrf0244557		TOOL DATA from: FBal0358600
+FBti0211172_cas	carries_tool	FBto0000375	FBrf0244557		TOOL DATA from: FBal0358600
+FBti0211174_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0116623
+FBti0211174_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0116623
+FBti0211175_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0141341
+FBti0211175_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141341
+FBti0211176_cas	encodes_tool	FBto0000157			TOOL DATA from: FBtp0141342
+FBti0211176_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141342
+FBti0211181_cas				FTA: unable to add tool information from FBal0358641 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211182_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358642
+FBti0211182_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358642
+FBti0211183_cas				FTA: unable to add tool information from FBal0358643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211184_cas				FTA: unable to add tool information from FBal0358644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211185_cas				FTA: unable to add tool information from FBal0358645 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211186_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358646
+FBti0211186_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358646
+FBti0211187_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358647
+FBti0211187_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358647
+FBti0211188_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358648
+FBti0211188_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358648
+FBti0211189_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358649
+FBti0211189_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358649
+FBti0211190_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358650
+FBti0211190_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358650
+FBti0211191_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358651
+FBti0211191_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358651
+FBti0211192_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358652
+FBti0211192_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358652
+FBti0211193_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358653
+FBti0211193_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358653
+FBti0211194_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358654
+FBti0211194_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358654
+FBti0211195_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358655
+FBti0211195_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358655
+FBti0211196_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358656
+FBti0211196_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358656
+FBti0211197_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358657
+FBti0211197_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358657
+FBti0211205_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0211205_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0211205_cas	carries_tool	FBto0000320	FBrf0244531		TOOL DATA from: FBal0358699
+FBti0211205_cas	carries_tool	FBto0000349	FBrf0244531		TOOL DATA from: FBal0358699
+FBti0211205_cas	carries_tool	FBto0000356	FBrf0244531		TOOL DATA from: FBal0358699
+FBti0211211_cas	tagged_with	FBto0000027	FBrf0244258		TOOL DATA from: FBal0358713
+FBti0211212_cas	tagged_with	FBto0000027	FBrf0244258		TOOL DATA from: FBal0358719
+FBti0211222_cas	carries_tool	FBto0000318	FBrf0244620		TOOL DATA from: FBal0358724
+FBti0211222_cas	carries_tool	FBto0000349	FBrf0244620		TOOL DATA from: FBal0358724
+FBti0211222_cas	tagged_with	FBto0000093	FBrf0244620		TOOL DATA from: FBal0358724
+FBti0211223_cas	carries_tool	FBto0000318	FBrf0244620		TOOL DATA from: FBal0358725
+FBti0211223_cas	tagged_with	FBto0000076	FBrf0244620		TOOL DATA from: FBal0358725
+FBti0211224_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0211224_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0211224_cas	carries_tool	FBto0000349	FBrf0244526		TOOL DATA from: FBal0358729
+FBti0211224_cas	carries_tool	FBto0000349	FBrf0244526		TOOL DATA from: FBal0358730
+FBti0211241_cas	encodes_tool	FBto0000621			TOOL DATA from: FBtp0141328
+FBti0211241_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141328
+FBti0211250_cas	tagged_with	FBto0000076	FBrf0244753		TOOL DATA from: FBal0358829
+FBti0211276_cas	carries_tool	FBto0000318	FBrf0244760		TOOL DATA from: FBal0358914
+FBti0211276_cas	tagged_with	FBto0000079	FBrf0244760		TOOL DATA from: FBal0358914
+FBti0211277_cas	carries_tool	FBto0000326	FBrf0244760		TOOL DATA from: FBal0358915
+FBti0211277_cas	tagged_with	FBto0000079	FBrf0244760		TOOL DATA from: FBal0358915
+FBti0211278_cas	carries_tool	FBto0000318	FBrf0244760		TOOL DATA from: FBal0358916
+FBti0211278_cas	tagged_with	FBto0000081	FBrf0244760		TOOL DATA from: FBal0358916
+FBti0211279_cas	carries_tool	FBto0000326	FBrf0244760		TOOL DATA from: FBal0358917
+FBti0211279_cas	tagged_with	FBto0000081	FBrf0244760		TOOL DATA from: FBal0358917
+FBti0211280_cas	carries_tool	FBto0000318	FBrf0244760		TOOL DATA from: FBal0358918
+FBti0211280_cas	tagged_with	FBto0000079	FBrf0244760		TOOL DATA from: FBal0358918
+FBti0211281_cas	carries_tool	FBto0000326	FBrf0244760		TOOL DATA from: FBal0358919
+FBti0211281_cas	tagged_with	FBto0000079	FBrf0244760		TOOL DATA from: FBal0358919
+FBti0211282_cas	carries_tool	FBto0000318	FBrf0244760		TOOL DATA from: FBal0358920
+FBti0211282_cas	tagged_with	FBto0000081	FBrf0244760		TOOL DATA from: FBal0358920
+FBti0211283_cas	carries_tool	FBto0000326	FBrf0244760		TOOL DATA from: FBal0358921
+FBti0211283_cas	tagged_with	FBto0000081	FBrf0244760		TOOL DATA from: FBal0358921
+FBti0211290_cas	tagged_with	FBto0000079	FBrf0244809		TOOL DATA from: FBal0358927
+FBti0211290_cas	tagged_with	FBto0000093	FBrf0244809		TOOL DATA from: FBal0358927
+FBti0211290_cas	tagged_with	FBto0000403	FBrf0244809		TOOL DATA from: FBal0358927
+FBti0211291_cas	tagged_with	FBto0000079	FBrf0244809		TOOL DATA from: FBal0358928
+FBti0211291_cas	tagged_with	FBto0000093	FBrf0244809		TOOL DATA from: FBal0358928
+FBti0211291_cas	tagged_with	FBto0000403	FBrf0244809		TOOL DATA from: FBal0358928
+FBti0211296_cas	tagged_with	FBto0000335	FBrf0243150		TOOL DATA from: FBal0358944
+FBti0211300_cas	tagged_with	FBto0000623	FBrf0239119		TOOL DATA from: FBal0358953
+FBti0211301_cas	tagged_with	FBto0000622	FBrf0239119		TOOL DATA from: FBal0358955
+FBti0211313_cas	tagged_with	FBto0000126	FBrf0244839		TOOL DATA from: FBal0358978
+FBti0211314_cas	tagged_with	FBto0000126	FBrf0244839		TOOL DATA from: FBal0358979
+FBti0211325_cas	tagged_with	FBto0000633	FBrf0243137		TOOL DATA from: FBal0359012
+FBti0211378_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211378_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211378_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359119
+FBti0211378_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359119
+FBti0211378_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359119
+FBti0211378_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359210
+FBti0211378_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359210
+FBti0211378_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359210
+FBti0211379_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211379_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211379_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359120
+FBti0211379_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359120
+FBti0211379_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359120
+FBti0211379_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359211
+FBti0211379_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359211
+FBti0211379_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359211
+FBti0211380_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211380_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211380_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359121
+FBti0211380_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359121
+FBti0211380_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359121
+FBti0211380_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359212
+FBti0211380_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359212
+FBti0211380_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359212
+FBti0211381_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211381_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211381_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359122
+FBti0211381_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359122
+FBti0211381_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359122
+FBti0211381_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359213
+FBti0211381_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359213
+FBti0211381_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359213
+FBti0211382_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211382_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211382_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359123
+FBti0211382_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359123
+FBti0211382_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359123
+FBti0211382_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359214
+FBti0211382_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359214
+FBti0211382_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359214
+FBti0211383_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211383_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211383_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359124
+FBti0211383_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359124
+FBti0211383_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359124
+FBti0211383_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359215
+FBti0211383_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359215
+FBti0211383_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359215
+FBti0211384_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211384_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211384_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359125
+FBti0211384_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359125
+FBti0211384_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359125
+FBti0211384_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359216
+FBti0211384_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359216
+FBti0211384_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359216
+FBti0211385_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211385_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211385_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359126
+FBti0211385_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359126
+FBti0211385_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359126
+FBti0211385_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359217
+FBti0211385_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359217
+FBti0211385_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359217
+FBti0211386_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211386_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211386_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359127
+FBti0211386_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359127
+FBti0211386_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359127
+FBti0211386_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359218
+FBti0211386_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359218
+FBti0211386_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359218
+FBti0211387_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211387_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211387_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359128
+FBti0211387_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359128
+FBti0211387_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359128
+FBti0211387_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359219
+FBti0211387_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359219
+FBti0211387_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359219
+FBti0211388_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211388_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211388_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359129
+FBti0211388_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359129
+FBti0211388_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359129
+FBti0211388_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359220
+FBti0211388_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359220
+FBti0211388_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359220
+FBti0211389_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211389_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211389_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359130
+FBti0211389_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359130
+FBti0211389_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359130
+FBti0211389_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359221
+FBti0211389_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359221
+FBti0211389_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359221
+FBti0211390_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211390_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211390_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359131
+FBti0211390_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359131
+FBti0211390_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359131
+FBti0211390_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359222
+FBti0211390_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359222
+FBti0211390_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359222
+FBti0211391_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211391_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211391_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359132
+FBti0211391_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359132
+FBti0211391_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359132
+FBti0211391_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359223
+FBti0211391_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359223
+FBti0211391_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359223
+FBti0211392_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211392_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211392_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359133
+FBti0211392_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359133
+FBti0211392_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359133
+FBti0211392_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359224
+FBti0211392_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359224
+FBti0211392_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359224
+FBti0211393_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211393_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211393_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359134
+FBti0211393_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359134
+FBti0211393_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359134
+FBti0211393_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359225
+FBti0211393_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359225
+FBti0211393_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359225
+FBti0211394_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211394_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211394_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359135
+FBti0211394_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359135
+FBti0211394_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359135
+FBti0211394_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359226
+FBti0211394_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359226
+FBti0211394_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359226
+FBti0211395_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211395_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211395_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359136
+FBti0211395_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359136
+FBti0211395_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359136
+FBti0211395_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359227
+FBti0211395_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359227
+FBti0211395_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359227
+FBti0211396_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211396_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211396_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359137
+FBti0211396_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359137
+FBti0211396_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359137
+FBti0211396_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359259
+FBti0211396_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359259
+FBti0211396_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359259
+FBti0211397_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359138
+FBti0211397_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359138
+FBti0211397_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359138
+FBti0211398_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211398_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211398_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359139
+FBti0211398_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359139
+FBti0211398_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359139
+FBti0211398_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359228
+FBti0211398_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359228
+FBti0211398_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359228
+FBti0211399_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0211399_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0211399_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359140
+FBti0211399_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359140
+FBti0211399_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359291
+FBti0211399_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359291
+FBti0211400_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359141
+FBti0211400_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359141
+FBti0211400_cas	tagged_with	FBto0000070	FBrf0244475		TOOL DATA from: FBal0359141
+FBti0211401_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211401_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211401_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359142
+FBti0211401_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359142
+FBti0211401_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359142
+FBti0211401_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359229
+FBti0211401_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359229
+FBti0211401_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359229
+FBti0211402_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359143
+FBti0211402_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359143
+FBti0211402_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359143
+FBti0211403_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211403_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211403_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359144
+FBti0211403_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359144
+FBti0211403_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359144
+FBti0211403_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359230
+FBti0211403_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359230
+FBti0211403_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359230
+FBti0211404_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359145
+FBti0211404_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359145
+FBti0211404_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359145
+FBti0211405_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359146
+FBti0211405_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359146
+FBti0211405_cas	tagged_with	FBto0000070	FBrf0244475		TOOL DATA from: FBal0359146
+FBti0211406_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211406_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211406_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359147
+FBti0211406_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359147
+FBti0211406_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359147
+FBti0211406_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359231
+FBti0211406_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359231
+FBti0211406_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359231
+FBti0211407_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211407_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211407_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359148
+FBti0211407_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359148
+FBti0211407_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359148
+FBti0211407_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359232
+FBti0211407_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359232
+FBti0211407_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359232
+FBti0211408_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211408_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211408_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359149
+FBti0211408_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359149
+FBti0211408_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359149
+FBti0211408_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359233
+FBti0211408_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359233
+FBti0211408_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359233
+FBti0211409_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211409_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211409_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359150
+FBti0211409_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359150
+FBti0211409_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359150
+FBti0211409_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359234
+FBti0211409_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359234
+FBti0211409_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359234
+FBti0211410_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211410_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211410_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359151
+FBti0211410_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359151
+FBti0211410_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359151
+FBti0211410_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359235
+FBti0211410_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359235
+FBti0211410_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359235
+FBti0211411_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211411_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211411_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359152
+FBti0211411_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359152
+FBti0211411_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359152
+FBti0211411_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359236
+FBti0211411_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359236
+FBti0211411_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359236
+FBti0211412_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211412_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211412_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359153
+FBti0211412_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359153
+FBti0211412_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359153
+FBti0211412_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359237
+FBti0211412_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359237
+FBti0211412_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359237
+FBti0211413_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211413_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211413_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359154
+FBti0211413_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359154
+FBti0211413_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359154
+FBti0211413_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359238
+FBti0211413_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359238
+FBti0211413_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359238
+FBti0211414_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211414_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211414_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359155
+FBti0211414_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359155
+FBti0211414_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359155
+FBti0211414_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359239
+FBti0211414_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359239
+FBti0211414_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359239
+FBti0211415_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211415_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211415_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359156
+FBti0211415_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359156
+FBti0211415_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359156
+FBti0211415_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359240
+FBti0211415_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359240
+FBti0211415_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359240
+FBti0211416_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211416_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211416_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359157
+FBti0211416_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359157
+FBti0211416_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359157
+FBti0211416_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359241
+FBti0211416_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359241
+FBti0211416_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359241
+FBti0211417_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211417_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211417_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359158
+FBti0211417_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359158
+FBti0211417_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359158
+FBti0211417_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359242
+FBti0211417_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359242
+FBti0211417_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359242
+FBti0211418_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211418_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211418_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359159
+FBti0211418_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359159
+FBti0211418_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359159
+FBti0211418_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359243
+FBti0211418_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359243
+FBti0211418_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359243
+FBti0211419_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211419_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211419_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359160
+FBti0211419_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359160
+FBti0211419_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359160
+FBti0211419_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359244
+FBti0211419_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359244
+FBti0211419_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359244
+FBti0211420_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211420_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211420_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359161
+FBti0211420_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359161
+FBti0211420_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359161
+FBti0211420_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359245
+FBti0211420_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359245
+FBti0211420_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359245
+FBti0211421_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211421_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211421_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359162
+FBti0211421_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359162
+FBti0211421_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359162
+FBti0211421_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359246
+FBti0211421_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359246
+FBti0211421_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359246
+FBti0211422_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211422_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211422_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359163
+FBti0211422_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359163
+FBti0211422_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359163
+FBti0211422_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359247
+FBti0211422_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359247
+FBti0211422_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359247
+FBti0211423_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211423_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211423_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359164
+FBti0211423_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359164
+FBti0211423_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359164
+FBti0211423_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359248
+FBti0211423_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359248
+FBti0211423_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359248
+FBti0211424_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211424_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211424_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359165
+FBti0211424_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359165
+FBti0211424_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359165
+FBti0211424_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359249
+FBti0211424_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359249
+FBti0211424_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359249
+FBti0211425_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211425_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211425_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359166
+FBti0211425_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359166
+FBti0211425_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359166
+FBti0211425_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359250
+FBti0211425_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359250
+FBti0211425_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359250
+FBti0211426_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211426_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211426_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359167
+FBti0211426_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359167
+FBti0211426_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359167
+FBti0211426_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359251
+FBti0211426_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359251
+FBti0211426_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359251
+FBti0211427_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211427_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211427_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359168
+FBti0211427_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359168
+FBti0211427_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359168
+FBti0211427_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359252
+FBti0211427_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359252
+FBti0211427_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359252
+FBti0211428_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211428_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211428_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359169
+FBti0211428_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359169
+FBti0211428_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359169
+FBti0211428_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359253
+FBti0211428_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359253
+FBti0211428_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359253
+FBti0211429_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211429_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211429_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359170
+FBti0211429_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359170
+FBti0211429_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359170
+FBti0211429_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359254
+FBti0211429_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359254
+FBti0211429_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359254
+FBti0211430_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0211430_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0211430_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359171
+FBti0211430_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359171
+FBti0211430_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359290
+FBti0211430_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359290
+FBti0211431_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211431_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211431_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359172
+FBti0211431_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359172
+FBti0211431_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359172
+FBti0211431_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359255
+FBti0211431_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359255
+FBti0211431_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359255
+FBti0211432_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211432_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211432_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359173
+FBti0211432_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359173
+FBti0211432_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359173
+FBti0211432_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359256
+FBti0211432_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359256
+FBti0211432_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359256
+FBti0211433_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211433_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211433_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359174
+FBti0211433_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359174
+FBti0211433_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359174
+FBti0211433_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359257
+FBti0211433_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359257
+FBti0211433_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359257
+FBti0211434_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211434_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211434_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359175
+FBti0211434_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359175
+FBti0211434_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359175
+FBti0211434_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359258
+FBti0211434_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359258
+FBti0211434_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359258
+FBti0211435_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211435_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211435_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359176
+FBti0211435_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359176
+FBti0211435_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359176
+FBti0211435_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359260
+FBti0211435_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359260
+FBti0211435_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359260
+FBti0211436_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211436_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211436_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359177
+FBti0211436_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359177
+FBti0211436_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359177
+FBti0211436_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359261
+FBti0211436_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359261
+FBti0211436_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359261
+FBti0211437_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211437_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211437_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359178
+FBti0211437_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359178
+FBti0211437_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359178
+FBti0211437_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359262
+FBti0211437_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359262
+FBti0211437_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359262
+FBti0211438_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211438_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211438_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359179
+FBti0211438_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359179
+FBti0211438_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359179
+FBti0211438_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359263
+FBti0211438_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359263
+FBti0211438_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359263
+FBti0211439_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211439_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211439_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359180
+FBti0211439_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359180
+FBti0211439_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359180
+FBti0211439_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359264
+FBti0211439_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359264
+FBti0211439_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359264
+FBti0211440_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211440_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211440_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359181
+FBti0211440_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359181
+FBti0211440_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359181
+FBti0211440_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359265
+FBti0211440_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359265
+FBti0211440_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359265
+FBti0211441_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211441_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211441_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359182
+FBti0211441_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359182
+FBti0211441_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359182
+FBti0211441_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359266
+FBti0211441_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359266
+FBti0211441_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359266
+FBti0211442_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211442_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211442_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359183
+FBti0211442_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359183
+FBti0211442_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359183
+FBti0211442_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359267
+FBti0211442_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359267
+FBti0211442_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359267
+FBti0211443_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0211443_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0211443_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359184
+FBti0211443_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359184
+FBti0211443_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359292
+FBti0211443_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359292
+FBti0211444_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359185
+FBti0211444_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359185
+FBti0211444_cas	tagged_with	FBto0000070	FBrf0244475		TOOL DATA from: FBal0359185
+FBti0211445_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211445_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211445_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359186
+FBti0211445_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359186
+FBti0211445_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359186
+FBti0211445_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359268
+FBti0211445_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359268
+FBti0211445_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359268
+FBti0211446_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359187
+FBti0211446_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359187
+FBti0211446_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359187
+FBti0211447_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211447_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211447_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359188
+FBti0211447_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359188
+FBti0211447_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359188
+FBti0211447_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359269
+FBti0211447_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359269
+FBti0211447_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359269
+FBti0211448_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359189
+FBti0211448_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359189
+FBti0211448_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359189
+FBti0211449_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211449_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211449_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359190
+FBti0211449_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359190
+FBti0211449_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359190
+FBti0211449_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359270
+FBti0211449_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359270
+FBti0211449_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359270
+FBti0211450_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211450_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211450_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359191
+FBti0211450_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359191
+FBti0211450_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359191
+FBti0211450_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359271
+FBti0211450_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359271
+FBti0211450_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359271
+FBti0211451_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211451_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211451_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359192
+FBti0211451_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359192
+FBti0211451_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359192
+FBti0211451_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359272
+FBti0211451_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359272
+FBti0211451_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359272
+FBti0211452_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211452_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211452_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359193
+FBti0211452_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359193
+FBti0211452_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359193
+FBti0211452_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359273
+FBti0211452_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359273
+FBti0211452_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359273
+FBti0211453_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211453_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211453_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359194
+FBti0211453_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359194
+FBti0211453_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359194
+FBti0211453_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359274
+FBti0211453_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359274
+FBti0211453_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359274
+FBti0211454_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211454_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211454_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359195
+FBti0211454_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359195
+FBti0211454_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359195
+FBti0211454_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359275
+FBti0211454_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359275
+FBti0211454_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359275
+FBti0211455_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211455_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211455_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359196
+FBti0211455_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359196
+FBti0211455_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359196
+FBti0211455_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359276
+FBti0211455_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359276
+FBti0211455_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359276
+FBti0211456_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211456_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211456_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359197
+FBti0211456_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359197
+FBti0211456_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359197
+FBti0211456_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359277
+FBti0211456_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359277
+FBti0211456_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359277
+FBti0211457_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211457_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211457_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359198
+FBti0211457_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359198
+FBti0211457_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359198
+FBti0211457_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359278
+FBti0211457_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359278
+FBti0211457_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359278
+FBti0211458_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211458_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211458_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359199
+FBti0211458_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359199
+FBti0211458_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359199
+FBti0211458_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359279
+FBti0211458_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359279
+FBti0211458_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359279
+FBti0211459_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211459_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211459_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359200
+FBti0211459_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359200
+FBti0211459_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359200
+FBti0211459_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359280
+FBti0211459_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359280
+FBti0211459_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359280
+FBti0211460_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211460_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211460_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359201
+FBti0211460_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359201
+FBti0211460_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359201
+FBti0211460_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359281
+FBti0211460_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359281
+FBti0211460_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359281
+FBti0211461_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211461_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211461_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359202
+FBti0211461_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359202
+FBti0211461_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359202
+FBti0211461_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359282
+FBti0211461_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359282
+FBti0211461_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359282
+FBti0211462_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211462_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211462_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359203
+FBti0211462_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359203
+FBti0211462_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359203
+FBti0211462_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359283
+FBti0211462_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359283
+FBti0211462_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359283
+FBti0211463_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211463_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211463_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359204
+FBti0211463_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359204
+FBti0211463_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359204
+FBti0211463_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359284
+FBti0211463_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359284
+FBti0211463_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359284
+FBti0211464_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211464_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211464_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359205
+FBti0211464_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359205
+FBti0211464_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359205
+FBti0211464_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359285
+FBti0211464_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359285
+FBti0211464_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359285
+FBti0211465_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211465_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211465_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359206
+FBti0211465_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359206
+FBti0211465_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359206
+FBti0211465_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359286
+FBti0211465_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359286
+FBti0211465_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359286
+FBti0211466_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211466_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211466_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359207
+FBti0211466_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359207
+FBti0211466_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359207
+FBti0211466_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359287
+FBti0211466_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359287
+FBti0211466_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359287
+FBti0211467_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211467_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211467_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359208
+FBti0211467_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359208
+FBti0211467_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359208
+FBti0211467_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359288
+FBti0211467_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359288
+FBti0211467_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359288
+FBti0211468_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211468_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211468_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359209
+FBti0211468_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359209
+FBti0211468_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359209
+FBti0211468_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359289
+FBti0211468_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359289
+FBti0211468_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359289
+FBti0211477_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211477_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211477_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359444
+FBti0211477_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359487
+FBti0211478_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211478_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211478_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359445
+FBti0211478_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359465
+FBti0211479_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211479_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211479_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359446
+FBti0211479_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359466
+FBti0211480_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211480_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211480_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359447
+FBti0211480_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359467
+FBti0211481_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211481_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211481_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359448
+FBti0211481_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359468
+FBti0211482_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211482_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211482_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359449
+FBti0211482_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359469
+FBti0211483_cas				FTA: unable to add tool information from FBal0359455 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211484_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359456
+FBti0211485_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359457
+FBti0211486_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359458
+FBti0211487_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359459
+FBti0211488_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359460
+FBti0211489_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359461
+FBti0211490_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359462
+FBti0211491_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359463
+FBti0211492_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359464
+FBti0211493_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0211493_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0211493_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359470
+FBti0211493_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359490
+FBti0211494_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0211494_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0211494_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359471
+FBti0211494_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359491
+FBti0211495_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0211495_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0211495_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359472
+FBti0211495_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359492
+FBti0211496_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0211496_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0211496_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359473
+FBti0211496_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359493
+FBti0211497_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0211497_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0211497_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359474
+FBti0211497_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359494
+FBti0211498_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359475
+FBti0211498_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359475
+FBti0211499_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359476
+FBti0211499_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359476
+FBti0211500_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359477
+FBti0211500_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359477
+FBti0211501_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359478
+FBti0211501_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359478
+FBti0211502_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359479
+FBti0211502_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359479
+FBti0211503_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359480
+FBti0211503_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359480
+FBti0211504_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359481
+FBti0211504_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359481
+FBti0211505_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359482
+FBti0211505_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359482
+FBti0211506_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359483
+FBti0211506_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359483
+FBti0211507_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359484
+FBti0211507_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359484
+FBti0211508_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359485
+FBti0211508_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359485
+FBti0211509_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359486
+FBti0211509_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359486
+FBti0211510_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0211510_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0211510_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359488
+FBti0211510_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359489
+FBti0211563_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0211563_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0211563_cas	carries_tool	FBto0000328	FBrf0245076		TOOL DATA from: FBal0359570
+FBti0211564_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0211564_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0211565_cas	carries_tool	FBto0000330	FBrf0245076		TOOL DATA from: FBal0359574
+FBti0211565_cas	tagged_with	FBto0000093	FBrf0245076		TOOL DATA from: FBal0359574
+FBti0211571_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0359583
+FBti0211572_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0359584
+FBti0211573_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0359585
+FBti0211573_cas	tagged_with	FBto0000631	FBrf0228036		TOOL DATA from: FBal0359585
+FBti0211576_cas	encodes_tool	FBto0000140			TOOL DATA from: FBtp0128008
+FBti0211576_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128008
+FBti0211578_cas	tagged_with	FBto0000063	FBrf0245110		TOOL DATA from: FBal0359623
+FBti0211579_cas	tagged_with	FBto0000027	FBrf0244780		TOOL DATA from: FBal0359625
+FBti0211584_cas	carries_tool	FBto0000349	FBrf0244840		TOOL DATA from: FBal0359654
+FBti0211584_cas	carries_tool	FBto0000356	FBrf0244840		TOOL DATA from: FBal0359654
+FBti0211585_cas	tagged_with	FBto0000031	FBrf0244840		TOOL DATA from: FBal0359655
+FBti0211586_cas	tagged_with	FBto0000079	FBrf0244840		TOOL DATA from: FBal0359656
+FBti0211587_cas	tagged_with	FBto0000031	FBrf0244840		TOOL DATA from: FBal0359657
+FBti0211588_cas	tagged_with	FBto0000079	FBrf0244840		TOOL DATA from: FBal0359658
+FBti0211589_cas	tagged_with	FBto0000079	FBrf0244840		TOOL DATA from: FBal0359659
+FBti0211590_cas	tagged_with	FBto0000031	FBrf0244840		TOOL DATA from: FBal0359660
+FBti0211591_cas	tagged_with	FBto0000079	FBrf0244840		TOOL DATA from: FBal0359661
+FBti0211618_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211618_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211636_cas	carries_tool	FBto0000318	FBrf0245010		TOOL DATA from: FBal0359829
+FBti0211637_cas	carries_tool	FBto0000318	FBrf0245010		TOOL DATA from: FBal0359830
+FBti0211651_cas	tagged_with	FBto0000077	FBrf0245266		TOOL DATA from: FBal0359851
+FBti0211652_cas	tagged_with	FBto0000081	FBrf0245266		TOOL DATA from: FBal0359852
+FBti0211658_cas	tagged_with	FBto0000070	FBrf0245151		TOOL DATA from: FBal0359889
+FBti0211658_cas	tagged_with	FBto0000093	FBrf0245151		TOOL DATA from: FBal0359889
+FBti0211659_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359910
+FBti0211660_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359911
+FBti0211661_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359912
+FBti0211662_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359913
+FBti0211663_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359914
+FBti0211674_cas	tagged_with	FBto0000126	FBrf0245336		TOOL DATA from: FBal0359962
+FBti0211693_cas	carries_tool	FBto0000349	FBrf0238973		TOOL DATA from: FBal0360037
+FBti0211693_cas	tagged_with	FBto0000102	FBrf0238973		TOOL DATA from: FBal0360037
+FBti0211694_cas	carries_tool	FBto0000318	FBrf0243105		TOOL DATA from: FBal0360072
+FBti0211694_cas	tagged_with	FBto0000031	FBrf0243105		TOOL DATA from: FBal0360072
+FBti0211695_cas	carries_tool	FBto0000318	FBrf0243105		TOOL DATA from: FBal0360074
+FBti0211695_cas	carries_tool	FBto0000349	FBrf0243105		TOOL DATA from: FBal0360074
+FBti0211695_cas	tagged_with	FBto0000093	FBrf0243105		TOOL DATA from: FBal0360074
+FBti0211723_cas				FTA: unable to add tool information from FBal0360096 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211742_cas	carries_tool	FBto0000349	FBrf0245480		TOOL DATA from: FBal0360116
+FBti0211742_cas	tagged_with	FBto0000118	FBrf0245480		TOOL DATA from: FBal0360116
+FBti0211743_cas	carries_tool	FBto0000349	FBrf0245480		TOOL DATA from: FBal0360118
+FBti0211743_cas	tagged_with	FBto0000077	FBrf0245480		TOOL DATA from: FBal0360118
+FBti0211745_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360147
+FBti0211745_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360147
+FBti0211746_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360148
+FBti0211746_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360148
+FBti0211747_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360149
+FBti0211747_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360149
+FBti0211748_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360150
+FBti0211748_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360150
+FBti0211749_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360151
+FBti0211749_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360151
+FBti0211750_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360152
+FBti0211750_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360152
+FBti0211751_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360153
+FBti0211751_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360153
+FBti0211752_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360154
+FBti0211752_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360154
+FBti0211753_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360155
+FBti0211753_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360155
+FBti0211756_cas	carries_tool	FBto0000349	FBrf0245267		TOOL DATA from: FBal0360161
+FBti0211767_cas	tagged_with	FBto0000063	FBrf0245244		TOOL DATA from: FBal0360193
+FBti0211773_cas	tagged_with	FBto0000027	FBrf0245489		TOOL DATA from: FBal0360203
+FBti0211774_cas	tagged_with	FBto0000027	FBrf0245489		TOOL DATA from: FBal0360204
+FBti0211781_cas	tagged_with	FBto0000077	FBrf0240007		TOOL DATA from: FBal0360217
+FBti0211781_cas	tagged_with	FBto0000083	FBrf0240007		TOOL DATA from: FBal0360217
+FBti0211781_cas	tagged_with	FBto0000341	FBrf0240007		TOOL DATA from: FBal0360217
+FBti0211781_cas	tagged_with	FBto0000648	FBrf0240007		TOOL DATA from: FBal0360217
+FBti0211792_cas	tagged_with	FBto0000079	FBrf0245546		TOOL DATA from: FBal0360254
+FBti0211793_cas	tagged_with	FBto0000623	FBrf0245546		TOOL DATA from: FBal0360255
+FBti0211800_cas	carries_tool	FBto0000318	FBrf0245549		TOOL DATA from: FBal0360263
+FBti0211812_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211812_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211812_cas	has_reg_region	FBgn0024184	FBrf0245411		TOOL DATA from: FBal0360280
+FBti0211813_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0211813_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0211813_cas	has_reg_region	FBgn0024184	FBrf0245411		TOOL DATA from: FBal0360281
+FBti0211816_cas	carries_tool	FBto0000318	FBrf0245411		TOOL DATA from: FBal0360285
+FBti0211816_cas	carries_tool	FBto0000356	FBrf0245411		TOOL DATA from: FBal0360285
+FBti0211818_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0211818_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0211819_cas	carries_tool	FBto0000349	FBrf0245582		TOOL DATA from: FBal0360294
+FBti0211819_cas	carries_tool	FBto0000356	FBrf0245582		TOOL DATA from: FBal0360294
+FBti0211829_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0211829_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0211829_cas	carries_tool	FBto0000320	FBrf0245361		TOOL DATA from: FBal0360341
+FBti0211829_cas	carries_tool	FBto0000349	FBrf0245361		TOOL DATA from: FBal0360341
+FBti0211829_cas	carries_tool	FBto0000356	FBrf0245361		TOOL DATA from: FBal0360341
+FBti0211837_cas	tagged_with	FBto0000102	FBrf0245401		TOOL DATA from: FBal0360412
+FBti0211843_cas	carries_tool	FBto0000318	FBrf0243127		TOOL DATA from: FBal0360428
+FBti0211865_cas	tagged_with	FBto0000027	FBrf0240504		TOOL DATA from: FBal0360440
+FBti0211868_cas	tagged_with	FBto0000027	FBrf0238303		TOOL DATA from: FBal0360454
+FBti0211887_cas	tagged_with	FBto0000375	FBrf0245670		TOOL DATA from: FBal0360508
+FBti0211888_cas	tagged_with	FBto0000063	FBrf0245670		TOOL DATA from: FBal0360509
+FBti0211889_cas	tagged_with	FBto0000063	FBrf0245670		TOOL DATA from: FBal0360511
+FBti0211890_cas	carries_tool	FBto0000349	FBrf0245649		TOOL DATA from: FBal0360512
+FBti0211890_cas	carries_tool	FBto0000356	FBrf0245649		TOOL DATA from: FBal0360512
+FBti0211891_cas	tagged_with	FBto0000077	FBrf0245649		TOOL DATA from: FBal0360513
+FBti0211895_cas	tagged_with	FBto0000076	FBrf0245656		TOOL DATA from: FBal0360516
+FBti0211895_cas	tagged_with	FBto0000077	FBrf0245656		TOOL DATA from: FBal0360516
+FBti0211896_cas	tagged_with	FBto0000076	FBrf0245656		TOOL DATA from: FBal0360517
+FBti0211896_cas	tagged_with	FBto0000077	FBrf0245656		TOOL DATA from: FBal0360517
+FBti0211897_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0211897_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0211897_cas	tagged_with	FBto0000349	FBrf0245496		TOOL DATA from: FBal0360518
+FBti0211897_cas	tagged_with	FBto0000349	FBrf0245496		TOOL DATA from: FBal0360522
+FBti0211898_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211898_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211898_cas	tagged_with	FBto0000079	FBrf0245496		TOOL DATA from: FBal0360519
+FBti0211898_cas	tagged_with	FBto0000079	FBrf0245496		TOOL DATA from: FBal0360521
+FBti0211965_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0211965_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0211966_cas	encodes_tool	FBto0000140			TOOL DATA from: FBtp0128008
+FBti0211966_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128008
+FBti0211967_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0211967_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0211968_cas	encodes_tool	FBto0000140			TOOL DATA from: FBtp0128008
+FBti0211968_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128008
+FBti0211969_cas	tagged_with	FBto0000076	FBrf0244403		TOOL DATA from: FBal0360585
+FBti0211969_cas	tagged_with	FBto0000403	FBrf0244403		TOOL DATA from: FBal0360585
+FBti0211970_cas	tagged_with	FBto0000076	FBrf0244403		TOOL DATA from: FBal0360586
+FBti0211970_cas	tagged_with	FBto0000403	FBrf0244403		TOOL DATA from: FBal0360586
+FBti0211973_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0211973_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0211980_cas	carries_tool	FBto0000349	FBrf0235399		TOOL DATA from: FBal0360611
+FBti0211980_cas	carries_tool	FBto0000356	FBrf0235399		TOOL DATA from: FBal0360611
+FBti0211981_cas	carries_tool	FBto0000349	FBrf0235399		TOOL DATA from: FBal0360612
+FBti0211981_cas	carries_tool	FBto0000356	FBrf0235399		TOOL DATA from: FBal0360612
+FBti0211982_cas	carries_tool	FBto0000349	FBrf0235399		TOOL DATA from: FBal0360613
+FBti0211982_cas	carries_tool	FBto0000356	FBrf0235399		TOOL DATA from: FBal0360613
+FBti0211988_cas	tagged_with	FBto0000063	FBrf0245723		TOOL DATA from: FBal0360679
+FBti0211989_cas	tagged_with	FBto0000063	FBrf0245723		TOOL DATA from: FBal0360681
+FBti0211990_cas	tagged_with	FBto0000638	FBrf0245723		TOOL DATA from: FBal0360682
+FBti0211991_cas	tagged_with	FBto0000031	FBrf0245652		TOOL DATA from: FBal0360684
+FBti0212028_cas	tagged_with	FBto0000044	FBrf0245368		TOOL DATA from: FBal0360691
+FBti0212029_cas	tagged_with	FBto0000657	FBrf0245368		TOOL DATA from: FBal0360692
+FBti0212039_cas	carries_tool	FBto0000349	FBrf0236734		TOOL DATA from: FBal0360710
+FBti0212040_cas	carries_tool	FBto0000349	FBrf0236734		TOOL DATA from: FBal0360711
+FBti0212041_cas	carries_tool	FBto0000349	FBrf0236734		TOOL DATA from: FBal0360712
+FBti0212042_cas	carries_tool	FBto0000349	FBrf0236734		TOOL DATA from: FBal0360713
+FBti0212043_cas	carries_tool	FBto0000318	FBrf0236421		TOOL DATA from: FBal0360714
+FBti0212043_cas	tagged_with	FBto0000077	FBrf0236421		TOOL DATA from: FBal0360714
+FBti0212044_cas	carries_tool	FBto0000318	FBrf0236421		TOOL DATA from: FBal0360715
+FBti0212044_cas	tagged_with	FBto0000077	FBrf0236421		TOOL DATA from: FBal0360715
+FBti0212045_cas	carries_tool	FBto0000318	FBrf0236421		TOOL DATA from: FBal0360716
+FBti0212045_cas	tagged_with	FBto0000031	FBrf0236421		TOOL DATA from: FBal0360716
+FBti0212045_cas	tagged_with	FBto0000077	FBrf0236421		TOOL DATA from: FBal0360716
+FBti0212045_cas	tagged_with	FBto0000208	FBrf0236421		TOOL DATA from: FBal0360716
+FBti0212049_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0212049_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0212050_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0212050_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0212051_cas	carries_tool	FBto0000349	FBrf0245680		TOOL DATA from: FBal0360757
+FBti0212051_cas	tagged_with	FBto0000087	FBrf0245680		TOOL DATA from: FBal0360757
+FBti0212052_cas	carries_tool	FBto0000349	FBrf0245680		TOOL DATA from: FBal0360758
+FBti0212053_cas	carries_tool	FBto0000349	FBrf0245680		TOOL DATA from: FBal0360759
+FBti0212053_cas	tagged_with	FBto0000093	FBrf0245680		TOOL DATA from: FBal0360759
+FBti0212054_cas	carries_tool	FBto0000318	FBrf0245817		TOOL DATA from: FBal0360829
+FBti0212054_cas	tagged_with	FBto0000027	FBrf0245817		TOOL DATA from: FBal0360829
+FBti0212055_cas	carries_tool	FBto0000318	FBrf0245817		TOOL DATA from: FBal0360830
+FBti0212055_cas	tagged_with	FBto0000027	FBrf0245817		TOOL DATA from: FBal0360830
+FBti0212056_cas	carries_tool	FBto0000318	FBrf0245817		TOOL DATA from: FBal0360832
+FBti0212056_cas	tagged_with	FBto0000027	FBrf0245817		TOOL DATA from: FBal0360832
+FBti0212057_cas	carries_tool	FBto0000318	FBrf0245817		TOOL DATA from: FBal0360833
+FBti0212057_cas	tagged_with	FBto0000027	FBrf0245817		TOOL DATA from: FBal0360833
+FBti0212058_cas	tagged_with	FBto0000059	FBrf0237415		TOOL DATA from: FBal0360835
+FBti0212058_cas	tagged_with	FBto0000093	FBrf0237415		TOOL DATA from: FBal0360835
+FBti0212059_cas	tagged_with	FBto0000027	FBrf0244153		TOOL DATA from: FBal0360844
+FBti0212060_cas	carries_tool	FBto0000318	FBrf0244135		TOOL DATA from: FBal0360845
+FBti0212060_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360845
+FBti0212061_cas	carries_tool	FBto0000318	FBrf0244135		TOOL DATA from: FBal0360846
+FBti0212061_cas	tagged_with	FBto0000079	FBrf0244135		TOOL DATA from: FBal0360846
+FBti0212062_cas				FTA: unable to add tool information from FBal0360847 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212063_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360848
+FBti0212064_cas	carries_tool	FBto0000318	FBrf0244135		TOOL DATA from: FBal0360849
+FBti0212064_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360849
+FBti0212065_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360850
+FBti0212066_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360851
+FBti0212067_cas				FTA: unable to add tool information from FBal0360858 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212068_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360859
+FBti0212070_cas	tagged_with	FBto0000077	FBrf0245745		TOOL DATA from: FBal0360882
+FBti0212071_cas	tagged_with	FBto0000077	FBrf0245745		TOOL DATA from: FBal0360883
+FBti0212072_cas	tagged_with	FBto0000077	FBrf0245745		TOOL DATA from: FBal0360884
+FBti0212073_cas	has_reg_region	FBto0000180			TOOL DATA from: FBtp0117267
+FBti0212073_cas	tool_uses	misexpression element			TOOL DATA from: FBtp0117267
+FBti0212074_cas	tagged_with	FBto0000031	FBrf0245625		TOOL DATA from: FBal0360900
+FBti0212075_cas	tagged_with	FBto0000031	FBrf0245625		TOOL DATA from: FBal0360901
+FBti0212076_cas	tagged_with	FBto0000031	FBrf0245625		TOOL DATA from: FBal0360902
+FBti0212077_cas	tagged_with	FBto0000031	FBrf0245625		TOOL DATA from: FBal0360903
+FBti0212078_cas	tagged_with	FBto0000027	FBrf0245610		TOOL DATA from: FBal0360907
+FBti0212078_cas	tagged_with	FBto0000645	FBrf0245610		TOOL DATA from: FBal0360907
+FBti0212108_cas	tagged_with	FBto0000118	FBrf0230036		TOOL DATA from: FBal0361023
+FBti0212109_cas	tagged_with	FBto0000031	FBrf0230036		TOOL DATA from: FBal0361024
+FBti0212110_cas	tagged_with	FBto0000031	FBrf0230036		TOOL DATA from: FBal0361025
+FBti0212111_cas	tagged_with	FBto0000031	FBrf0230036		TOOL DATA from: FBal0361026
+FBti0212127_cas	tagged_with	FBto0000031	FBrf0235463		TOOL DATA from: FBal0361063
+FBti0212128_cas	tagged_with	FBto0000031	FBrf0235463		TOOL DATA from: FBal0361064
+FBti0212129_cas	tagged_with	FBto0000098	FBrf0235463		TOOL DATA from: FBal0361065
+FBti0212130_cas	tagged_with	FBto0000335	FBrf0235463		TOOL DATA from: FBal0361066
+FBti0212132_cas				FTA: unable to add tool information from FBal0361089 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212133_cas	tagged_with	FBto0000077	FBrf0245714		TOOL DATA from: FBal0361093
+FBti0212162_cas	carries_tool	FBto0000349	FBrf0236127		TOOL DATA from: FBal0361096
+FBti0212162_cas	carries_tool	FBto0000356	FBrf0236127		TOOL DATA from: FBal0361096
+FBti0212164_cas	tagged_with	FBto0000077	FBrf0236127		TOOL DATA from: FBal0361098
+FBti0212164_cas	tagged_with	FBto0000118	FBrf0236127		TOOL DATA from: FBal0361098
+FBti0212165_cas	tagged_with	FBto0000118	FBrf0236127		TOOL DATA from: FBal0361100
+FBti0212165_cas	tagged_with	FBto0000389	FBrf0236127		TOOL DATA from: FBal0361100
+FBti0212166_cas	tagged_with	FBto0000077	FBrf0236127		TOOL DATA from: FBal0361101
+FBti0212167_cas	tagged_with	FBto0000389	FBrf0236127		TOOL DATA from: FBal0361102
+FBti0212168_cas	tagged_with	FBto0000027	FBrf0236127		TOOL DATA from: FBal0361103
+FBti0212169_cas	tagged_with	FBto0000118	FBrf0236127		TOOL DATA from: FBal0361104
+FBti0212169_cas	tagged_with	FBto0000389	FBrf0236127		TOOL DATA from: FBal0361104
+FBti0212170_cas	tagged_with	FBto0000118	FBrf0236127		TOOL DATA from: FBal0361105
+FBti0212172_cas	carries_tool	FBto0000349	FBrf0244288		TOOL DATA from: FBal0361108
+FBti0212194_cas	tagged_with	FBto0000383	FBrf0245675		TOOL DATA from: FBal0361143
+FBti0212194_cas	tagged_with	FBto0000623	FBrf0245675		TOOL DATA from: FBal0361143
+FBti0212249_cas	tagged_with	FBto0000118	FBrf0237927		TOOL DATA from: FBal0361228
+FBti0212250_cas	tagged_with	FBto0000118	FBrf0237927		TOOL DATA from: FBal0361229
+FBti0212251_cas	tagged_with	FBto0000118	FBrf0237927		TOOL DATA from: FBal0361230
+FBti0212260_cas	encodes_tool	FBto0000659			TOOL DATA from: FBtp0142855
+FBti0212260_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0142855
+FBti0212435_cas	tagged_with	FBto0000126	FBrf0245622		TOOL DATA from: FBal0361564
+FBti0212436_cas	tagged_with	FBto0000118	FBrf0245622		TOOL DATA from: FBal0361565
+FBti0212439_cas				FTA: unable to add tool information from FBal0361572 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212441_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361606
+FBti0212441_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361611
+FBti0212442_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361607
+FBti0212442_cas	tagged_with	FBto0000088	FBrf0245820		TOOL DATA from: FBal0361607
+FBti0212442_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361613
+FBti0212442_cas	tagged_with	FBto0000088	FBrf0245820		TOOL DATA from: FBal0361613
+FBti0212443_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361608
+FBti0212443_cas	tagged_with	FBto0000088	FBrf0245820		TOOL DATA from: FBal0361608
+FBti0212443_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361612
+FBti0212443_cas	tagged_with	FBto0000088	FBrf0245820		TOOL DATA from: FBal0361612
+FBti0212455_cas	carries_tool	FBto0000349	FBrf0245851		TOOL DATA from: FBal0361663
+FBti0212455_cas	carries_tool	FBto0000356	FBrf0245851		TOOL DATA from: FBal0361663
+FBti0212472_cas	carries_tool	FBto0000356	FBrf0240602		TOOL DATA from: FBal0361792
+FBti0212473_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0212473_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0212474_cas	carries_tool	FBto0000356	FBrf0240602		TOOL DATA from: FBal0361794
+FBti0212475_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0212475_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0212476_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0212476_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0212476_cas	carries_tool	FBto0000320	FBrf0245208		TOOL DATA from: FBal0361817
+FBti0212476_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361817
+FBti0212476_cas	carries_tool	FBto0000356	FBrf0245208		TOOL DATA from: FBal0361817
+FBti0212476_cas	carries_tool	FBto0000320	FBrf0245208		TOOL DATA from: FBal0361825
+FBti0212476_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361825
+FBti0212476_cas	carries_tool	FBto0000356	FBrf0245208		TOOL DATA from: FBal0361825
+FBti0212477_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0212477_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0212478_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0212478_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0212478_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361821
+FBti0212478_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361826
+FBti0212479_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0212479_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0212479_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361822
+FBti0212479_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361827
+FBti0212494_cas	carries_tool	FBto0000349	FBrf0245934		TOOL DATA from: FBal0361909
+FBti0212495_cas				FTA: unable to add tool information from FBal0361910 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212498_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361916
+FBti0212498_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361916
+FBti0212498_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361916
+FBti0212499_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361917
+FBti0212499_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361917
+FBti0212499_cas	tagged_with	FBto0000118	FBrf0239019		TOOL DATA from: FBal0361917
+FBti0212500_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361918
+FBti0212500_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361918
+FBti0212500_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361918
+FBti0212501_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361919
+FBti0212501_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361919
+FBti0212501_cas	tagged_with	FBto0000118	FBrf0239019		TOOL DATA from: FBal0361919
+FBti0212502_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361920
+FBti0212502_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361920
+FBti0212502_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361920
+FBti0212503_cas				FTA: unable to add tool information from FBal0361921 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212504_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361922
+FBti0212504_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361922
+FBti0212504_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361922
+FBti0212505_cas				FTA: unable to add tool information from FBal0361923 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212506_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361924
+FBti0212506_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361924
+FBti0212506_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361924
+FBti0212507_cas				FTA: unable to add tool information from FBal0361925 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212508_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361926
+FBti0212508_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361926
+FBti0212508_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361926
+FBti0212509_cas				FTA: unable to add tool information from FBal0361927 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212510_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361928
+FBti0212510_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361928
+FBti0212510_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361928
+FBti0212511_cas				FTA: unable to add tool information from FBal0361929 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212535_cas	tagged_with	FBto0000031	FBrf0245969		TOOL DATA from: FBal0362005
+FBti0212542_cas	tagged_with	FBto0000076	FBrf0246239		TOOL DATA from: FBal0362028
+FBti0212563_cas	tagged_with	FBto0000093	FBrf0246013		TOOL DATA from: FBal0362049
+FBti0212595_cas				FTA: unable to add tool information from FBal0362192 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212596_cas				FTA: unable to add tool information from FBal0362197 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212638_cas	tagged_with	FBto0000079	FBrf0239855		TOOL DATA from: FBal0362366
+FBti0212658_cas	carries_tool	FBto0000349	FBrf0246291		TOOL DATA from: FBal0362379
+FBti0212659_cas	carries_tool	FBto0000349	FBrf0246291		TOOL DATA from: FBal0362380
+FBti0212662_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0212662_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0212662_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0362384
+FBti0212662_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0362386
+FBti0212662_cas	tagged_with	FBto0000242	FBrf0239978		TOOL DATA from: FBal0362386
+FBti0212663_cas	tagged_with	FBto0000077	FBrf0246343		TOOL DATA from: FBal0362400
+FBti0212664_cas	tagged_with	FBto0000077	FBrf0246343		TOOL DATA from: FBal0362401
+FBti0212679_cas	tagged_with	FBto0000031	FBrf0246316		TOOL DATA from: FBal0362413
+FBti0212681_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362428
+FBti0212681_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362428
+FBti0212681_cas	tagged_with	FBto0000102	FBrf0246393		TOOL DATA from: FBal0362428
+FBti0212682_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362429
+FBti0212682_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362429
+FBti0212682_cas	tagged_with	FBto0000102	FBrf0246393		TOOL DATA from: FBal0362429
+FBti0212683_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362430
+FBti0212683_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362430
+FBti0212684_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362431
+FBti0212684_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362431
+FBti0212685_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362432
+FBti0212685_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362432
+FBti0212686_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362433
+FBti0212686_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362433
+FBti0212687_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362434
+FBti0212687_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362434
+FBti0212688_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362435
+FBti0212688_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362435
+FBti0212689_cas	tagged_with	FBto0000118	FBrf0246393		TOOL DATA from: FBal0362436
+FBti0212690_cas	tagged_with	FBto0000118	FBrf0246393		TOOL DATA from: FBal0362437
+FBti0212691_cas	tagged_with	FBto0000349	FBrf0246393		TOOL DATA from: FBal0362438
+FBti0212692_cas	tagged_with	FBto0000349	FBrf0246393		TOOL DATA from: FBal0362439
+FBti0212712_cas				FTA: unable to add tool information from FBal0361571 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212713_cas	tagged_with	FBto0000063	FBrf0246352		TOOL DATA from: FBal0362482
+FBti0212714_cas	tagged_with	FBto0000063	FBrf0246352		TOOL DATA from: FBal0362483
+FBti0212715_cas	carries_tool	FBto0000349	FBrf0246352		TOOL DATA from: FBal0362484
+FBti0212715_cas	tagged_with	FBto0000027	FBrf0246352		TOOL DATA from: FBal0362484
+FBti0212835_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0212835_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0212838_cas	tagged_with	FBto0000063	FBrf0246491		TOOL DATA from: FBal0362633
+FBti0212839_cas				FTA: unable to add tool information from FBal0362634 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212840_cas	carries_tool	FBto0000356	FBrf0246334		TOOL DATA from: FBal0362644
+FBti0212852_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0212852_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0212852_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362679
+FBti0212852_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362697
+FBti0212853_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0212853_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0212853_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362680
+FBti0212853_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362706
+FBti0212854_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0212854_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0212854_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362681
+FBti0212854_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362709
+FBti0212855_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0212855_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0212855_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362682
+FBti0212855_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362713
+FBti0212856_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0212856_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0212856_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362683
+FBti0212856_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362718
+FBti0212857_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0212857_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0212857_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362684
+FBti0212857_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362721
+FBti0212859_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0212859_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0212859_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362686
+FBti0212859_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362692
+FBti0212860_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0212860_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0212860_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362687
+FBti0212860_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362698
+FBti0212861_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0212861_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0212861_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362688
+FBti0212861_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362707
+FBti0212862_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0212862_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0212862_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362689
+FBti0212862_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362714
+FBti0212863_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0212863_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0212863_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362690
+FBti0212863_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362719
+FBti0212864_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0212864_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0212864_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362691
+FBti0212864_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362722
+FBti0212876_cas	tagged_with	FBto0000063	FBrf0246472		TOOL DATA from: FBal0362737
+FBti0212877_cas	tagged_with	FBto0000076	FBrf0246472		TOOL DATA from: FBal0362738
+FBti0212884_cas	tagged_with	FBto0000076	FBrf0246152		TOOL DATA from: FBal0362756
+FBti0212884_cas	tagged_with	FBto0000077	FBrf0246152		TOOL DATA from: FBal0362756
+FBti0212885_cas	tagged_with	FBto0000077	FBrf0240108		TOOL DATA from: FBal0362757
+FBti0212886_cas	tagged_with	FBto0000063	FBrf0246424		TOOL DATA from: FBal0362758
+FBti0212889_cas	tagged_with	FBto0000077	FBrf0245204		TOOL DATA from: FBal0362762
+FBti0212890_cas				FTA: unable to add tool information from FBal0362770 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212906_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362797
+FBti0212906_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362797
+FBti0212907_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362798
+FBti0212907_cas	tagged_with	FBto0000118	FBrf0246756		TOOL DATA from: FBal0362798
+FBti0212908_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362799
+FBti0212908_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362799
+FBti0212908_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362808
+FBti0212908_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362808
+FBti0212909_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362800
+FBti0212909_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362800
+FBti0212909_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362804
+FBti0212909_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362804
+FBti0212910_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362801
+FBti0212910_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362801
+FBti0212910_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362805
+FBti0212910_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362805
+FBti0212911_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362802
+FBti0212911_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362802
+FBti0212911_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362806
+FBti0212911_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362806
+FBti0212912_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362803
+FBti0212912_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362803
+FBti0212912_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362807
+FBti0212912_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362807
+FBti0212913_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362809
+FBti0212913_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362809
+FBti0212913_cas	tagged_with	FBto0000027	FBrf0246730		TOOL DATA from: FBal0362809
+FBti0212914_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362811
+FBti0212914_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362811
+FBti0212914_cas	tagged_with	FBto0000014	FBrf0246730		TOOL DATA from: FBal0362811
+FBti0212914_cas	tagged_with	FBto0000643	FBrf0246730		TOOL DATA from: FBal0362811
+FBti0212915_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362812
+FBti0212915_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362812
+FBti0212915_cas	tagged_with	FBto0000027	FBrf0246730		TOOL DATA from: FBal0362812
+FBti0212916_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362813
+FBti0212916_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362813
+FBti0212916_cas	tagged_with	FBto0000027	FBrf0246730		TOOL DATA from: FBal0362813
+FBti0212916_cas	tagged_with	FBto0000643	FBrf0246730		TOOL DATA from: FBal0362813
+FBti0212917_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362815
+FBti0212917_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362815
+FBti0212917_cas	tagged_with	FBto0000027	FBrf0246730		TOOL DATA from: FBal0362815
+FBti0213045_cas	tagged_with	FBto0000081	FBrf0246671		TOOL DATA from: FBal0363093
+FBti0213045_cas	tagged_with	FBto0000213	FBrf0246671		TOOL DATA from: FBal0363093
+FBti0213048_cas				FTA: unable to add tool information from FBal0363113 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213049_cas	tagged_with	FBto0000077	FBrf0246134		TOOL DATA from: FBal0363114
+FBti0213050_cas				FTA: unable to add tool information from FBal0363116 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213051_cas	tagged_with	FBto0000077	FBrf0246134		TOOL DATA from: FBal0363118
+FBti0213052_cas				FTA: unable to add tool information from FBal0363121 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213053_cas	tagged_with	FBto0000077	FBrf0246134		TOOL DATA from: FBal0363123
+FBti0213054_cas				FTA: unable to add tool information from FBal0363126 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213055_cas	tagged_with	FBto0000077	FBrf0246134		TOOL DATA from: FBal0363127
+FBti0213089_cas				FTA: unable to add tool information from FBal0363195 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213090_cas				FTA: unable to add tool information from FBal0363196 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213099_cas	tagged_with	FBto0000076	FBrf0246833		TOOL DATA from: FBal0363276
+FBti0213099_cas	tagged_with	FBto0000093	FBrf0246833		TOOL DATA from: FBal0363276
+FBti0213100_cas	tagged_with	FBto0000076	FBrf0246833		TOOL DATA from: FBal0363277
+FBti0213100_cas	tagged_with	FBto0000093	FBrf0246833		TOOL DATA from: FBal0363277
+FBti0213145_cas				FTA: unable to add tool information from FBal0363343 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213153_cas	carries_tool	FBto0000349	FBrf0222906		TOOL DATA from: FBal0363450
+FBti0213154_cas	carries_tool	FBto0000349	FBrf0222906		TOOL DATA from: FBal0363451
+FBti0213159_cas	carries_tool	FBto0000349	FBrf0246761		TOOL DATA from: FBal0363459
+FBti0213197_cas	tagged_with	FBto0000102	FBrf0246880		TOOL DATA from: FBal0363552
+FBti0213198_cas	tagged_with	FBto0000099	FBrf0246880		TOOL DATA from: FBal0363554
+FBti0213199_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0213199_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0213200_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0213200_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0213201_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363561
+FBti0213201_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363561
+FBti0213202_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0213202_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0213202_cas	tagged_with	FBto0000242	FBrf0246737		TOOL DATA from: FBal0363576
+FBti0213203_cas	carries_tool	FBto0000320	FBrf0246737		TOOL DATA from: FBal0363563
+FBti0213204_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363564
+FBti0213204_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363564
+FBti0213205_cas	tagged_with	FBto0000031	FBrf0246737		TOOL DATA from: FBal0363565
+FBti0213206_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0213206_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0213206_cas	tagged_with	FBto0000242	FBrf0246737		TOOL DATA from: FBal0363575
+FBti0213207_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363571
+FBti0213207_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363571
+FBti0213208_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0213208_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0213208_cas	tagged_with	FBto0000242	FBrf0246737		TOOL DATA from: FBal0363577
+FBti0213209_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0213209_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0213209_cas	tagged_with	FBto0000242	FBrf0246737		TOOL DATA from: FBal0363578
+FBti0213210_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363579
+FBti0213210_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363579
+FBti0213211_cas	tagged_with	FBto0000077	FBrf0246737		TOOL DATA from: FBal0363580
+FBti0213212_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363583
+FBti0213212_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363583
+FBti0213213_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363585
+FBti0213213_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363585
+FBti0213214_cas	tagged_with	FBto0000031	FBrf0246737		TOOL DATA from: FBal0363586
+FBti0213234_cas	tagged_with	FBto0000099	FBrf0243017		TOOL DATA from: FBal0363669
+FBti0213242_cas	tagged_with	FBto0000076	FBrf0242056		TOOL DATA from: FBal0363694
+FBti0213244_cas	carries_tool	FBto0000349	FBrf0246147		TOOL DATA from: FBal0363739
+FBti0213244_cas	carries_tool	FBto0000356	FBrf0246147		TOOL DATA from: FBal0363739
+FBti0213245_cas	tagged_with	FBto0000076	FBrf0246147		TOOL DATA from: FBal0363741
+FBti0213245_cas	tagged_with	FBto0000077	FBrf0246147		TOOL DATA from: FBal0363741
+FBti0213246_cas	carries_tool	FBto0000349	FBrf0246147		TOOL DATA from: FBal0363744
+FBti0213246_cas	carries_tool	FBto0000356	FBrf0246147		TOOL DATA from: FBal0363744
+FBti0213247_cas	carries_tool	FBto0000349	FBrf0246147		TOOL DATA from: FBal0363745
+FBti0213247_cas	carries_tool	FBto0000356	FBrf0246147		TOOL DATA from: FBal0363745
+FBti0213385_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0213385_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0213385_cas	carries_tool	FBto0000328	FBrf0246203		TOOL DATA from: FBal0363913
+FBti0213386_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0213386_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0213386_cas	carries_tool	FBto0000328	FBrf0246203		TOOL DATA from: FBal0363914
+FBti0213386_cas	carries_tool	FBto0000328	FBrf0246203		TOOL DATA from: FBal0363918
+FBti0213386_cas	has_reg_region	FBgn0050446	FBrf0246203		TOOL DATA from: FBal0363918
+FBti0213387_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0144644
+FBti0213387_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0144644
+FBti0213387_cas	carries_tool	FBto0000323	FBrf0246203		TOOL DATA from: FBal0363919
+FBti0213388_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0144644
+FBti0213388_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0144644
+FBti0213388_cas	carries_tool	FBto0000323	FBrf0246203		TOOL DATA from: FBal0363920
+FBti0213388_cas	carries_tool	FBto0000323	FBrf0246203		TOOL DATA from: FBal0363921
+FBti0213388_cas	has_reg_region	FBgn0004619	FBrf0246203		TOOL DATA from: FBal0363921
+FBti0213398_cas	tagged_with	FBto0000093	FBrf0246470		TOOL DATA from: FBal0363990
+FBti0213398_cas	tagged_with	FBto0000589	FBrf0246470		TOOL DATA from: FBal0363990
+FBti0213399_cas	tagged_with	FBto0000031	FBrf0246839		TOOL DATA from: FBal0363992
+FBti0213400_cas	carries_tool	FBto0000349	FBrf0246839		TOOL DATA from: FBal0363999
+FBti0213400_cas	carries_tool	FBto0000356	FBrf0246839		TOOL DATA from: FBal0363999
+FBti0213412_cas				FTA: unable to add tool information from FBal0364007 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213413_cas	tagged_with	FBto0000389	FBrf0246834		TOOL DATA from: FBal0364008
+FBti0213414_cas	tagged_with	FBto0000389	FBrf0246834		TOOL DATA from: FBal0364009
+FBti0213415_cas				FTA: unable to add tool information from FBal0364010 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213416_cas	tagged_with	FBto0000389	FBrf0246834		TOOL DATA from: FBal0364011
+FBti0213417_cas	tagged_with	FBto0000389	FBrf0246834		TOOL DATA from: FBal0364012
+FBti0213424_cas	has_reg_region	FBgn0261019	FBrf0247098		TOOL DATA from: FBal0364090
+FBti0213558_cas	encodes_tool	FBto0000140			TOOL DATA from: FBtp0128008
+FBti0213558_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128008
+FBti0213594_cas	carries_tool	FBto0000349	FBrf0220649		TOOL DATA from: FBal0364428
+FBti0213594_cas	carries_tool	FBto0000356	FBrf0220649		TOOL DATA from: FBal0364428
+FBti0213594_cas	carries_tool	FBto0000357	FBrf0220649		TOOL DATA from: FBal0364428
+FBti0213597_cas	tagged_with	FBto0000077	FBrf0247007		TOOL DATA from: FBal0364439
+FBti0213618_cas	tagged_with	FBto0000031	FBrf0246245|FBrf0249020		TOOL DATA from: FBal0364505
+FBti0213664_cas	tagged_with	FBto0000031	FBrf0247069		TOOL DATA from: FBal0364880
+FBti0213664_cas	tagged_with	FBto0000093	FBrf0247069		TOOL DATA from: FBal0364880
+FBti0213665_cas	tagged_with	FBto0000031	FBrf0247069		TOOL DATA from: FBal0364883
+FBti0213665_cas	tagged_with	FBto0000079	FBrf0247069		TOOL DATA from: FBal0364883
+FBti0213686_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0364910
+FBti0213686_cas	tagged_with	FBto0000093	FBrf0228036		TOOL DATA from: FBal0364910
+FBti0213686_cas	tagged_with	FBto0000631	FBrf0228036		TOOL DATA from: FBal0364910
+FBti0213687_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0364911
+FBti0213687_cas	tagged_with	FBto0000093	FBrf0228036		TOOL DATA from: FBal0364911
+FBti0213687_cas	tagged_with	FBto0000631	FBrf0228036		TOOL DATA from: FBal0364911
+FBti0213875_cas				FTA: unable to add tool information from FBal0343866 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213916_cas	tagged_with	FBto0000694	FBrf0247068		TOOL DATA from: FBal0365216
+FBti0213918_cas				FTA: unable to add tool information from FBal0365222 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213919_cas	carries_tool	FBto0000349	FBrf0247226		TOOL DATA from: FBal0365223
+FBti0213920_cas	carries_tool	FBto0000349	FBrf0247226		TOOL DATA from: FBal0365224
+FBti0213921_cas	carries_tool	FBto0000349	FBrf0247226		TOOL DATA from: FBal0365225
+FBti0213922_cas	tagged_with	FBto0000076	FBrf0247226		TOOL DATA from: FBal0365232
+FBti0213923_cas	tagged_with	FBto0000076	FBrf0247226		TOOL DATA from: FBal0365235
+FBti0213933_cas	tagged_with	FBto0000522	FBrf0244621		TOOL DATA from: FBal0365249
+FBti0213933_cas	tagged_with	FBto0000585	FBrf0244621		TOOL DATA from: FBal0365249
+FBti0213934_cas				FTA: unable to add tool information from FBal0365256 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213935_cas				FTA: unable to add tool information from FBal0365257 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213936_cas				FTA: unable to add tool information from FBal0365258 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213937_cas	carries_tool	FBto0000318	FBrf0224708		TOOL DATA from: FBal0365262
+FBti0213940_cas	tagged_with	FBto0000063	FBrf0247123		TOOL DATA from: FBal0365277
+FBti0214014_cas	tagged_with	FBto0000079	FBrf0230844		TOOL DATA from: FBal0365289
+FBti0214017_cas	tagged_with	FBto0000403	FBrf0247412		TOOL DATA from: FBal0365301
+FBti0214081_cas	carries_tool	FBto0000349	FBrf0247081		TOOL DATA from: FBal0365341
+FBti0214117_cas	tagged_with	FBto0000076	FBrf0247174		TOOL DATA from: FBal0365409
+FBti0214117_cas	tagged_with	FBto0000083	FBrf0247174		TOOL DATA from: FBal0365409
+FBti0214117_cas	tagged_with	FBto0000341	FBrf0247174		TOOL DATA from: FBal0365409
+FBti0214135_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0214135_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0214177_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0214177_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0214178_cas	carries_tool	FBto0000349	FBrf0247550		TOOL DATA from: FBal0365538
+FBti0214178_cas	carries_tool	FBto0000356	FBrf0247550		TOOL DATA from: FBal0365538
+FBti0214222_cas	tagged_with	FBto0000093	FBrf0247523		TOOL DATA from: FBal0365590
+FBti0214256_cas	tagged_with	FBto0000031	FBrf0247340		TOOL DATA from: FBal0365655
+FBti0214257_cas	tagged_with	FBto0000076	FBrf0247340		TOOL DATA from: FBal0365656
+FBti0214258_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365657
+FBti0214258_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365657
+FBti0214259_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365658
+FBti0214259_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365658
+FBti0214260_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365659
+FBti0214260_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365659
+FBti0214261_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365660
+FBti0214261_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365660
+FBti0214262_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365661
+FBti0214262_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365661
+FBti0214263_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365662
+FBti0214263_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365662
+FBti0214277_cas				FTA: unable to add tool information from FBal0365691 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0214278_cas				FTA: unable to add tool information from FBal0365692 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0214325_cas				FTA: unable to add tool information from FBal0365766 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0214362_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0214362_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0214373_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0214373_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0214373_cas	has_reg_region	FBgn0262381	FBrf0247752		TOOL DATA from: FBal0365947
+FBti0214376_cas	tagged_with	FBto0000118	FBrf0247271		TOOL DATA from: FBal0365838
+FBti0214398_cas	tagged_with	FBto0000076	FBrf0247665		TOOL DATA from: FBal0365915
+FBti0214421_cas	tagged_with	FBto0000031	FBrf0247474		TOOL DATA from: FBal0365959
+FBti0214422_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0214422_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0214422_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0365975
+FBti0214422_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0365975
+FBti0214422_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0365975
+FBti0214422_cas	has_reg_region	FBgn0031424	FBrf0247391		TOOL DATA from: FBal0365975
+FBti0214422_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0365983
+FBti0214422_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0365983
+FBti0214422_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0365983
+FBti0214423_cas	has_reg_region	FBgn0013720	FBrf0247845		TOOL DATA from: FBal0365987
+FBti0214423_cas	tagged_with	FBto0000104	FBrf0247845		TOOL DATA from: FBal0365987
+FBti0214424_cas	has_reg_region	FBgn0010238	FBrf0247845		TOOL DATA from: FBal0365988
+FBti0214424_cas	tagged_with	FBto0000031	FBrf0247845		TOOL DATA from: FBal0365988
+FBti0214432_cas	tagged_with	FBto0000102	FBrf0247526		TOOL DATA from: FBal0366013
+FBti0214433_cas	tagged_with	FBto0000102	FBrf0247526		TOOL DATA from: FBal0366019
+FBti0214434_cas	tagged_with	FBto0000102	FBrf0247526		TOOL DATA from: FBal0366020
+FBti0214435_cas	tagged_with	FBto0000102	FBrf0247526		TOOL DATA from: FBal0366021
+FBti0214436_cas	tagged_with	FBto0000707	FBrf0247526		TOOL DATA from: FBal0366022
+FBti0214490_cas	tagged_with	FBto0000076	FBrf0247676		TOOL DATA from: FBal0366112
+FBti0214491_cas	tagged_with	FBto0000076	FBrf0247676		TOOL DATA from: FBal0366113
+FBti0214491_cas	tagged_with	FBto0000076	FBrf0247676		TOOL DATA from: FBal0366116
+FBti0214492_cas	tagged_with	FBto0000077	FBrf0247676		TOOL DATA from: FBal0366117
+FBti0214497_cas	has_reg_region	FBgn0026257	FBrf0213318		TOOL DATA from: FBal0367053
+FBti0214497_cas	tagged_with	FBto0000027	FBrf0213318		TOOL DATA from: FBal0367053
+FBti0214536_cas	carries_tool	FBto0000330	FBrf0247657		TOOL DATA from: FBal0366197
+FBti0214536_cas	tagged_with	FBto0000093	FBrf0247657		TOOL DATA from: FBal0366197
+FBti0214546_cas	tagged_with	FBto0000389	FBrf0223858		TOOL DATA from: FBal0295469
+FBti0214858_cas	carries_tool	FBto0000349	FBrf0247740		TOOL DATA from: FBal0366568
+FBti0214858_cas	tagged_with	FBto0000716	FBrf0247740		TOOL DATA from: FBal0366568
+FBti0214859_cas	tagged_with	FBto0000601	FBrf0247740		TOOL DATA from: FBal0366570
+FBti0214978_cas	tagged_with	FBto0000077	FBrf0247921		TOOL DATA from: FBal0366851
+FBti0214980_cas	tagged_with	FBto0000093	FBrf0247967		TOOL DATA from: FBal0366865
+FBti0215070_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0215070_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0215070_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0367038
+FBti0215070_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0367038
+FBti0215070_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0367038
+FBti0215070_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0367039
+FBti0215070_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0367039
+FBti0215070_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0367039
+FBti0215404_cas	tagged_with	FBto0000076	FBrf0245859		TOOL DATA from: FBal0367093
+FBti0215405_cas				FTA: unable to add tool information from FBal0367098 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215406_cas	carries_tool	FBto0000349	FBrf0248471		TOOL DATA from: FBal0367099
+FBti0215406_cas	carries_tool	FBto0000356	FBrf0248471		TOOL DATA from: FBal0367099
+FBti0215407_cas	carries_tool	FBto0000349	FBrf0248471		TOOL DATA from: FBal0367100
+FBti0215407_cas	carries_tool	FBto0000356	FBrf0248471		TOOL DATA from: FBal0367100
+FBti0215417_cas	carries_tool	FBto0000349	FBrf0244216		TOOL DATA from: FBal0367132
+FBti0215417_cas	carries_tool	FBto0000356	FBrf0244216		TOOL DATA from: FBal0367132
+FBti0215418_cas	tagged_with	FBto0000027	FBrf0244216		TOOL DATA from: FBal0367133
+FBti0215419_cas	tagged_with	FBto0000582	FBrf0244216		TOOL DATA from: FBal0367134
+FBti0215420_cas	tagged_with	FBto0000027	FBrf0244216		TOOL DATA from: FBal0367135
+FBti0215420_cas	tagged_with	FBto0000582	FBrf0244216		TOOL DATA from: FBal0367135
+FBti0215421_cas	tagged_with	FBto0000098	FBrf0244216		TOOL DATA from: FBal0367136
+FBti0215421_cas	tagged_with	FBto0000582	FBrf0244216		TOOL DATA from: FBal0367136
+FBti0215422_cas	tagged_with	FBto0000098	FBrf0244216		TOOL DATA from: FBal0367137
+FBti0215422_cas	tagged_with	FBto0000699	FBrf0244216		TOOL DATA from: FBal0367137
+FBti0215423_cas	tagged_with	FBto0000583	FBrf0244216		TOOL DATA from: FBal0367138
+FBti0215424_cas	tagged_with	FBto0000063	FBrf0248448		TOOL DATA from: FBal0367148
+FBti0215425_cas	tagged_with	FBto0000014	FBrf0248448		TOOL DATA from: FBal0367149
+FBti0215426_cas	tagged_with	FBto0000063	FBrf0248448		TOOL DATA from: FBal0367150
+FBti0215430_cas	tagged_with	FBto0000077	FBrf0248542		TOOL DATA from: FBal0367170
+FBti0215431_cas	tagged_with	FBto0000063	FBrf0246607		TOOL DATA from: FBal0367175
+FBti0215438_cas				FTA: unable to add tool information from FBal0367203 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215440_cas	tagged_with	FBto0000063	FBrf0247840		TOOL DATA from: FBal0367204
+FBti0215441_cas	tagged_with	FBto0000063	FBrf0247840		TOOL DATA from: FBal0367211
+FBti0215442_cas				FTA: unable to add tool information from FBal0367213 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215443_cas				FTA: unable to add tool information from FBal0367234 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215444_cas				FTA: unable to add tool information from FBal0367235 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215445_cas	carries_tool	FBto0000318	FBrf0248082		TOOL DATA from: FBal0367236
+FBti0215445_cas	carries_tool	FBto0000349	FBrf0248082		TOOL DATA from: FBal0367236
+FBti0215455_cas	carries_tool	FBto0000349	FBrf0248667		TOOL DATA from: FBal0367246
+FBti0215455_cas	carries_tool	FBto0000356	FBrf0248667		TOOL DATA from: FBal0367246
+FBti0215456_cas	carries_tool	FBto0000349	FBrf0248667		TOOL DATA from: FBal0367247
+FBti0215457_cas	carries_tool	FBto0000349	FBrf0248667		TOOL DATA from: FBal0367248
+FBti0215458_cas				FTA: unable to add tool information from FBal0367249 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215459_cas				FTA: unable to add tool information from FBal0367250 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215460_cas				FTA: unable to add tool information from FBal0367251 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215560_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0215560_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0215707_cas	tagged_with	FBto0000076	FBrf0248665		TOOL DATA from: FBal0367628
+FBti0215708_cas	tagged_with	FBto0000077	FBrf0248665		TOOL DATA from: FBal0367629
+FBti0215709_cas	tagged_with	FBto0000076	FBrf0248665		TOOL DATA from: FBal0367630
+FBti0215710_cas	tagged_with	FBto0000077	FBrf0248665		TOOL DATA from: FBal0367631
+FBti0215711_cas	tagged_with	FBto0000093	FBrf0248665		TOOL DATA from: FBal0367632
+FBti0215712_cas	tagged_with	FBto0000093	FBrf0248665		TOOL DATA from: FBal0367633
+FBti0215715_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0215715_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0215715_cas	has_reg_region	FBgn0003300	FBrf0248620		TOOL DATA from: FBal0367636
+FBti0215715_cas	has_reg_region	FBgn0003300	FBrf0248620		TOOL DATA from: FBal0367637
+FBti0215719_cas	tagged_with	FBto0000079	FBrf0248517		TOOL DATA from: FBal0367654
+FBti0215720_cas	tagged_with	FBto0000077	FBrf0248517		TOOL DATA from: FBal0367655
+FBti0215740_cas	tagged_with	FBto0000403	FBrf0248673		TOOL DATA from: FBal0367671
+FBti0215741_cas	tagged_with	FBto0000601	FBrf0248673		TOOL DATA from: FBal0367672
+FBti0215751_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0215751_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0215752_cas	has_reg_region	FBto0000180			TOOL DATA from: FBtp0117267
+FBti0215752_cas	tool_uses	misexpression element			TOOL DATA from: FBtp0117267
+FBti0215752_cas				FTA: unable to add tool information from FBal0367699 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215769_cas	tagged_with	FBto0000077	FBrf0247295		TOOL DATA from: FBal0367760
+FBti0215770_cas	tagged_with	FBto0000077	FBrf0247295		TOOL DATA from: FBal0367761
+FBti0215779_cas	carries_tool	FBto0000349	FBrf0248749		TOOL DATA from: FBal0367778
+FBti0215779_cas	carries_tool	FBto0000356	FBrf0248749		TOOL DATA from: FBal0367778
+FBti0215779_cas	carries_tool	FBto0000349	FBrf0248749		TOOL DATA from: FBal0367784
+FBti0215779_cas	carries_tool	FBto0000356	FBrf0248749		TOOL DATA from: FBal0367784
+FBti0215782_cas	tagged_with	FBto0000126	FBrf0248547		TOOL DATA from: FBal0367805
+FBti0215783_cas	tagged_with	FBto0000426	FBrf0248547		TOOL DATA from: FBal0367806
+FBti0215795_cas	tagged_with	FBto0000126	FBrf0248225		TOOL DATA from: FBal0367825
+FBti0215796_cas	tagged_with	FBto0000126	FBrf0248225		TOOL DATA from: FBal0367832
+FBti0215800_cas	tagged_with	FBto0000063	FBrf0248795		TOOL DATA from: FBal0367850
+FBti0215801_cas	tagged_with	FBto0000063	FBrf0248795		TOOL DATA from: FBal0367851
+FBti0215832_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0215832_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0215834_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0215834_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0215838_cas	tagged_with	FBto0000031	FBrf0248472		TOOL DATA from: FBal0367942
+FBti0215839_cas	tagged_with	FBto0000126	FBrf0248472		TOOL DATA from: FBal0367943
+FBti0215840_cas				FTA: unable to add tool information from FBal0367944 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215841_cas	tagged_with	FBto0000046	FBrf0248472		TOOL DATA from: FBal0367945
+FBti0215844_cas	carries_tool	FBto0000349	FBrf0248830		TOOL DATA from: FBal0367960
+FBti0215845_cas	carries_tool	FBto0000349	FBrf0248830		TOOL DATA from: FBal0367961
+FBti0215853_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0215853_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0215869_cas	tagged_with	FBto0000102	FBrf0232782		TOOL DATA from: FBal0368001
+FBti0215870_cas				FTA: unable to add tool information from FBal0368002 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215890_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0215890_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0215890_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368018
+FBti0215890_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368024
+FBti0215891_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0215891_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0215891_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368019
+FBti0215891_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368025
+FBti0215892_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0215892_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0215892_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368020
+FBti0215892_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368026
+FBti0215893_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0215893_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0215893_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368021
+FBti0215893_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368027
+FBti0215894_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0215894_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0215894_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368022
+FBti0215894_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368028
+FBti0215895_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0215895_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0215895_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368023
+FBti0215895_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368029
+FBti0215896_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0215896_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0215896_cas	tagged_with	FBto0000027	FBrf0248683		TOOL DATA from: FBal0368033
+FBti0215897_cas	carries_tool	FBto0000349	FBrf0248683		TOOL DATA from: FBal0368032
+FBti0215897_cas	carries_tool	FBto0000356	FBrf0248683		TOOL DATA from: FBal0368032
+FBti0215906_cas	carries_tool	FBto0000349	FBrf0249068		TOOL DATA from: FBal0368037
+FBti0215907_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0215907_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0215926_cas	tagged_with	FBto0000077	FBrf0248983		TOOL DATA from: FBal0368065
+FBti0215927_cas				FTA: unable to add tool information from FBal0368066 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216052_cas	tagged_with	FBto0000027	FBrf0248474		TOOL DATA from: FBal0368292
+FBti0216052_cas	tagged_with	FBto0000077	FBrf0248474		TOOL DATA from: FBal0368292
+FBti0216071_cas	carries_tool	FBto0000349	FBrf0248996		TOOL DATA from: FBal0368321
+FBti0216072_cas				FTA: unable to add tool information from FBal0368322 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216074_cas	carries_tool	FBto0000318	FBrf0248878		TOOL DATA from: FBal0368324
+FBti0216091_cas	tagged_with	FBto0000738	FBrf0249049		TOOL DATA from: FBal0368351
+FBti0216092_cas	tagged_with	FBto0000389	FBrf0249049		TOOL DATA from: FBal0368352
+FBti0216092_cas	tagged_with	FBto0000738	FBrf0249049		TOOL DATA from: FBal0368352
+FBti0216159_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0216159_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0216163_cas				FTA: unable to add tool information from FBal0368461 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216311_cas	tagged_with	FBto0000375	FBrf0249038		TOOL DATA from: FBal0368707
+FBti0216312_cas	tagged_with	FBto0000031	FBrf0249038		TOOL DATA from: FBal0368709
+FBti0216315_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216315_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216354_cas	carries_tool	FBto0000349	FBrf0249305		TOOL DATA from: FBal0368758
+FBti0216354_cas	tagged_with	FBto0000102	FBrf0249305		TOOL DATA from: FBal0368758
+FBti0216355_cas	carries_tool	FBto0000349	FBrf0249305		TOOL DATA from: FBal0368759
+FBti0216355_cas	tagged_with	FBto0000102	FBrf0249305		TOOL DATA from: FBal0368759
+FBti0216356_cas	carries_tool	FBto0000349	FBrf0249127		TOOL DATA from: FBal0368760
+FBti0216356_cas	tagged_with	FBto0000070	FBrf0249127		TOOL DATA from: FBal0368760
+FBti0216356_cas	tagged_with	FBto0000077	FBrf0249127		TOOL DATA from: FBal0368760
+FBti0216357_cas	carries_tool	FBto0000349	FBrf0249127		TOOL DATA from: FBal0368762
+FBti0216357_cas	tagged_with	FBto0000070	FBrf0249127		TOOL DATA from: FBal0368762
+FBti0216357_cas	tagged_with	FBto0000077	FBrf0249127		TOOL DATA from: FBal0368762
+FBti0216378_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0140111
+FBti0216378_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140111
+FBti0216379_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0216379_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0216379_cas	carries_tool	FBto0000318	FBrf0249021		TOOL DATA from: FBal0368791
+FBti0216379_cas	carries_tool	FBto0000318	FBrf0249021		TOOL DATA from: FBal0368793
+FBti0216380_cas	tagged_with	FBto0000031	FBrf0249101		TOOL DATA from: FBal0368799
+FBti0216381_cas	tagged_with	FBto0000031	FBrf0249101		TOOL DATA from: FBal0368807
+FBti0216382_cas	tagged_with	FBto0000031	FBrf0249101		TOOL DATA from: FBal0368813
+FBti0216406_cas	tagged_with	FBto0000031	FBrf0248794		TOOL DATA from: FBal0368875
+FBti0216407_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368882
+FBti0216407_cas	carries_tool	FBto0000356	FBrf0248618		TOOL DATA from: FBal0368882
+FBti0216408_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368883
+FBti0216409_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368884
+FBti0216410_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368885
+FBti0216411_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368886
+FBti0216419_cas	carries_tool	FBto0000318	FBrf0244135		TOOL DATA from: FBal0368900
+FBti0216423_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0216423_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0216423_cas	carries_tool	FBto0000349	FBrf0244265		TOOL DATA from: FBal0368910
+FBti0216424_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0368913
+FBti0216428_cas	carries_tool	FBto0000356	FBrf0241076		TOOL DATA from: FBal0368922
+FBti0216429_cas	carries_tool	FBto0000356	FBrf0241076		TOOL DATA from: FBal0368923
+FBti0216430_cas	carries_tool	FBto0000356	FBrf0241076		TOOL DATA from: FBal0368924
+FBti0216432_cas				FTA: unable to add tool information from FBal0368945 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216433_cas	carries_tool	FBto0000349	FBrf0238744		TOOL DATA from: FBal0368946
+FBti0216433_cas	tagged_with	FBto0000383	FBrf0238744		TOOL DATA from: FBal0368946
+FBti0216456_cas				FTA: unable to add tool information from FBal0368956 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216457_cas	tagged_with	FBto0000031	FBrf0249270		TOOL DATA from: FBal0368962
+FBti0216458_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216458_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216459_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216459_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216460_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216460_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216461_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216461_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216462_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216462_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216463_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216463_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216464_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216464_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216465_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216465_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216466_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216466_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216467_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216467_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216468_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216468_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216469_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216469_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216470_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216470_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216471_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216471_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216472_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216472_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216473_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216473_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216474_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216474_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216475_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216475_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216494_cas	tagged_with	FBto0000696	FBrf0246064		TOOL DATA from: FBal0369026
+FBti0216495_cas	tagged_with	FBto0000118	FBrf0246064		TOOL DATA from: FBal0369027
+FBti0216495_cas	tagged_with	FBto0000696	FBrf0246064		TOOL DATA from: FBal0369027
+FBti0216496_cas	tagged_with	FBto0000118	FBrf0246064		TOOL DATA from: FBal0369028
+FBti0216497_cas	carries_tool	FBto0000349	FBrf0239819		TOOL DATA from: FBal0369030
+FBti0216497_cas	tagged_with	FBto0000383	FBrf0239819		TOOL DATA from: FBal0369030
+FBti0216498_cas				FTA: unable to add tool information from FBal0369029 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216498_cas				FTA: unable to add tool information from FBal0369031 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216499_cas				FTA: unable to add tool information from FBal0369031 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216504_cas	tagged_with	FBto0000077	FBrf0249139		TOOL DATA from: FBal0369042
+FBti0216505_cas	tagged_with	FBto0000093	FBrf0249139		TOOL DATA from: FBal0369043
+FBti0216506_cas	tagged_with	FBto0000077	FBrf0249139		TOOL DATA from: FBal0369044
+FBti0216508_cas	tagged_with	FBto0000077	FBrf0249139		TOOL DATA from: FBal0369046
+FBti0216509_cas	tagged_with	FBto0000093	FBrf0249139		TOOL DATA from: FBal0369047
+FBti0216511_cas	tagged_with	FBto0000093	FBrf0249139		TOOL DATA from: FBal0369049
+FBti0216519_cas	carries_tool	FBto0000349	FBrf0249279		TOOL DATA from: FBal0369058
+FBti0216519_cas	carries_tool	FBto0000356	FBrf0249279		TOOL DATA from: FBal0369058
+FBti0216534_cas				FTA: unable to add tool information from FBal0369081 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216535_cas				FTA: unable to add tool information from FBal0369082 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216536_cas				FTA: unable to add tool information from FBal0369083 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216537_cas				FTA: unable to add tool information from FBal0369084 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216538_cas				FTA: unable to add tool information from FBal0369085 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216539_cas				FTA: unable to add tool information from FBal0369086 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216540_cas				FTA: unable to add tool information from FBal0369087 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216541_cas				FTA: unable to add tool information from FBal0369088 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216548_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369109
+FBti0216548_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369109
+FBti0216549_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369110
+FBti0216549_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369110
+FBti0216550_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369111
+FBti0216550_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369111
+FBti0216551_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369112
+FBti0216551_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369112
+FBti0216552_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369113
+FBti0216552_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369113
+FBti0216553_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369114
+FBti0216553_cas	tagged_with	FBto0000383	FBrf0249089		TOOL DATA from: FBal0369114
+FBti0216554_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369115
+FBti0216554_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369115
+FBti0216555_cas				FTA: unable to add tool information from FBal0369116 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216556_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369117
+FBti0216556_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369117
+FBti0216557_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369118
+FBti0216557_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369118
+FBti0216559_cas				FTA: unable to add tool information from FBal0369119 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216559_cas				FTA: unable to add tool information from FBal0369120 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216560_cas				FTA: unable to add tool information from FBal0369120 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216563_cas	carries_tool	FBto0000349	FBrf0249403		TOOL DATA from: FBal0369127
+FBti0216643_cas				FTA: unable to add tool information from FBal0369273 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216644_cas	tagged_with	FBto0000077	FBrf0250889		TOOL DATA from: FBal0369274
+FBti0216649_cas	tagged_with	FBto0000102	FBrf0249753		TOOL DATA from: FBal0369278
+FBti0216650_cas	carries_tool	FBto0000349	FBrf0249480		TOOL DATA from: FBal0369279
+FBti0216650_cas	carries_tool	FBto0000356	FBrf0249480		TOOL DATA from: FBal0369279
+FBti0216673_cas	tagged_with	FBto0000031	FBrf0249591		TOOL DATA from: FBal0369299
+FBti0216674_cas	carries_tool	FBto0000076	FBrf0249591		TOOL DATA from: FBal0369300
+FBti0216675_cas	carries_tool	FBto0000349	FBrf0251008		TOOL DATA from: FBal0369308
+FBti0216675_cas	carries_tool	FBto0000349	FBrf0251008		TOOL DATA from: FBal0369309
+FBti0216675_cas	tagged_with	FBto0000076	FBrf0251008		TOOL DATA from: FBal0369309
+FBti0216737_cas	tagged_with	FBto0000031	FBrf0248770		TOOL DATA from: FBal0369382
+FBti0216738_cas	tagged_with	FBto0000121	FBrf0248770		TOOL DATA from: FBal0369383
+FBti0216740_cas				FTA: unable to add tool information from FBal0369380 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216742_cas	carries_tool	FBto0000349	FBrf0248805		TOOL DATA from: FBal0369387
+FBti0216745_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0216745_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0216745_cas				FTA: unable to add tool information from FBal0369396 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216746_cas	encodes_tool	FBto0000022			TOOL DATA from: FBtp0148518
+FBti0216746_cas				FTA: unable to add tool information from FBal0369397 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216787_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0216787_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0216787_cas	carries_tool	FBto0000320	FBrf0250949		TOOL DATA from: FBal0369449
+FBti0216787_cas	carries_tool	FBto0000349	FBrf0250949		TOOL DATA from: FBal0369449
+FBti0216787_cas	carries_tool	FBto0000356	FBrf0250949		TOOL DATA from: FBal0369449
+FBti0216807_cas				FTA: unable to add tool information from FBal0369500 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216849_cas	tagged_with	FBto0000031	FBrf0249790		TOOL DATA from: FBal0369541
+FBti0216849_cas	tagged_with	FBto0000307	FBrf0249790		TOOL DATA from: FBal0369541
+FBti0216855_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369574
+FBti0216855_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369574
+FBti0216856_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369575
+FBti0216856_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369575
+FBti0216857_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369576
+FBti0216857_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369576
+FBti0216858_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369577
+FBti0216858_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369577
+FBti0216859_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369578
+FBti0216859_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369578
+FBti0216860_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369579
+FBti0216860_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369579
+FBti0216861_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369580
+FBti0216861_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369580
+FBti0216862_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369581
+FBti0216862_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369581
+FBti0216863_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369582
+FBti0216863_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369582
+FBti0216869_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0216869_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0216869_cas	carries_tool	FBto0000345	FBrf0250203		TOOL DATA from: FBal0369592
+FBti0216869_cas	carries_tool	FBto0000349	FBrf0250203		TOOL DATA from: FBal0369592
+FBti0216869_cas	carries_tool	FBto0000356	FBrf0250203		TOOL DATA from: FBal0369592
+FBti0216869_cas	carries_tool	FBto0000345	FBrf0250203		TOOL DATA from: FBal0369595
+FBti0216869_cas	carries_tool	FBto0000349	FBrf0250203		TOOL DATA from: FBal0369595
+FBti0216869_cas	carries_tool	FBto0000356	FBrf0250203		TOOL DATA from: FBal0369595
+FBti0216933_cas	carries_tool	FBto0000349	FBrf0250163		TOOL DATA from: FBal0369714
+FBti0216933_cas	tagged_with	FBto0000750	FBrf0250163		TOOL DATA from: FBal0369714
+FBti0216945_cas	tagged_with	FBto0000077	FBrf0251238		TOOL DATA from: FBal0369742
+FBti0217045_cas	carries_tool	FBto0000349	FBrf0250944		TOOL DATA from: FBal0369967
+FBti0217045_cas	carries_tool	FBto0000356	FBrf0250944		TOOL DATA from: FBal0369967
+FBti0217046_cas	carries_tool	FBto0000349	FBrf0250944		TOOL DATA from: FBal0369968
+FBti0217046_cas	carries_tool	FBto0000356	FBrf0250944		TOOL DATA from: FBal0369968
+FBti0217047_cas	carries_tool	FBto0000349	FBrf0250944		TOOL DATA from: FBal0369969
+FBti0217047_cas	tagged_with	FBto0000077	FBrf0250944		TOOL DATA from: FBal0369969
+FBti0217048_cas	carries_tool	FBto0000349	FBrf0250944		TOOL DATA from: FBal0369970
+FBti0217048_cas	tagged_with	FBto0000077	FBrf0250944		TOOL DATA from: FBal0369970
+FBti0217052_cas	carries_tool	FBto0000349	FBrf0251068		TOOL DATA from: FBal0370060
+FBti0217052_cas	carries_tool	FBto0000356	FBrf0251068		TOOL DATA from: FBal0370060
+FBti0217065_cas	tagged_with	FBto0000063	FBrf0249586		TOOL DATA from: FBal0370083
+FBti0217117_cas	tagged_with	FBto0000077	FBrf0248591		TOOL DATA from: FBal0370212
+FBti0217118_cas	tagged_with	FBto0000027	FBrf0251462		TOOL DATA from: FBal0370221
+FBti0217120_cas	carries_tool	FBto0000349	FBrf0251393		TOOL DATA from: FBal0370244
+FBti0217217_cas	tagged_with	FBto0000093	FBrf0251632		TOOL DATA from: FBal0370449
+FBti0217239_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217239_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217239_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370483
+FBti0217240_cas				FTA: unable to add tool information from FBal0370484 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217241_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217241_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217241_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370485
+FBti0217242_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217242_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217242_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370486
+FBti0217243_cas				FTA: unable to add tool information from FBal0370487 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217244_cas				FTA: unable to add tool information from FBal0370488 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217245_cas				FTA: unable to add tool information from FBal0370489 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217246_cas				FTA: unable to add tool information from FBal0370490 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217247_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217247_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217247_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370491
+FBti0217248_cas				FTA: unable to add tool information from FBal0370492 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217249_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217249_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217249_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370493
+FBti0217250_cas				FTA: unable to add tool information from FBal0370494 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217251_cas				FTA: unable to add tool information from FBal0370495 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217252_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370496
+FBti0217253_cas				FTA: unable to add tool information from FBal0370497 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217254_cas				FTA: unable to add tool information from FBal0370498 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217255_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217255_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217255_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370499
+FBti0217279_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0217279_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0217280_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217280_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217289_cas	carries_tool	FBto0000349	FBrf0251492		TOOL DATA from: FBal0370558
+FBti0217289_cas	carries_tool	FBto0000356	FBrf0251492		TOOL DATA from: FBal0370558
+FBti0217291_cas	tagged_with	FBto0000031	FBrf0251847		TOOL DATA from: FBal0370579
+FBti0217292_cas	tagged_with	FBto0000031	FBrf0251848		TOOL DATA from: FBal0370580
+FBti0217293_cas	tagged_with	FBto0000031	FBrf0251849		TOOL DATA from: FBal0370581
+FBti0217309_cas				FTA: unable to add tool information from FBal0370599 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217310_cas				FTA: unable to add tool information from FBal0360099 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217311_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0217311_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0217312_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0217312_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0217313_cas	tagged_with	FBto0000031	FBrf0251850		TOOL DATA from: FBal0370602
+FBti0217314_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0217314_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0217315_cas	tagged_with	FBto0000031	FBrf0251850		TOOL DATA from: FBal0370604
+FBti0217446_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217446_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217446_cas	carries_tool	FBto0000349	FBrf0251799		TOOL DATA from: FBal0370819
+FBti0217446_cas	carries_tool	FBto0000349	FBrf0251799		TOOL DATA from: FBal0370822
+FBti0217447_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0217447_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0217447_cas	carries_tool	FBto0000320	FBrf0251799		TOOL DATA from: FBal0370821
+FBti0217447_cas	carries_tool	FBto0000349	FBrf0251799		TOOL DATA from: FBal0370821
+FBti0217447_cas	carries_tool	FBto0000356	FBrf0251799		TOOL DATA from: FBal0370821
+FBti0217448_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0217448_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0217448_cas	carries_tool	FBto0000320	FBrf0251787		TOOL DATA from: FBal0370826
+FBti0217448_cas	carries_tool	FBto0000349	FBrf0251787		TOOL DATA from: FBal0370826
+FBti0217448_cas	carries_tool	FBto0000356	FBrf0251787		TOOL DATA from: FBal0370826
+FBti0217449_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217449_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217449_cas	carries_tool	FBto0000349	FBrf0251787		TOOL DATA from: FBal0370827
+FBti0217449_cas	carries_tool	FBto0000349	FBrf0251787		TOOL DATA from: FBal0370832
+FBti0217521_cas				FTA: unable to add tool information from FBal0370911 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217522_cas	carries_tool	FBto0000349	FBrf0252036		TOOL DATA from: FBal0370912
+FBti0217523_cas				FTA: unable to add tool information from FBal0370913 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217539_cas				FTA: unable to add tool information from FBal0370934 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217542_cas	tagged_with	FBto0000079	FBrf0251724		TOOL DATA from: FBal0370939
+FBti0217543_cas				FTA: unable to add tool information from FBal0370942 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217600_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0217600_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0217601_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0217601_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0217704_cas	tagged_with	FBto0000126	FBrf0252194		TOOL DATA from: FBal0371380
+FBti0217705_cas				FTA: unable to add tool information from FBal0371385 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217712_cas	tagged_with	FBto0000522	FBrf0252184		TOOL DATA from: FBal0371408
+FBti0217713_cas	tagged_with	FBto0000522	FBrf0252184		TOOL DATA from: FBal0371409
+FBti0217714_cas	tagged_with	FBto0000585	FBrf0252184		TOOL DATA from: FBal0371410
+FBti0217715_cas	tagged_with	FBto0000585	FBrf0252184		TOOL DATA from: FBal0371411
+FBti0217720_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0217720_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0217721_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0217721_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0217722_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0217722_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0217723_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0217723_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0217746_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217746_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217747_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0116623
+FBti0217747_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0116623
+FBti0217748_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0217748_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0217748_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0371482
+FBti0217748_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0371482
+FBti0217748_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0371482
+FBti0217748_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0371491
+FBti0217748_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0371491
+FBti0217748_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0371491
+FBti0217749_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0217749_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0217749_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0371483
+FBti0217749_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0371483
+FBti0217749_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0371483
+FBti0217749_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0371493
+FBti0217749_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0371493
+FBti0217749_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0371493
+FBti0217750_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0217750_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0217752_cas	encodes_tool	FBto0000777			TOOL DATA from: FBtp0149613
+FBti0217752_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0149613
+FBti0217779_cas	tagged_with	FBto0000027	FBrf0251782		TOOL DATA from: FBal0371534
+FBti0217780_cas	tagged_with	FBto0000027	FBrf0251782		TOOL DATA from: FBal0371535
+FBti0217781_cas	tagged_with	FBto0000118	FBrf0251782		TOOL DATA from: FBal0371536
+FBti0217811_cas	tagged_with	FBto0000077	FBrf0251844		TOOL DATA from: FBal0371610
+FBti0217811_cas	tagged_with	FBto0000081	FBrf0251844		TOOL DATA from: FBal0371610
+FBti0217813_cas	carries_tool	FBto0000318	FBrf0251844		TOOL DATA from: FBal0371613
+FBti0217813_cas	tagged_with	FBto0000077	FBrf0251844		TOOL DATA from: FBal0371613
+FBti0217817_cas	tagged_with	FBto0000081	FBrf0252121		TOOL DATA from: FBal0371626
+FBti0217818_cas	carries_tool	FBto0000349	FBrf0252318		TOOL DATA from: FBal0371627
+FBti0217818_cas	carries_tool	FBto0000356	FBrf0252318		TOOL DATA from: FBal0371627
+FBti0217819_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0217819_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0217829_cas				FTA: unable to add tool information from FBal0371646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217830_cas	tagged_with	FBto0000031	FBrf0252329		TOOL DATA from: FBal0371647
+FBti0217831_cas	tagged_with	FBto0000077	FBrf0252329		TOOL DATA from: FBal0371648
+FBti0217840_cas	carries_tool	FBto0000349	FBrf0252413		TOOL DATA from: FBal0371677
+FBti0217840_cas	carries_tool	FBto0000356	FBrf0252413		TOOL DATA from: FBal0371677
+FBti0217841_cas				FTA: unable to add tool information from FBal0371678 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217842_cas	tagged_with	FBto0000093	FBrf0252413		TOOL DATA from: FBal0371679
+FBti0217843_cas	tagged_with	FBto0000093	FBrf0252413		TOOL DATA from: FBal0371683
+FBti0217902_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0217902_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0217902_cas	tagged_with	FBto0000092	FBrf0252465		TOOL DATA from: FBal0371751
+FBti0217906_cas	tagged_with	FBto0000077	FBrf0236455		TOOL DATA from: FBal0371757
+FBti0217929_cas				FTA: unable to add tool information from FBal0371806 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217930_cas	carries_tool	FBto0000349	FBrf0252264		TOOL DATA from: FBal0371807
+FBti0217930_cas	tagged_with	FBto0000077	FBrf0252264		TOOL DATA from: FBal0371807
+FBti0217931_cas	carries_tool	FBto0000349	FBrf0252264		TOOL DATA from: FBal0371808
+FBti0217931_cas	tagged_with	FBto0000077	FBrf0252264		TOOL DATA from: FBal0371808
+FBti0217937_cas	tagged_with	FBto0000077	FBrf0251588		TOOL DATA from: FBal0371823
+FBti0219083_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0219083_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0219085_cas				FTA: unable to add tool information from FBal0373166 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219086_cas	carries_tool	FBto0000349	FBrf0252532		TOOL DATA from: FBal0373167
+FBti0219086_cas	carries_tool	FBto0000356	FBrf0252532		TOOL DATA from: FBal0373167
+FBti0219094_cas				FTA: unable to add tool information from FBal0373181 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219095_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373183
+FBti0219095_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373183
+FBti0219096_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373184
+FBti0219096_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373184
+FBti0219096_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373184
+FBti0219097_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373186
+FBti0219097_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373186
+FBti0219097_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373186
+FBti0219099_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373188
+FBti0219099_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373188
+FBti0219099_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373188
+FBti0219100_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373189
+FBti0219100_cas	tagged_with	FBto0000118	FBrf0248198		TOOL DATA from: FBal0373189
+FBti0219100_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373189
+FBti0219101_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373190
+FBti0219101_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373190
+FBti0219101_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373190
+FBti0219102_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373191
+FBti0219102_cas	tagged_with	FBto0000118	FBrf0248198		TOOL DATA from: FBal0373191
+FBti0219102_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373191
+FBti0219103_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373192
+FBti0219103_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373192
+FBti0219103_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373192
+FBti0219104_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373193
+FBti0219104_cas	tagged_with	FBto0000118	FBrf0248198		TOOL DATA from: FBal0373193
+FBti0219104_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373193
+FBti0219105_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373194
+FBti0219105_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373194
+FBti0219105_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373194
+FBti0219106_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373195
+FBti0219106_cas	tagged_with	FBto0000118	FBrf0248198		TOOL DATA from: FBal0373195
+FBti0219106_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373195
+FBti0219107_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0219107_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0219108_cas	encodes_tool	FBto0000167			TOOL DATA from: FBtp0099206
+FBti0219108_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099206
+FBti0219111_cas	tagged_with	FBto0000335	FBrf0252719		TOOL DATA from: FBal0373209
+FBti0219113_cas	tagged_with	FBto0000031	FBrf0252880		TOOL DATA from: FBal0373218
+FBti0219114_cas	tagged_with	FBto0000031	FBrf0252880		TOOL DATA from: FBal0373219
+FBti0219115_cas	tagged_with	FBto0000031	FBrf0252880		TOOL DATA from: FBal0373220
+FBti0219116_cas	tagged_with	FBto0000031	FBrf0252880		TOOL DATA from: FBal0373221
+FBti0219126_cas	carries_tool	FBto0000349	FBrf0252516		TOOL DATA from: FBal0373246
+FBti0219126_cas	tagged_with	FBto0000077	FBrf0252516		TOOL DATA from: FBal0373246
+FBti0219129_cas	carries_tool	FBto0000349	FBrf0252566		TOOL DATA from: FBal0373252
+FBti0219130_cas	carries_tool	FBto0000349	FBrf0252566		TOOL DATA from: FBal0373253
+FBti0219131_cas	tagged_with	FBto0000070	FBrf0252566		TOOL DATA from: FBal0373255
+FBti0219139_cas	tagged_with	FBto0000102	FBrf0251965		TOOL DATA from: FBal0373271
+FBti0219140_cas	tagged_with	FBto0000047	FBrf0251916		TOOL DATA from: FBal0373272
+FBti0219251_cas				FTA: unable to add tool information from FBal0373473 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219255_cas	tagged_with	FBto0000787	FBrf0252708		TOOL DATA from: FBal0373492
+FBti0219256_cas	tagged_with	FBto0000785	FBrf0252708		TOOL DATA from: FBal0373493
+FBti0219257_cas	tagged_with	FBto0000787	FBrf0252708		TOOL DATA from: FBal0373494
+FBti0219288_cas	carries_tool	FBto0000349	FBrf0252657		TOOL DATA from: FBal0373534
+FBti0219288_cas	carries_tool	FBto0000356	FBrf0252657		TOOL DATA from: FBal0373534
+FBti0219289_cas	carries_tool	FBto0000349	FBrf0252657		TOOL DATA from: FBal0373535
+FBti0219289_cas	carries_tool	FBto0000356	FBrf0252657		TOOL DATA from: FBal0373535
+FBti0219291_cas	carries_tool	FBto0000349	FBrf0252657		TOOL DATA from: FBal0373537
+FBti0219291_cas	carries_tool	FBto0000356	FBrf0252657		TOOL DATA from: FBal0373537
+FBti0219291_cas	tagged_with	FBto0000077	FBrf0252657		TOOL DATA from: FBal0373537
+FBti0219295_cas	carries_tool	FBto0000349	FBrf0252934		TOOL DATA from: FBal0373571
+FBti0219296_cas				FTA: unable to add tool information from FBal0373573 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219297_cas	tagged_with	FBto0000027	FBrf0252717		TOOL DATA from: FBal0373576
+FBti0219301_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0150003
+FBti0219301_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0150003
+FBti0219306_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0219306_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0219307_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0219307_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0219307_cas	carries_tool	FBto0000349	FBrf0252199		TOOL DATA from: FBal0373628
+FBti0219307_cas	carries_tool	FBto0000349	FBrf0252199		TOOL DATA from: FBal0373630
+FBti0219329_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373693
+FBti0219329_cas	carries_tool	FBto0000356	FBrf0251832		TOOL DATA from: FBal0373693
+FBti0219330_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373694
+FBti0219330_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373694
+FBti0219331_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373695
+FBti0219331_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373695
+FBti0219332_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373696
+FBti0219332_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373696
+FBti0219333_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373697
+FBti0219333_cas	carries_tool	FBto0000356	FBrf0251832		TOOL DATA from: FBal0373697
+FBti0219333_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373697
+FBti0219334_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373698
+FBti0219334_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373698
+FBti0219335_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373699
+FBti0219335_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373699
+FBti0219337_cas	tagged_with	FBto0000031	FBrf0252920		TOOL DATA from: FBal0373715
+FBti0219348_cas	carries_tool	FBto0000349	FBrf0235886		TOOL DATA from: FBal0373746
+FBti0219348_cas	carries_tool	FBto0000356	FBrf0235886		TOOL DATA from: FBal0373746
+FBti0219348_cas	tagged_with	FBto0000079	FBrf0235886		TOOL DATA from: FBal0373746
+FBti0219349_cas	carries_tool	FBto0000349	FBrf0235886		TOOL DATA from: FBal0373749
+FBti0219349_cas	carries_tool	FBto0000356	FBrf0235886		TOOL DATA from: FBal0373749
+FBti0219362_cas	carries_tool	FBto0000349	FBrf0253229		TOOL DATA from: FBal0373770
+FBti0219362_cas	carries_tool	FBto0000356	FBrf0253229		TOOL DATA from: FBal0373770
+FBti0219373_cas	carries_tool	FBto0000318			TOOL DATA from: FBtp0150177
+FBti0219374_cas	carries_tool	FBto0000318			TOOL DATA from: FBtp0150177
+FBti0219425_cas	carries_tool	FBto0000349	FBrf0248551		TOOL DATA from: FBal0373855
+FBti0219425_cas	tagged_with	FBto0000389	FBrf0248551		TOOL DATA from: FBal0373855
+FBti0219479_cas	carries_tool	FBto0000326	FBrf0252818		TOOL DATA from: FBal0373907
+FBti0219479_cas	tagged_with	FBto0000076	FBrf0252818		TOOL DATA from: FBal0373907
+FBti0219480_cas	carries_tool	FBto0000326	FBrf0252818		TOOL DATA from: FBal0373908
+FBti0219480_cas	tagged_with	FBto0000076	FBrf0252818		TOOL DATA from: FBal0373908
+FBti0219597_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0219597_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0219598_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0219598_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0219598_cas	carries_tool	FBto0000349	FBrf0246949		TOOL DATA from: FBal0374049
+FBti0219598_cas	carries_tool	FBto0000349	FBrf0246949		TOOL DATA from: FBal0374058
+FBti0219599_cas	carries_tool	FBto0000318	FBrf0246949		TOOL DATA from: FBal0374050
+FBti0219599_cas	encodes_tool	FBto0000031	FBrf0246949		TOOL DATA from: FBal0374050
+FBti0219599_cas	tagged_with	FBto0000281	FBrf0246949		TOOL DATA from: FBal0374050
+FBti0219599_cas	carries_tool	FBto0000318	FBrf0246949		TOOL DATA from: FBal0374064
+FBti0219600_cas	encodes_tool	FBto0000623			TOOL DATA from: FBtp0150835
+FBti0219600_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0150835
+FBti0219600_cas	tagged_with	FBto0000077	FBrf0246949		TOOL DATA from: FBal0374051
+FBti0219600_cas	tagged_with	FBto0000631	FBrf0246949		TOOL DATA from: FBal0374051
+FBti0219601_cas	encodes_tool	FBto0000795			TOOL DATA from: FBtp0150467
+FBti0219601_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0150467
+FBti0219601_cas	tagged_with	FBto0000077	FBrf0246949		TOOL DATA from: FBal0374052
+FBti0219601_cas	tagged_with	FBto0000631	FBrf0246949		TOOL DATA from: FBal0374052
+FBti0219602_cas	encodes_tool	FBto0000795			TOOL DATA from: FBtp0150467
+FBti0219602_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0150467
+FBti0219602_cas	tagged_with	FBto0000694	FBrf0246949		TOOL DATA from: FBal0374053
+FBti0219603_cas				FTA: unable to add tool information from FBal0374055 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219604_cas				FTA: unable to add tool information from FBal0374057 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219605_cas	carries_tool	FBto0000356	FBrf0246949		TOOL DATA from: FBal0374059
+FBti0219606_cas	carries_tool	FBto0000318	FBrf0246949		TOOL DATA from: FBal0374063
+FBti0219606_cas	tagged_with	FBto0000077	FBrf0246949		TOOL DATA from: FBal0374063
+FBti0219608_cas	encodes_tool	FBto0000791			TOOL DATA from: FBtp0150465
+FBti0219608_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0150465
+FBti0219608_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374069
+FBti0219608_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374079
+FBti0219609_cas	encodes_tool	FBto0000791			TOOL DATA from: FBtp0150465
+FBti0219609_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0150465
+FBti0219609_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374070
+FBti0219609_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374080
+FBti0219610_cas	encodes_tool	FBto0000791			TOOL DATA from: FBtp0150465
+FBti0219610_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0150465
+FBti0219610_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374071
+FBti0219610_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374081
+FBti0219611_cas	tagged_with	FBto0000683	FBrf0252177		TOOL DATA from: FBal0374072
+FBti0219612_cas	carries_tool	FBto0000318	FBrf0252177		TOOL DATA from: FBal0374073
+FBti0219612_cas	tagged_with	FBto0000077	FBrf0252177		TOOL DATA from: FBal0374073
+FBti0219637_cas	carries_tool	FBto0000349	FBrf0253037		TOOL DATA from: FBal0374097
+FBti0219637_cas	tagged_with	FBto0000076	FBrf0253037		TOOL DATA from: FBal0374097
+FBti0219638_cas	carries_tool	FBto0000349	FBrf0253037		TOOL DATA from: FBal0374098
+FBti0219638_cas	tagged_with	FBto0000076	FBrf0253037		TOOL DATA from: FBal0374098
+FBti0219639_cas	tagged_with	FBto0000083	FBrf0251869		TOOL DATA from: FBal0374101
+FBti0219639_cas	tagged_with	FBto0000790	FBrf0251869		TOOL DATA from: FBal0374101
+FBti0219689_cas	carries_tool	FBto0000356	FBrf0253136		TOOL DATA from: FBal0374221
+FBti0219690_cas	tagged_with	FBto0000126	FBrf0253136		TOOL DATA from: FBal0374222
+FBti0219702_cas	tagged_with	FBto0000077	FBrf0251969		TOOL DATA from: FBal0374305
+FBti0219702_cas	tagged_with	FBto0000589	FBrf0251969		TOOL DATA from: FBal0374305
+FBti0219703_cas	tagged_with	FBto0000077	FBrf0251969		TOOL DATA from: FBal0374306
+FBti0219703_cas	tagged_with	FBto0000590	FBrf0251969		TOOL DATA from: FBal0374306
+FBti0219704_cas	tagged_with	FBto0000077	FBrf0251969		TOOL DATA from: FBal0374307
+FBti0219704_cas	tagged_with	FBto0000588	FBrf0251969		TOOL DATA from: FBal0374307
+FBti0219727_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0219727_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0219727_cas	carries_tool	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374335
+FBti0219727_cas	carries_tool	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374339
+FBti0219728_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0219728_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0219728_cas	tagged_with	FBto0000242	FBrf0252790		TOOL DATA from: FBal0374337
+FBti0219728_cas	tagged_with	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374337
+FBti0219728_cas	tagged_with	FBto0000242	FBrf0252790		TOOL DATA from: FBal0374343
+FBti0219728_cas	tagged_with	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374343
+FBti0219729_cas	carries_tool	FBto0000155	FBrf0252790		TOOL DATA from: FBal0374338
+FBti0219729_cas	tagged_with	FBto0000242	FBrf0252790		TOOL DATA from: FBal0374338
+FBti0219729_cas	tagged_with	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374338
+FBti0219729_cas	tagged_with	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374341
+FBti0219731_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0219731_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0219751_cas	tagged_with	FBto0000389	FBrf0252858		TOOL DATA from: FBal0374402
+FBti0219775_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374431
+FBti0219776_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374432
+FBti0219777_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374433
+FBti0219778_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374436
+FBti0219779_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374437
+FBti0219785_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0219785_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0219788_cas	tagged_with	FBto0000031	FBrf0248779		TOOL DATA from: FBal0374449
+FBti0219789_cas	tagged_with	FBto0000031	FBrf0248779		TOOL DATA from: FBal0374450
+FBti0219790_cas	tagged_with	FBto0000031	FBrf0248779		TOOL DATA from: FBal0374451
+FBti0219791_cas	tagged_with	FBto0000031	FBrf0248779		TOOL DATA from: FBal0374452
+FBti0219838_cas	carries_tool	FBto0000356	FBrf0253099		TOOL DATA from: FBal0374546
+FBti0219842_cas	carries_tool	FBto0000356	FBrf0253099		TOOL DATA from: FBal0374550
+FBti0219852_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374574
+FBti0219853_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374575
+FBti0219853_cas	tagged_with	FBto0000093	FBrf0247204		TOOL DATA from: FBal0374575
+FBti0219854_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374576
+FBti0219855_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374577
+FBti0219856_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374578
+FBti0219856_cas	tagged_with	FBto0000077	FBrf0247204		TOOL DATA from: FBal0374578
+FBti0219857_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374580
+FBti0219857_cas	tagged_with	FBto0000093	FBrf0247204		TOOL DATA from: FBal0374580
+FBti0219858_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374581
+FBti0219859_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374582
+FBti0219859_cas	tagged_with	FBto0000093	FBrf0247204		TOOL DATA from: FBal0374582
+FBti0219860_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374583
+FBti0219861_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374584
+FBti0219861_cas	tagged_with	FBto0000093	FBrf0247204		TOOL DATA from: FBal0374584
+FBti0219863_cas	carries_tool	FBto0000349	FBrf0252652		TOOL DATA from: FBal0374588
+FBti0219863_cas	tagged_with	FBto0000027	FBrf0252652		TOOL DATA from: FBal0374588
+FBti0219866_cas				FTA: unable to add tool information from FBal0374593 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219867_cas				FTA: unable to add tool information from FBal0374594 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219868_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0219868_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0219868_cas	carries_tool	FBto0000349	FBrf0253240		TOOL DATA from: FBal0374595
+FBti0219868_cas	carries_tool	FBto0000356	FBrf0253240		TOOL DATA from: FBal0374595
+FBti0219868_cas	carries_tool	FBto0000349	FBrf0253240		TOOL DATA from: FBal0374601
+FBti0219868_cas	carries_tool	FBto0000356	FBrf0253240		TOOL DATA from: FBal0374601
+FBti0219901_cas	tagged_with	FBto0000076	FBrf0249020		TOOL DATA from: FBal0374678
+FBti0219902_cas	tagged_with	FBto0000076	FBrf0249020		TOOL DATA from: FBal0374680
+FBti0219903_cas	tagged_with	FBto0000031	FBrf0249020		TOOL DATA from: FBal0374681
+FBti0219904_cas	carries_tool	FBto0000356	FBrf0249020		TOOL DATA from: FBal0374682
+FBti0219905_cas	tagged_with	FBto0000076	FBrf0249020		TOOL DATA from: FBal0374683
+FBti0219906_cas	tagged_with	FBto0000076	FBrf0249020		TOOL DATA from: FBal0374685
+FBti0219909_cas	carries_tool	FBto0000318	FBrf0253290		TOOL DATA from: FBal0374690
+FBti0219909_cas	tagged_with	FBto0000077	FBrf0253290		TOOL DATA from: FBal0374690
+FBti0219909_cas	tagged_with	FBto0000739	FBrf0253290		TOOL DATA from: FBal0374690
+FBti0219910_cas	carries_tool	FBto0000318	FBrf0253290		TOOL DATA from: FBal0374691
+FBti0219910_cas	tagged_with	FBto0000031	FBrf0253290		TOOL DATA from: FBal0374691
+FBti0219910_cas	tagged_with	FBto0000403	FBrf0253290		TOOL DATA from: FBal0374691
+FBti0219911_cas	carries_tool	FBto0000318	FBrf0253290		TOOL DATA from: FBal0374692
+FBti0219911_cas	tagged_with	FBto0000077	FBrf0253290		TOOL DATA from: FBal0374692
+FBti0219911_cas	tagged_with	FBto0000118	FBrf0253290		TOOL DATA from: FBal0374692
+FBti0219911_cas	tagged_with	FBto0000739	FBrf0253290		TOOL DATA from: FBal0374692
+FBti0220024_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374831
+FBti0220025_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374832
+FBti0220026_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374833
+FBti0220027_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374834
+FBti0220028_cas	tagged_with	FBto0000802	FBrf0253221		TOOL DATA from: FBal0374835
+FBti0220029_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374836
+FBti0220037_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0220037_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0220047_cas	tagged_with	FBto0000027	FBrf0253239		TOOL DATA from: FBal0374903
+FBti0220048_cas	tagged_with	FBto0000027	FBrf0253239		TOOL DATA from: FBal0374904
+FBti0220049_cas	tagged_with	FBto0000027	FBrf0253239		TOOL DATA from: FBal0374905
+FBti0220050_cas	tagged_with	FBto0000027	FBrf0253239		TOOL DATA from: FBal0374906
+FBti0220068_cas	tagged_with	FBto0000031	FBrf0253559		TOOL DATA from: FBal0374956
+FBti0220069_cas	tagged_with	FBto0000031	FBrf0253559		TOOL DATA from: FBal0374958
+FBti0220098_cas				FTA: unable to add tool information from FBal0374997 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220099_cas				FTA: unable to add tool information from FBal0374998 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220101_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375012
+FBti0220101_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375012
+FBti0220102_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375013
+FBti0220102_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375013
+FBti0220102_cas	tagged_with	FBto0000088	FBrf0253425		TOOL DATA from: FBal0375013
+FBti0220102_cas	tagged_with	FBto0000102	FBrf0253425		TOOL DATA from: FBal0375013
+FBti0220103_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375014
+FBti0220103_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375014
+FBti0220104_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375015
+FBti0220104_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375015
+FBti0220105_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375016
+FBti0220105_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375016
+FBti0220106_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375017
+FBti0220106_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375017
+FBti0220107_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375018
+FBti0220107_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375018
+FBti0220108_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375019
+FBti0220108_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375019
+FBti0220108_cas	tagged_with	FBto0000088	FBrf0253425		TOOL DATA from: FBal0375019
+FBti0220108_cas	tagged_with	FBto0000102	FBrf0253425		TOOL DATA from: FBal0375019
+FBti0220109_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375020
+FBti0220109_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375020
+FBti0220110_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375021
+FBti0220110_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375021
+FBti0220111_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375022
+FBti0220111_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375022
+FBti0220111_cas	tagged_with	FBto0000088	FBrf0253425		TOOL DATA from: FBal0375022
+FBti0220111_cas	tagged_with	FBto0000102	FBrf0253425		TOOL DATA from: FBal0375022
+FBti0220112_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375023
+FBti0220112_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375023
+FBti0220113_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375024
+FBti0220113_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375024
+FBti0220113_cas	tagged_with	FBto0000088	FBrf0253425		TOOL DATA from: FBal0375024
+FBti0220113_cas	tagged_with	FBto0000102	FBrf0253425		TOOL DATA from: FBal0375024
+FBti0220131_cas	tagged_with	FBto0000789	FBrf0250332		TOOL DATA from: FBal0375118
+FBti0220132_cas	tagged_with	FBto0000789	FBrf0250332		TOOL DATA from: FBal0375119
+FBti0220133_cas	tagged_with	FBto0000118	FBrf0250332		TOOL DATA from: FBal0375120
+FBti0220133_cas	tagged_with	FBto0000789	FBrf0250332		TOOL DATA from: FBal0375120
+FBti0220134_cas	tagged_with	FBto0000118	FBrf0250332		TOOL DATA from: FBal0375121
+FBti0220134_cas	tagged_with	FBto0000807	FBrf0250332		TOOL DATA from: FBal0375121
+FBti0220135_cas	tagged_with	FBto0000118	FBrf0250332		TOOL DATA from: FBal0375122
+FBti0220135_cas	tagged_with	FBto0000808	FBrf0250332		TOOL DATA from: FBal0375122
+FBti0220136_cas	tagged_with	FBto0000118	FBrf0250332		TOOL DATA from: FBal0375123
+FBti0220136_cas	tagged_with	FBto0000809	FBrf0250332		TOOL DATA from: FBal0375123
+FBti0220148_cas	carries_tool	FBto0000349	FBrf0253558		TOOL DATA from: FBal0375146
+FBti0220148_cas	carries_tool	FBto0000356	FBrf0253558		TOOL DATA from: FBal0375146
+FBti0220149_cas	carries_tool	FBto0000349	FBrf0253558		TOOL DATA from: FBal0375147
+FBti0220149_cas	carries_tool	FBto0000356	FBrf0253558		TOOL DATA from: FBal0375147
+FBti0220338_cas	tagged_with	FBto0000077	FBrf0236830		TOOL DATA from: FBal0375520
+FBti0220340_cas				FTA: unable to add tool information from FBal0375530 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220341_cas	carries_tool	FBto0000349	FBrf0253731		TOOL DATA from: FBal0375531
+FBti0220341_cas	tagged_with	FBto0000126	FBrf0253731		TOOL DATA from: FBal0375531
+FBti0220342_cas	carries_tool	FBto0000349	FBrf0253731		TOOL DATA from: FBal0375532
+FBti0220342_cas	tagged_with	FBto0000126	FBrf0253731		TOOL DATA from: FBal0375532
+FBti0220344_cas	tagged_with	FBto0000076	FBrf0253598		TOOL DATA from: FBal0375536
+FBti0220344_cas	tagged_with	FBto0000088	FBrf0253598		TOOL DATA from: FBal0375536
+FBti0220368_cas	tagged_with	FBto0000102	FBrf0253831		TOOL DATA from: FBal0375598
+FBti0220369_cas	tagged_with	FBto0000063	FBrf0253899		TOOL DATA from: FBal0375765
+FBti0220370_cas	tagged_with	FBto0000063	FBrf0253899		TOOL DATA from: FBal0375766
+FBti0220371_cas	tagged_with	FBto0000063	FBrf0253899		TOOL DATA from: FBal0375767
+FBti0220480_cas				FTA: unable to add tool information from FBal0375768 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220489_cas	carries_tool	FBto0000349	FBrf0253546		TOOL DATA from: FBal0375789
+FBti0220489_cas	tagged_with	FBto0000027	FBrf0253546		TOOL DATA from: FBal0375789
+FBti0220528_cas	encodes_tool	FBto0000020			TOOL DATA from: FBtp0099208
+FBti0220528_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099208
+FBti0220529_cas	encodes_tool	FBto0000020			TOOL DATA from: FBtp0099208
+FBti0220529_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099208
+FBti0220649_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0220649_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0220649_cas	carries_tool	FBto0000356	FBrf0253396		TOOL DATA from: FBal0375994
+FBti0220649_cas	carries_tool	FBto0000356	FBrf0253396		TOOL DATA from: FBal0375999
+FBti0220659_cas	carries_tool	FBto0000349	FBrf0250623		TOOL DATA from: FBal0376015
+FBti0220659_cas	carries_tool	FBto0000356	FBrf0250623		TOOL DATA from: FBal0376015
+FBti0220664_cas	carries_tool	FBto0000356	FBrf0253814		TOOL DATA from: FBal0376045
+FBti0220666_cas				FTA: unable to add tool information from FBal0376047 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220667_cas	carries_tool	FBto0000318	FBrf0253814		TOOL DATA from: FBal0376048
+FBti0220668_cas	carries_tool	FBto0000318	FBrf0253814		TOOL DATA from: FBal0376049
+FBti0220674_cas	tagged_with	FBto0000815	FBrf0253726		TOOL DATA from: FBal0376070
+FBti0220776_cas	carries_tool	FBto0000349	FBrf0253833		TOOL DATA from: FBal0376105
+FBti0220776_cas	tagged_with	FBto0000076	FBrf0253833		TOOL DATA from: FBal0376105
+FBti0220777_cas	carries_tool	FBto0000349	FBrf0253833		TOOL DATA from: FBal0376106
+FBti0220777_cas	tagged_with	FBto0000076	FBrf0253833		TOOL DATA from: FBal0376106
+FBti0220778_cas	carries_tool	FBto0000349	FBrf0253833		TOOL DATA from: FBal0376107
+FBti0220778_cas	tagged_with	FBto0000076	FBrf0253833		TOOL DATA from: FBal0376107
+FBti0220784_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0220784_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0220784_cas				FTA: unable to add tool information from FBal0376119 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220795_cas	tagged_with	FBto0000076	FBrf0253978		TOOL DATA from: FBal0376164
+FBti0220796_cas	tagged_with	FBto0000076	FBrf0253978		TOOL DATA from: FBal0376167
+FBti0220800_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376169
+FBti0220801_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376170
+FBti0220802_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376171
+FBti0220803_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376172
+FBti0220804_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376173
+FBti0220817_cas	carries_tool	FBto0000349	FBrf0254170		TOOL DATA from: FBal0376180
+FBti0220817_cas	carries_tool	FBto0000356	FBrf0254170		TOOL DATA from: FBal0376180
+FBti0220818_cas	tagged_with	FBto0000076	FBrf0253888		TOOL DATA from: FBal0376185
+FBti0220819_cas	tagged_with	FBto0000076	FBrf0253888		TOOL DATA from: FBal0376186
+FBti0220860_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376228
+FBti0220861_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376231
+FBti0220862_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376238
+FBti0220863_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376239
+FBti0220864_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376240
+FBti0220865_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376241
+FBti0220866_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376242
+FBti0220867_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376243
+FBti0220878_cas	carries_tool	FBto0000349	FBrf0253864		TOOL DATA from: FBal0376263
+FBti0220878_cas	carries_tool	FBto0000356	FBrf0253864		TOOL DATA from: FBal0376263
+FBti0220880_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0220880_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0220881_cas	tagged_with	FBto0000076	FBrf0253864		TOOL DATA from: FBal0376270
+FBti0220882_cas	tagged_with	FBto0000076	FBrf0253864		TOOL DATA from: FBal0376271
+FBti0220883_cas	tagged_with	FBto0000076	FBrf0253864		TOOL DATA from: FBal0376272
+FBti0220886_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376274
+FBti0220886_cas	carries_tool	FBto0000356	FBrf0253894		TOOL DATA from: FBal0376274
+FBti0220887_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0220887_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0220887_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376275
+FBti0220887_cas	tagged_with	FBto0000093	FBrf0253894		TOOL DATA from: FBal0376275
+FBti0220887_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376280
+FBti0220888_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0220888_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0220888_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376276
+FBti0220888_cas	tagged_with	FBto0000027	FBrf0253894		TOOL DATA from: FBal0376276
+FBti0220888_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376279
+FBti0220910_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0220910_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0220910_cas	carries_tool	FBto0000349	FBrf0253944		TOOL DATA from: FBal0376334
+FBti0220910_cas	carries_tool	FBto0000349	FBrf0253944		TOOL DATA from: FBal0376338
+FBti0220913_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0220913_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0220913_cas	carries_tool	FBto0000349	FBrf0253971		TOOL DATA from: FBal0376344
+FBti0220913_cas	carries_tool	FBto0000349	FBrf0253971		TOOL DATA from: FBal0376348
+FBti0220914_cas	carries_tool	FBto0000356	FBrf0253971		TOOL DATA from: FBal0376345
+FBti0220915_cas	carries_tool	FBto0000349	FBrf0253971		TOOL DATA from: FBal0376346
+FBti0220915_cas	tagged_with	FBto0000118	FBrf0253971		TOOL DATA from: FBal0376346
+FBti0220929_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0220929_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0220929_cas	carries_tool	FBto0000349	FBrf0254101		TOOL DATA from: FBal0376354
+FBti0220930_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0220930_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0220930_cas	carries_tool	FBto0000349	FBrf0254101		TOOL DATA from: FBal0376356
+FBti0220934_cas	tagged_with	FBto0000118	FBrf0254123		TOOL DATA from: FBal0376372
+FBti0220935_cas	tagged_with	FBto0000022	FBrf0254123		TOOL DATA from: FBal0376373
+FBti0220936_cas	tagged_with	FBto0000027	FBrf0254123		TOOL DATA from: FBal0376374
+FBti0220937_cas	carries_tool	FBto0000330	FBrf0252993		TOOL DATA from: FBal0376379
+FBti0220937_cas	tagged_with	FBto0000093	FBrf0252993		TOOL DATA from: FBal0376379
+FBti0220938_cas	carries_tool	FBto0000330	FBrf0252993		TOOL DATA from: FBal0376380
+FBti0220938_cas	tagged_with	FBto0000093	FBrf0252993		TOOL DATA from: FBal0376380
+FBti0221011_cas	tagged_with	FBto0000638	FBrf0254383		TOOL DATA from: FBal0376525
+FBti0221037_cas	carries_tool	FBto0000349	FBrf0254489		TOOL DATA from: FBal0376565
+FBti0221037_cas	tagged_with	FBto0000093	FBrf0254489		TOOL DATA from: FBal0376565
+FBti0221141_cas	carries_tool	FBto0000349	FBrf0254302		TOOL DATA from: FBal0376687
+FBti0221142_cas	carries_tool	FBto0000349	FBrf0254302		TOOL DATA from: FBal0376688
+FBti0221142_cas	carries_tool	FBto0000356	FBrf0254302		TOOL DATA from: FBal0376688
+FBti0221146_cas	tagged_with	FBto0000063	FBrf0254188		TOOL DATA from: FBal0376697
+FBti0221147_cas	carries_tool	FBto0000349	FBrf0254188		TOOL DATA from: FBal0376698
+FBti0221147_cas	tagged_with	FBto0000079	FBrf0254188		TOOL DATA from: FBal0376698
+FBti0221165_cas				FTA: unable to add tool information from FBal0376735 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0225521_cas	tagged_with	FBto0000076	FBrf0254696|FBrf0255181		TOOL DATA from: FBal0384519
+FBti0225523_cas	carries_tool	FBto0000349	FBrf0254213		TOOL DATA from: FBal0384547
+FBti0225523_cas	carries_tool	FBto0000356	FBrf0254213		TOOL DATA from: FBal0384547
+FBti0225541_cas	tagged_with	FBto0000077	FBrf0254265		TOOL DATA from: FBal0384557
+FBti0225542_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384560
+FBti0225542_cas	carries_tool	FBto0000349	FBrf0254036		TOOL DATA from: FBal0384560
+FBti0225542_cas	tagged_with	FBto0000093	FBrf0254036		TOOL DATA from: FBal0384560
+FBti0225543_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384561
+FBti0225543_cas	tagged_with	FBto0000076	FBrf0254036		TOOL DATA from: FBal0384561
+FBti0225544_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384564
+FBti0225544_cas	carries_tool	FBto0000349	FBrf0254036		TOOL DATA from: FBal0384564
+FBti0225544_cas	tagged_with	FBto0000093	FBrf0254036		TOOL DATA from: FBal0384564
+FBti0225545_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384565
+FBti0225545_cas	tagged_with	FBto0000076	FBrf0254036		TOOL DATA from: FBal0384565
+FBti0225546_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384566
+FBti0225546_cas	carries_tool	FBto0000349	FBrf0254036		TOOL DATA from: FBal0384566
+FBti0225546_cas	tagged_with	FBto0000093	FBrf0254036		TOOL DATA from: FBal0384566
+FBti0225547_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384567
+FBti0225547_cas	tagged_with	FBto0000076	FBrf0254036		TOOL DATA from: FBal0384567
+FBti0225959_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0225959_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0225959_cas				FTA: unable to add tool information from FBal0385047 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0225960_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0225960_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0225960_cas				FTA: unable to add tool information from FBal0385048 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0225961_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385051
+FBti0225962_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385052
+FBti0225963_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385053
+FBti0225964_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385054
+FBti0225965_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385055
+FBti0225966_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385056
+FBti0225967_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385057
+FBti0225968_cas	tagged_with	FBto0000031	FBrf0254633		TOOL DATA from: FBal0385060
+FBti0225968_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385060
+FBti0225968_cas	tagged_with	FBto0000093	FBrf0254633		TOOL DATA from: FBal0385060
+FBti0225969_cas	tagged_with	FBto0000031	FBrf0254633		TOOL DATA from: FBal0385061
+FBti0225969_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385061
+FBti0225969_cas	tagged_with	FBto0000093	FBrf0254633		TOOL DATA from: FBal0385061
+FBti0226008_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385070
+FBti0226008_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385070
+FBti0226008_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385070
+FBti0226009_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385071
+FBti0226009_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385071
+FBti0226010_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385072
+FBti0226010_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385072
+FBti0226010_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385072
+FBti0226011_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385073
+FBti0226011_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385073
+FBti0226012_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385074
+FBti0226012_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385074
+FBti0226012_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385074
+FBti0226013_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385075
+FBti0226013_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385075
+FBti0226014_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385076
+FBti0226014_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385076
+FBti0226014_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385076
+FBti0226015_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385077
+FBti0226015_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385077
+FBti0226016_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385078
+FBti0226016_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385078
+FBti0226016_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385078
+FBti0226017_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385079
+FBti0226017_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385079
+FBti0226218_cas	tagged_with	FBto0000076	FBrf0254644		TOOL DATA from: FBal0385303
+FBti0226218_cas	tagged_with	FBto0000079	FBrf0254644		TOOL DATA from: FBal0385303
+FBti0226219_cas	tagged_with	FBto0000076	FBrf0254644		TOOL DATA from: FBal0385304
+FBti0226219_cas	tagged_with	FBto0000093	FBrf0254644		TOOL DATA from: FBal0385304
+FBti0226228_cas	carries_tool	FBto0000349	FBrf0254671		TOOL DATA from: FBal0385314
+FBti0226228_cas	tagged_with	FBto0000102	FBrf0254671		TOOL DATA from: FBal0385314
+FBti0226229_cas	carries_tool	FBto0000349	FBrf0254546		TOOL DATA from: FBal0385328
+FBti0226229_cas	tagged_with	FBto0000077	FBrf0254546		TOOL DATA from: FBal0385328
+FBti0226230_cas	carries_tool	FBto0000349	FBrf0254546		TOOL DATA from: FBal0385329
+FBti0226230_cas	tagged_with	FBto0000077	FBrf0254546		TOOL DATA from: FBal0385329
+FBti0226231_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0226231_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0226243_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0116623
+FBti0226243_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0116623
+FBti0226243_cas	carries_tool	FBto0000349	FBrf0254474		TOOL DATA from: FBal0385332
+FBti0226243_cas	carries_tool	FBto0000349	FBrf0254474		TOOL DATA from: FBal0385333
+FBti0226247_cas	tagged_with	FBto0000027	FBrf0227637		TOOL DATA from: FBal0385338
+FBti0226256_cas	tagged_with	FBto0000079	FBrf0254752		TOOL DATA from: FBal0385353
+FBti0226293_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0226293_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0226294_cas				FTA: unable to add tool information from FBal0385410 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226295_cas				FTA: unable to add tool information from FBal0385412 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226296_cas	tagged_with	FBto0000076	FBrf0254714		TOOL DATA from: FBal0385415
+FBti0226297_cas	carries_tool	FBto0000349	FBrf0254662		TOOL DATA from: FBal0385416
+FBti0226298_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0226298_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0226315_cas	carries_tool	FBto0000356	FBrf0254602		TOOL DATA from: FBal0385472
+FBti0226351_cas	carries_tool	FBto0000349	FBrf0254607		TOOL DATA from: FBal0385529
+FBti0226351_cas	carries_tool	FBto0000356	FBrf0254607		TOOL DATA from: FBal0385529
+FBti0226352_cas				FTA: unable to add tool information from FBal0385530 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226353_cas	tagged_with	FBto0000093	FBrf0254607		TOOL DATA from: FBal0385531
+FBti0226353_cas	tagged_with	FBto0000118	FBrf0254607		TOOL DATA from: FBal0385531
+FBti0226356_cas	tagged_with	FBto0000027	FBrf0254801		TOOL DATA from: FBal0385534
+FBti0226357_cas	tagged_with	FBto0000118	FBrf0254801		TOOL DATA from: FBal0385535
+FBti0226364_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0226364_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0226365_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0226365_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0226380_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0226380_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0226381_cas	tagged_with	FBto0000070	FBrf0254561		TOOL DATA from: FBal0385585
+FBti0226398_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0226398_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0226399_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0226399_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0226400_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0226400_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0226401_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0226401_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0226405_cas	carries_tool	FBto0000349	FBrf0254731		TOOL DATA from: FBal0385621
+FBti0226405_cas	tagged_with	FBto0000027	FBrf0254731		TOOL DATA from: FBal0385621
+FBti0226416_cas	carries_tool	FBto0000349	FBrf0254511		TOOL DATA from: FBal0385651
+FBti0226416_cas	carries_tool	FBto0000356	FBrf0254511		TOOL DATA from: FBal0385651
+FBti0226416_cas	tagged_with	FBto0000027	FBrf0254511		TOOL DATA from: FBal0385651
+FBti0226417_cas	tagged_with	FBto0000077	FBrf0254847		TOOL DATA from: FBal0385653
+FBti0226417_cas	tagged_with	FBto0000093	FBrf0254847		TOOL DATA from: FBal0385653
+FBti0226417_cas	tagged_with	FBto0000077	FBrf0254847		TOOL DATA from: FBal0385655
+FBti0226417_cas	tagged_with	FBto0000093	FBrf0254847		TOOL DATA from: FBal0385655
+FBti0226418_cas	tagged_with	FBto0000076	FBrf0254847		TOOL DATA from: FBal0385654
+FBti0226418_cas	tagged_with	FBto0000093	FBrf0254847		TOOL DATA from: FBal0385654
+FBti0226419_cas	carries_tool	FBto0000349	FBrf0254693		TOOL DATA from: FBal0385657
+FBti0226441_cas	carries_tool	FBto0000349	FBrf0254765		TOOL DATA from: FBal0385712
+FBti0226442_cas	carries_tool	FBto0000349	FBrf0254765		TOOL DATA from: FBal0385714
+FBti0226443_cas	carries_tool	FBto0000349	FBrf0254765		TOOL DATA from: FBal0385716
+FBti0226502_cas	tagged_with	FBto0000031	FBrf0254313		TOOL DATA from: FBal0385812
+FBti0226511_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385819
+FBti0226511_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385819
+FBti0226512_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385820
+FBti0226512_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385820
+FBti0226513_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385821
+FBti0226513_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385821
+FBti0226514_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385822
+FBti0226514_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385822
+FBti0226515_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385823
+FBti0226515_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385823
+FBti0226516_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385824
+FBti0226516_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385824
+FBti0226517_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385825
+FBti0226517_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385825
+FBti0226518_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385826
+FBti0226518_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385826
+FBti0226520_cas	carries_tool	FBto0000349	FBrf0254362		TOOL DATA from: FBal0385828
+FBti0226520_cas	carries_tool	FBto0000356	FBrf0254362		TOOL DATA from: FBal0385828
+FBti0226521_cas	carries_tool	FBto0000349	FBrf0254362		TOOL DATA from: FBal0385829
+FBti0226527_cas	encodes_tool	FBto0000150			TOOL DATA from: FBtp0146569
+FBti0226527_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0146569
+FBti0226528_cas	tagged_with	FBto0000334	FBrf0254195		TOOL DATA from: FBal0385846
+FBti0226529_cas	tagged_with	FBto0000031	FBrf0254195		TOOL DATA from: FBal0385847
+FBti0226532_cas	carries_tool	FBto0000349	FBrf0254439		TOOL DATA from: FBal0385861
+FBti0226532_cas	carries_tool	FBto0000356	FBrf0254439		TOOL DATA from: FBal0385861
+FBti0226537_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0226537_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0226537_cas	carries_tool	FBto0000349	FBrf0254952		TOOL DATA from: FBal0385892
+FBti0226537_cas	carries_tool	FBto0000349	FBrf0254952		TOOL DATA from: FBal0385900
+FBti0226538_cas				FTA: unable to add tool information from FBal0385899 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226543_cas	tagged_with	FBto0000638	FBrf0254903		TOOL DATA from: FBal0385904
+FBti0226550_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385916
+FBti0226550_cas	carries_tool	FBto0000356	FBrf0244382		TOOL DATA from: FBal0385916
+FBti0226551_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385917
+FBti0226551_cas	carries_tool	FBto0000356	FBrf0244382		TOOL DATA from: FBal0385917
+FBti0226552_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385918
+FBti0226553_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385919
+FBti0226554_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385920
+FBti0226555_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385921
+FBti0226556_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385922
+FBti0226557_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385923
+FBti0226558_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385924
+FBti0226559_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385925
+FBti0226560_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385926
+FBti0226561_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385927
+FBti0226562_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385928
+FBti0226563_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385929
+FBti0226564_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385930
+FBti0226565_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385931
+FBti0226595_cas	tagged_with	FBto0000118	FBrf0253556		TOOL DATA from: FBal0385974
+FBti0226596_cas	tagged_with	FBto0000048	FBrf0253556		TOOL DATA from: FBal0385975
+FBti0226597_cas				FTA: unable to add tool information from FBal0385976 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226672_cas	tagged_with	FBto0000118	FBrf0253391		TOOL DATA from: FBal0386154
+FBti0226673_cas	tagged_with	FBto0000077	FBrf0254083		TOOL DATA from: FBal0386159
+FBti0226674_cas				FTA: unable to add tool information from FBal0386161 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226675_cas				FTA: unable to add tool information from FBal0386165 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226731_cas	tagged_with	FBto0000077	FBrf0255083		TOOL DATA from: FBal0386301
+FBti0226732_cas	tagged_with	FBto0000063	FBrf0255083		TOOL DATA from: FBal0386302
+FBti0226733_cas	tagged_with	FBto0000063	FBrf0255083		TOOL DATA from: FBal0386304
+FBti0226750_cas	carries_tool	FBto0000356	FBrf0235537		TOOL DATA from: FBal0386338
+FBti0226760_cas	tagged_with	FBto0000031	FBrf0235537		TOOL DATA from: FBal0386349
+FBti0226761_cas	tagged_with	FBto0000118	FBrf0235537		TOOL DATA from: FBal0386350
+FBti0226762_cas	tagged_with	FBto0000031	FBrf0235537		TOOL DATA from: FBal0386356
+FBti0226801_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386447
+FBti0226801_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386447
+FBti0226802_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386448
+FBti0226802_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386448
+FBti0226803_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386449
+FBti0226803_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386449
+FBti0226804_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386450
+FBti0226804_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386450
+FBti0226805_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386451
+FBti0226805_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386451
+FBti0226806_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386452
+FBti0226806_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386452
+FBti0226811_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226811_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226811_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386470
+FBti0226812_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226812_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226812_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386471
+FBti0226813_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226813_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226813_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386472
+FBti0226814_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226814_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226814_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386473
+FBti0226815_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226815_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226815_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386474
+FBti0226816_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226816_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226816_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386475
+FBti0226817_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226817_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226817_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386476
+FBti0226818_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226818_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226818_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386477
+FBti0226819_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226819_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226819_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386478
+FBti0226820_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226820_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226820_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386479
+FBti0226821_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226821_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226821_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386480
+FBti0226822_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226822_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226822_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386481
+FBti0226823_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226823_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226823_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386482
+FBti0226824_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0226824_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0226827_cas	tagged_with	FBto0000031	FBrf0255104		TOOL DATA from: FBal0386585
+FBti0226827_cas	tagged_with	FBto0000307	FBrf0255104		TOOL DATA from: FBal0386585
+FBti0226828_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0226828_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0226828_cas	carries_tool	FBto0000349	FBrf0254890		TOOL DATA from: FBal0386586
+FBti0226828_cas	carries_tool	FBto0000349	FBrf0254890		TOOL DATA from: FBal0386588
+FBti0226836_cas	tagged_with	FBto0000093	FBrf0255456		TOOL DATA from: FBal0386617
+FBti0226837_cas	tagged_with	FBto0000093	FBrf0255457		TOOL DATA from: FBal0386618
+FBti0226838_cas	tagged_with	FBto0000093	FBrf0255458		TOOL DATA from: FBal0386619
+FBti0226841_cas				FTA: unable to add tool information from FBal0386622 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226842_cas	tagged_with	FBto0000076	FBrf0255205		TOOL DATA from: FBal0386623
+FBti0226851_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0226851_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0226851_cas	carries_tool	FBto0000375	FBrf0255059		TOOL DATA from: FBal0386646
+FBti0226968_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0226968_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0226969_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0226969_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0226986_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386973
+FBti0226986_cas	carries_tool	FBto0000356	FBrf0255070		TOOL DATA from: FBal0386973
+FBti0226987_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386974
+FBti0226987_cas	carries_tool	FBto0000356	FBrf0255070		TOOL DATA from: FBal0386974
+FBti0226988_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386975
+FBti0226989_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386976
+FBti0226990_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386977
+FBti0226994_cas	carries_tool	FBto0000349	FBrf0255056		TOOL DATA from: FBal0386984
+FBti0226994_cas	tagged_with	FBto0000076	FBrf0255056		TOOL DATA from: FBal0386984
+FBti0227026_cas	tagged_with	FBto0000076	FBrf0254977		TOOL DATA from: FBal0387074
+FBti0227027_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387075
+FBti0227028_cas				FTA: unable to add tool information from FBal0387076 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227029_cas				FTA: unable to add tool information from FBal0387077 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227030_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387079
+FBti0227031_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387080
+FBti0227032_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387081
+FBti0227033_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387082
+FBti0227034_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387083
+FBti0227035_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387084
+FBti0227036_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387085
+FBti0227071_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387133
+FBti0227071_cas	carries_tool	FBto0000356	FBrf0255045		TOOL DATA from: FBal0387133
+FBti0227072_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387134
+FBti0227073_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387135
+FBti0227074_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0227074_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0227074_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387136
+FBti0227074_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387138
+FBti0227112_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227112_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227112_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387182
+FBti0227112_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387193
+FBti0227113_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227113_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227113_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387183
+FBti0227113_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387194
+FBti0227114_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227114_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227114_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387184
+FBti0227114_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387195
+FBti0227115_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227115_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227115_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387185
+FBti0227115_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387196
+FBti0227116_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227116_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227116_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387186
+FBti0227116_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387197
+FBti0227117_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227117_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227117_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387187
+FBti0227117_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387198
+FBti0227118_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227118_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227118_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387188
+FBti0227118_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387199
+FBti0227119_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227119_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227119_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387189
+FBti0227119_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387200
+FBti0227120_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227120_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227120_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387190
+FBti0227120_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387201
+FBti0227121_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227121_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227121_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387191
+FBti0227121_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387202
+FBti0227122_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227122_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227122_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387192
+FBti0227122_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387203
+FBti0227124_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0227124_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0227139_cas	carries_tool	FBto0000349	FBrf0254982		TOOL DATA from: FBal0387248
+FBti0227139_cas	carries_tool	FBto0000356	FBrf0254982		TOOL DATA from: FBal0387248
+FBti0227139_cas	tagged_with	FBto0000031	FBrf0254982		TOOL DATA from: FBal0387248
+FBti0227234_cas	tagged_with	FBto0000027	FBrf0255082		TOOL DATA from: FBal0387340
+FBti0227235_cas	tagged_with	FBto0000070	FBrf0255330		TOOL DATA from: FBal0387354
+FBti0227235_cas	tagged_with	FBto0000081	FBrf0255330		TOOL DATA from: FBal0387354
+FBti0227236_cas	tagged_with	FBto0000070	FBrf0255330		TOOL DATA from: FBal0387358
+FBti0227236_cas	tagged_with	FBto0000076	FBrf0255330		TOOL DATA from: FBal0387358
+FBti0227237_cas	tagged_with	FBto0000070	FBrf0255330		TOOL DATA from: FBal0387359
+FBti0227237_cas	tagged_with	FBto0000090	FBrf0255330		TOOL DATA from: FBal0387359
+FBti0227241_cas	tagged_with	FBto0000076	FBrf0242826		TOOL DATA from: FBal0387400
+FBti0227243_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227243_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227286_cas	has_reg_region	FBto0000180			TOOL DATA from: FBtp0117267
+FBti0227286_cas	tool_uses	misexpression element			TOOL DATA from: FBtp0117267
+FBti0227305_cas	carries_tool	FBto0000349	FBrf0255544		TOOL DATA from: FBal0387543
+FBti0227305_cas	tagged_with	FBto0000118	FBrf0255544		TOOL DATA from: FBal0387543
+FBti0227344_cas	tagged_with	FBto0000031	FBrf0255710		TOOL DATA from: FBal0387700
+FBti0227348_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387713
+FBti0227349_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387714
+FBti0227350_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387715
+FBti0227351_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387716
+FBti0227352_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387717
+FBti0227353_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387718
+FBti0227354_cas	carries_tool	FBto0000349	FBrf0241006		TOOL DATA from: FBal0387723
+FBti0227355_cas	carries_tool	FBto0000349	FBrf0241006		TOOL DATA from: FBal0387724
+FBti0227356_cas	carries_tool	FBto0000349	FBrf0241006		TOOL DATA from: FBal0387725
+FBti0227357_cas				FTA: unable to add tool information from FBal0387736 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227382_cas				FTA: unable to add tool information from FBal0387769 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227383_cas	carries_tool	FBto0000349	FBrf0233428		TOOL DATA from: FBal0387770
+FBti0227383_cas	carries_tool	FBto0000356	FBrf0233428		TOOL DATA from: FBal0387770
+FBti0227385_cas	tagged_with	FBto0000046	FBrf0233428		TOOL DATA from: FBal0387772
+FBti0227386_cas	tagged_with	FBto0000046	FBrf0233428		TOOL DATA from: FBal0387773
+FBti0227387_cas	tagged_with	FBto0000046	FBrf0233428		TOOL DATA from: FBal0387774
+FBti0227388_cas	tagged_with	FBto0000046	FBrf0233428		TOOL DATA from: FBal0387775
+FBti0227409_cas	tagged_with	FBto0000623	FBrf0255484		TOOL DATA from: FBal0387843
+FBti0227420_cas	carries_tool	FBto0000349	FBrf0255767		TOOL DATA from: FBal0387865
+FBti0227420_cas	carries_tool	FBto0000356	FBrf0255767		TOOL DATA from: FBal0387865
+FBti0227421_cas	carries_tool	FBto0000349	FBrf0255767		TOOL DATA from: FBal0387866
+FBti0227421_cas	carries_tool	FBto0000356	FBrf0255767		TOOL DATA from: FBal0387866
+FBti0227422_cas	carries_tool	FBto0000349	FBrf0255767		TOOL DATA from: FBal0387867
+FBti0227422_cas	carries_tool	FBto0000356	FBrf0255767		TOOL DATA from: FBal0387867
+FBti0227423_cas				FTA: unable to add tool information from FBal0387868 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227425_cas	carries_tool	FBto0000349	FBrf0255770		TOOL DATA from: FBal0387871
+FBti0227425_cas	carries_tool	FBto0000356	FBrf0255770		TOOL DATA from: FBal0387871
+FBti0227442_cas	tagged_with	FBto0000031	FBrf0255555		TOOL DATA from: FBal0387906
+FBti0227443_cas	tagged_with	FBto0000118	FBrf0239824		TOOL DATA from: FBal0387927
+FBti0227491_cas	tagged_with	FBto0000076	FBrf0255740		TOOL DATA from: FBal0388076
+FBti0227491_cas	tagged_with	FBto0000077	FBrf0255740		TOOL DATA from: FBal0388076
+FBti0227492_cas				FTA: unable to add tool information from FBal0388077 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227724_cas	tagged_with	FBto0000093	FBrf0255496		TOOL DATA from: FBal0388206
+FBti0227725_cas	tagged_with	FBto0000093	FBrf0255496		TOOL DATA from: FBal0388207
+FBti0227729_cas				FTA: unable to add tool information from FBal0388241 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227730_cas	tagged_with	FBto0000077	FBrf0255671		TOOL DATA from: FBal0388243
+FBti0227749_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227749_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227749_cas	carries_tool	FBto0000349	FBrf0227716		TOOL DATA from: FBal0388307
+FBti0227750_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227750_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227750_cas	carries_tool	FBto0000349	FBrf0227716		TOOL DATA from: FBal0388295
+FBti0227750_cas	carries_tool	FBto0000349	FBrf0227716		TOOL DATA from: FBal0388308
+FBti0227764_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388332
+FBti0227764_cas	carries_tool	FBto0000356	FBrf0247874		TOOL DATA from: FBal0388332
+FBti0227765_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388333
+FBti0227766_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388334
+FBti0227767_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388335
+FBti0227768_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388336
+FBti0227812_cas	tagged_with	FBto0000077	FBrf0235737		TOOL DATA from: FBal0388383
+FBti0227840_cas				FTA: unable to add tool information from FBal0388440 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227841_cas				FTA: unable to add tool information from FBal0388441 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227842_cas				FTA: unable to add tool information from FBal0388442 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227843_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0227843_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0227844_cas	tagged_with	FBto0000031	FBrf0255652		TOOL DATA from: FBal0388444
+FBti0227846_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0227846_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0227846_cas	carries_tool	FBto0000349	FBrf0245894		TOOL DATA from: FBal0388447
+FBti0227846_cas	carries_tool	FBto0000349	FBrf0245894		TOOL DATA from: FBal0388448
+FBti0227847_cas	encodes_tool	FBto0000322			TOOL DATA from: FBtp0159032
+FBti0227847_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0159032
+FBti0227847_cas	carries_tool	FBto0000349	FBrf0245894		TOOL DATA from: FBal0388449
+FBti0227847_cas	carries_tool	FBto0000349	FBrf0245894		TOOL DATA from: FBal0388450
+FBti0227860_cas	carries_tool	FBto0000349	FBrf0255737		TOOL DATA from: FBal0388465
+FBti0227860_cas	carries_tool	FBto0000356	FBrf0255737		TOOL DATA from: FBal0388465
+FBti0227861_cas	carries_tool	FBto0000349	FBrf0255737		TOOL DATA from: FBal0388466
+FBti0227862_cas	carries_tool	FBto0000349	FBrf0255737		TOOL DATA from: FBal0388467
+FBti0227863_cas	carries_tool	FBto0000349	FBrf0255737		TOOL DATA from: FBal0388468
+FBti0227887_cas	tool_uses	fluorescent protein	FBrf0236978		TOOL DATA from: FBal0388508
+FBti0227887_cas	tool_uses	mechanical force sensor	FBrf0236978		TOOL DATA from: FBal0388508
+FBti0227888_cas	tool_uses	fluorescent protein	FBrf0236978		TOOL DATA from: FBal0388509
+FBti0227889_cas	tagged_with	FBto0000025	FBrf0236978		TOOL DATA from: FBal0388510
+FBti0227890_cas	tagged_with	FBto0000030	FBrf0236978		TOOL DATA from: FBal0388511
+FBti0227909_cas				FTA: unable to add tool information from FBal0388536 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0228028_cas	encodes_tool	FBto0000601			TOOL DATA from: FBtp0159279
+FBti0228028_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0159279
+FBti0228052_cas	carries_tool	FBto0000349	FBrf0233364		TOOL DATA from: FBal0388750
+FBti0228052_cas	tagged_with	FBto0000093	FBrf0233364		TOOL DATA from: FBal0388750
+FBti0228052_cas	tagged_with	FBto0000295	FBrf0233364		TOOL DATA from: FBal0388750
+FBti0228052_cas	tagged_with	FBto0000340	FBrf0233364		TOOL DATA from: FBal0388750
+FBti0228053_cas	carries_tool	FBto0000349	FBrf0233364		TOOL DATA from: FBal0388751
+FBti0228053_cas	tagged_with	FBto0000093	FBrf0233364		TOOL DATA from: FBal0388751
+FBti0228053_cas	tagged_with	FBto0000295	FBrf0233364		TOOL DATA from: FBal0388751
+FBti0228053_cas	tagged_with	FBto0000340	FBrf0233364		TOOL DATA from: FBal0388751
+FBti0228287_cas	carries_tool	FBto0000349	FBrf0256005		TOOL DATA from: FBal0389322
+FBti0228288_cas				FTA: unable to add tool information from FBal0389323 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0228289_cas				FTA: unable to add tool information from FBal0389324 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0228294_cas	tagged_with	FBto0000099	FBrf0242829		TOOL DATA from: FBal0389337
+FBti0228322_cas	carries_tool	FBto0000349	FBrf0241714		TOOL DATA from: FBal0389433
+FBti0228322_cas	carries_tool	FBto0000356	FBrf0241714		TOOL DATA from: FBal0389433
+FBti0228367_cas	tagged_with	FBto0000077	FBrf0256014		TOOL DATA from: FBal0389522
+FBti0228369_cas	tagged_with	FBto0000869	FBrf0255785		TOOL DATA from: FBal0389536
+FBti0228370_cas	tagged_with	FBto0000869	FBrf0255785		TOOL DATA from: FBal0389537
+FBti0228371_cas	tagged_with	FBto0000869	FBrf0255785		TOOL DATA from: FBal0389538
+FBti0228444_cas	tagged_with	FBto0000077	FBrf0255847		TOOL DATA from: FBal0389628
+FBti0228520_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0228520_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0228663_cas	tagged_with	FBto0000031	FBrf0243377		TOOL DATA from: FBal0389815
+FBti0228664_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0141341
+FBti0228664_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141341
+FBti0228665_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0228665_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0228666_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0116623
+FBti0228666_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0116623
+FBti0228683_cas	carries_tool	FBto0000349	FBrf0234343		TOOL DATA from: FBal0389900
+FBti0228683_cas	carries_tool	FBto0000356	FBrf0234343		TOOL DATA from: FBal0389900
+FBti0228684_cas	carries_tool	FBto0000349	FBrf0234343		TOOL DATA from: FBal0389901
+FBti0228684_cas	carries_tool	FBto0000356	FBrf0234343		TOOL DATA from: FBal0389901
+FBti0228685_cas	carries_tool	FBto0000349	FBrf0234343		TOOL DATA from: FBal0389902
+FBti0228685_cas	tagged_with	FBto0000093	FBrf0234343		TOOL DATA from: FBal0389902
+FBti0228688_cas	tagged_with	FBto0000335	FBrf0235662		TOOL DATA from: FBal0389905
+FBti0228689_cas	tagged_with	FBto0000027	FBrf0235662		TOOL DATA from: FBal0389906
+FBti0228690_cas	carries_tool	FBto0000318	FBrf0256197		TOOL DATA from: FBal0389927
+FBti0228692_cas	tagged_with	FBto0000031	FBrf0256151		TOOL DATA from: FBal0390246
+FBti0228696_cas	carries_tool	FBto0000349	FBrf0256120		TOOL DATA from: FBal0390251
+FBti0228696_cas	tagged_with	FBto0000118	FBrf0256120		TOOL DATA from: FBal0390251
+FBti0228708_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0228708_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0228709_cas	tagged_with	FBto0000093	FBrf0255232		TOOL DATA from: FBal0390290
+FBti0228709_cas	tagged_with	FBto0000118	FBrf0255232		TOOL DATA from: FBal0390290
+FBti0228710_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390308
+FBti0228710_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390308
+FBti0228711_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390309
+FBti0228711_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390309
+FBti0228712_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390310
+FBti0228712_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390310
+FBti0228713_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390311
+FBti0228713_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390311
+FBti0228714_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390312
+FBti0228714_cas	tagged_with	FBto0000335	FBrf0256010		TOOL DATA from: FBal0390312
+FBti0228715_cas	carries_tool	FBto0000356	FBrf0256010		TOOL DATA from: FBal0390313
+FBti0228716_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390314
+FBti0228716_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390314
+FBti0228717_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390315
+FBti0228717_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390315
+FBti0228718_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390316
+FBti0228718_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390316
+FBti0228719_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390317
+FBti0228719_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390317
+FBti0228720_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390318
+FBti0228720_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390318
+FBti0228721_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390319
+FBti0228721_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390319
+FBti0228722_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390320
+FBti0228722_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390320
+FBti0228723_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390321
+FBti0228723_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390321
+FBti0228724_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390322
+FBti0228724_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390322
+FBti0228725_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390323
+FBti0228725_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390323
+FBti0228726_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390324
+FBti0228726_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390324
+FBti0228727_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390325
+FBti0228727_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390325
+FBti0228728_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390326
+FBti0228728_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390326
+FBti0228729_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390327
+FBti0228729_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390327
+FBti0228730_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390328
+FBti0228730_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390328
+FBti0228731_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390329
+FBti0228731_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390329
+FBti0228732_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390330
+FBti0228732_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390330
+FBti0228733_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390331
+FBti0228733_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390331
+FBti0228734_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390332
+FBti0228734_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390332
+FBti0228735_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390333
+FBti0228735_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390333
+FBti0228736_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390334
+FBti0228736_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390334
+FBti0228737_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390335
+FBti0228737_cas	tagged_with	FBto0000335	FBrf0256010		TOOL DATA from: FBal0390335
+FBti0228738_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390336
+FBti0228738_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390336
+FBti0228739_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390337
+FBti0228739_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390337
+FBti0228740_cas	carries_tool	FBto0000356	FBrf0256010		TOOL DATA from: FBal0390338
+FBti0228741_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390339
+FBti0228741_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390339
+FBti0228742_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390340
+FBti0228742_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390340
+FBti0228743_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390341
+FBti0228743_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390341
+FBti0228744_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390342
+FBti0228744_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390342
+FBti0228745_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390343
+FBti0228745_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390343
+FBti0228746_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390344
+FBti0228746_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390344
+FBti0228747_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390345
+FBti0228747_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390345
+FBti0228748_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390346
+FBti0228748_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390346
+FBti0228749_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390347
+FBti0228749_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390347
+FBti0228750_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390348
+FBti0228750_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390348
+FBti0228751_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390349
+FBti0228751_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390349
+FBti0228813_cas	carries_tool	FBto0000349	FBrf0237361		TOOL DATA from: FBal0390403
+FBti0228813_cas	carries_tool	FBto0000356	FBrf0237361		TOOL DATA from: FBal0390403
+FBti0228814_cas	carries_tool	FBto0000349	FBrf0237361		TOOL DATA from: FBal0390404
+FBti0228814_cas	carries_tool	FBto0000356	FBrf0237361		TOOL DATA from: FBal0390404
+FBti0228820_cas	carries_tool	FBto0000356	FBrf0239596		TOOL DATA from: FBal0390412
+FBti0228821_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0160138
+FBti0228821_cas	tool_uses	gene trap			TOOL DATA from: FBtp0160138
+FBti0228822_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128005
+FBti0228822_cas	tool_uses	gene trap			TOOL DATA from: FBtp0128005
+FBti0228823_cas	carries_tool	FBto0000356	FBrf0239596		TOOL DATA from: FBal0390415
+FBti0228936_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390698
+FBti0228937_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390699
+FBti0228938_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390700
+FBti0228939_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390701
+FBti0228940_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390702
+FBti0228941_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390681
+FBti0228941_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390681
+FBti0228942_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390707
+FBti0228942_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390707
+FBti0228943_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390709
+FBti0228943_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390709
+FBti0228944_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390710
+FBti0228944_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390710
+FBti0228945_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390712
+FBti0228945_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390712
+FBti0228947_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390713
+FBti0228947_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390713
+FBti0228948_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390714
+FBti0228948_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390714
+FBti0228949_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390715
+FBti0228949_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390715
+FBti0228950_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390717
+FBti0228950_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390717
+FBti0228951_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390719
+FBti0228951_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390719
+FBti0228952_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390720
+FBti0228952_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390720
+FBti0228953_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390721
+FBti0228953_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390721
+FBti0228954_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0228954_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0228954_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390682
+FBti0228954_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390722
+FBti0228955_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0228955_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0228955_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390708
+FBti0228955_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390723
+FBti0228956_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0228956_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0228956_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390718
+FBti0228956_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390724
+FBti0228957_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0228957_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0228957_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390716
+FBti0228957_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390725
+FBti0228958_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0228958_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0228958_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390711
+FBti0228958_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390726
+FBti0228959_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0228959_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0228959_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390727
+FBti0228960_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390730
+FBti0228960_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390730
+FBti0228968_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390684
+FBti0228969_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390685
+FBti0228969_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390690
+FBti0228970_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390686
+FBti0228970_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390692
+FBti0228971_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390687
+FBti0228971_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390696
+FBti0228972_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390688
+FBti0228972_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390697
+FBti0228973_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390689
+FBti0228974_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390691
+FBti0228974_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390691
+FBti0228978_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390678
+FBti0228978_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390706
+FBti0228979_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390675
+FBti0228979_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390703
+FBti0228980_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390676
+FBti0228980_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390704
+FBti0228981_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390677
+FBti0228981_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390705
+FBti0228984_cas	tagged_with	FBto0000031	FBrf0255068		TOOL DATA from: FBal0390733
+FBti0228985_cas	tagged_with	FBto0000031	FBrf0255068		TOOL DATA from: FBal0390734
+FBti0228986_cas	tagged_with	FBto0000031	FBrf0255068		TOOL DATA from: FBal0390735
+FBti0229124_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390893
+FBti0229124_cas	carries_tool	FBto0000356	FBrf0254393		TOOL DATA from: FBal0390893
+FBti0229125_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0229125_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0229125_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390894
+FBti0229125_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390895
+FBti0229126_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0229126_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0229126_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390896
+FBti0229126_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390898
+FBti0229163_cas	tagged_with	FBto0000077	FBrf0256130		TOOL DATA from: FBal0390932
+FBti0229173_cas	carries_tool	FBto0000349	FBrf0256457		TOOL DATA from: FBal0390949
+FBti0229173_cas	tagged_with	FBto0000372	FBrf0256457		TOOL DATA from: FBal0390949
+FBti0229281_cas	tagged_with	FBto0000063	FBrf0256322		TOOL DATA from: FBal0391075
+FBti0229282_cas	tagged_with	FBto0000014	FBrf0256322		TOOL DATA from: FBal0391076
+FBti0229283_cas	carries_tool	FBto0000349	FBrf0255170		TOOL DATA from: FBal0391085
+FBti0229283_cas	tagged_with	FBto0000077	FBrf0255170		TOOL DATA from: FBal0391085
+FBti0229304_cas	tagged_with	FBto0000088	FBrf0256636		TOOL DATA from: FBal0391108
+FBti0229311_cas	tagged_with	FBto0000031	FBrf0242317		TOOL DATA from: FBal0391114
+FBti0229311_cas	tagged_with	FBto0000886	FBrf0242317		TOOL DATA from: FBal0391114
+FBti0229335_cas	carries_tool	FBto0000318	FBrf0256307		TOOL DATA from: FBal0391133
+FBti0229335_cas	carries_tool	FBto0000356	FBrf0256307		TOOL DATA from: FBal0391133
+FBti0229336_cas	carries_tool	FBto0000318	FBrf0256307		TOOL DATA from: FBal0391136
+FBti0229337_cas	carries_tool	FBto0000318	FBrf0256307		TOOL DATA from: FBal0391137
+FBti0229338_cas				FTA: unable to add tool information from FBal0391134 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0229338_cas				FTA: unable to add tool information from FBal0391135 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0229339_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0229339_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0229339_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391138
+FBti0229339_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391144
+FBti0229340_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0229340_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0229340_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391139
+FBti0229340_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391145
+FBti0229341_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0229341_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0229341_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391140
+FBti0229341_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391148
+FBti0229342_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0229342_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0229342_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391141
+FBti0229342_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391149
+FBti0229348_cas	tagged_with	FBto0000028	FBrf0256570		TOOL DATA from: FBal0391153
+FBti0229477_cas	tagged_with	FBto0000076	FBrf0256335		TOOL DATA from: FBal0391408
+FBti0229478_cas	tagged_with	FBto0000076	FBrf0256335		TOOL DATA from: FBal0391409
+FBti0229479_cas	tagged_with	FBto0000076	FBrf0256335		TOOL DATA from: FBal0391410
+FBti0229480_cas	tagged_with	FBto0000076	FBrf0256335		TOOL DATA from: FBal0391411
+FBti0229481_cas	tagged_with	FBto0000027	FBrf0256335		TOOL DATA from: FBal0391412
+FBti0229502_cas	encodes_tool	FBto0000150			TOOL DATA from: FBtp0146569
+FBti0229502_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0146569
+FBti0229521_cas	tagged_with	FBto0000081	FBrf0256345		TOOL DATA from: FBal0391472
+FBti0229522_cas	tagged_with	FBto0000077	FBrf0256345		TOOL DATA from: FBal0391473
+FBti0229523_cas	tagged_with	FBto0000081	FBrf0256345		TOOL DATA from: FBal0391474
+FBti0229524_cas	tagged_with	FBto0000077	FBrf0256345		TOOL DATA from: FBal0391475
+FBti0229524_cas	tagged_with	FBto0000081	FBrf0256345		TOOL DATA from: FBal0391475
+FBti0229549_cas	carries_tool	FBto0000349	FBrf0256531		TOOL DATA from: FBal0391506
+FBti0229550_cas	carries_tool	FBto0000349	FBrf0256531		TOOL DATA from: FBal0391507
+FBti0229576_cas	carries_tool	FBto0000318	FBrf0239922		TOOL DATA from: FBal0391564
+FBti0229576_cas	carries_tool	FBto0000896	FBrf0239922		TOOL DATA from: FBal0391564
+FBti0229577_cas	carries_tool	FBto0000318	FBrf0239922		TOOL DATA from: FBal0391565
+FBti0229578_cas	encodes_tool	FBto0000159			TOOL DATA from: FBtp0099209
+FBti0229578_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099209
+FBti0229578_cas	carries_tool	FBto0000318	FBrf0239922		TOOL DATA from: FBal0391566
+FBti0229578_cas	carries_tool	FBto0000318	FBrf0239922		TOOL DATA from: FBal0391567
+FBti0229579_cas	carries_tool	FBto0000349	FBrf0239922		TOOL DATA from: FBal0391568
+FBti0229579_cas	carries_tool	FBto0000356	FBrf0239922		TOOL DATA from: FBal0391568
+FBti0229580_cas	carries_tool	FBto0000349	FBrf0239922		TOOL DATA from: FBal0391569
+FBti0229581_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0229581_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0229581_cas	carries_tool	FBto0000349	FBrf0239922		TOOL DATA from: FBal0391570
+FBti0229581_cas	carries_tool	FBto0000349	FBrf0239922		TOOL DATA from: FBal0391571
+FBti0229595_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229595_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229595_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229595_cas	tagged_with	FBto0000159	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229595_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229596_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391600
+FBti0229596_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391600
+FBti0229596_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391600
+FBti0229597_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391601
+FBti0229597_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391601
+FBti0229597_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391601
+FBti0229598_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229598_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229598_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229598_cas	tagged_with	FBto0000159	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229598_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229599_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391603
+FBti0229599_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391603
+FBti0229599_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391603
+FBti0229600_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391604
+FBti0229600_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391604
+FBti0229600_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391604
+FBti0229601_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229601_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229601_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229601_cas	tagged_with	FBto0000159	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229601_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229602_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391606
+FBti0229602_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391606
+FBti0229602_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391606
+FBti0229603_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391607
+FBti0229603_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391607
+FBti0229603_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391607
+FBti0229604_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229604_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229604_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229604_cas	tagged_with	FBto0000135	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229604_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229605_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229605_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229605_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229605_cas	tagged_with	FBto0000168	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229605_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229606_cas	tagged_with	FBto0000048	FBrf0261549		TOOL DATA from: FBal0391611
+FBti0229606_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0391611
+FBti0229607_cas	tagged_with	FBto0000093	FBrf0256127|FBrf0261549		TOOL DATA from: FBal0391612
+FBti0229609_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0229609_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0229609_cas				FTA: unable to add tool information from FBal0391610 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0229610_cas	encodes_tool	FBto0000159			TOOL DATA from: FBtp0160841
+FBti0229610_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0160841
+FBti0229610_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391610
+FBti0229610_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391614
+FBti0229612_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391623
+FBti0229613_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391624
+FBti0229613_cas	tagged_with	FBto0000025	FBrf0256675		TOOL DATA from: FBal0391624
+FBti0229614_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391625
+FBti0229614_cas	tagged_with	FBto0000025	FBrf0256675		TOOL DATA from: FBal0391625
+FBti0229615_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0099203
+FBti0229615_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099203
+FBti0229616_cas	tagged_with	FBto0000070	FBrf0256675		TOOL DATA from: FBal0391627
+FBti0229617_cas	tagged_with	FBto0000069	FBrf0256675		TOOL DATA from: FBal0391628
+FBti0229618_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0141341
+FBti0229618_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141341
+FBti0229619_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0116623
+FBti0229619_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0116623
+FBti0229620_cas	tagged_with	FBto0000018	FBrf0256675		TOOL DATA from: FBal0391633
+FBti0229621_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391634
+FBti0229621_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391634
+FBti0229622_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391635
+FBti0229622_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391635
+FBti0229623_cas	tagged_with	FBto0000018	FBrf0256675		TOOL DATA from: FBal0391636
+FBti0229624_cas	carries_tool	FBto0000356	FBrf0256675		TOOL DATA from: FBal0391637
+FBti0229625_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391638
+FBti0229625_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391638
+FBti0229626_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391639
+FBti0229626_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391639
+FBti0229627_cas	tagged_with	FBto0000070	FBrf0256675		TOOL DATA from: FBal0391642
+FBti0229636_cas	carries_tool	FBto0000356	FBrf0256741		TOOL DATA from: FBal0391651
+FBti0229641_cas				FTA: unable to add tool information from FBal0391659 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0229646_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0229646_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0229646_cas	tagged_with	FBto0000092	FBrf0256541		TOOL DATA from: FBal0391661
+FBti0229647_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0229647_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0229647_cas	carries_tool	FBto0000135	FBrf0256541		TOOL DATA from: FBal0391662
+FBti0229648_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0229648_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0229648_cas	tagged_with	FBto0000077	FBrf0256541		TOOL DATA from: FBal0391668
+FBti0229649_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0229649_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0229649_cas	tagged_with	FBto0000077	FBrf0256541		TOOL DATA from: FBal0391669
+FBti0229896_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0229896_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0229896_cas	carries_tool	FBto0000349	FBrf0256600		TOOL DATA from: FBal0391881
+FBti0229896_cas	carries_tool	FBto0000349	FBrf0256600		TOOL DATA from: FBal0391883
+FBti0229897_cas	carries_tool	FBto0000349	FBrf0256600		TOOL DATA from: FBal0391882
+FBti0229897_cas	tagged_with	FBto0000077	FBrf0256600		TOOL DATA from: FBal0391882
+FBti0229898_cas	carries_tool	FBto0000318	FBrf0256821		TOOL DATA from: FBal0391901
+FBti0229899_cas	carries_tool	FBto0000318	FBrf0256821		TOOL DATA from: FBal0391902
+FBti0229899_cas	tagged_with	FBto0000093	FBrf0256821		TOOL DATA from: FBal0391902
+FBti0229902_cas	encodes_tool	FBto0000159			TOOL DATA from: FBtp0160841
+FBti0229902_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0160841
+FBti0229902_cas	tagged_with	FBto0000093	FBrf0256663		TOOL DATA from: FBal0391927
+FBti0229902_cas	tagged_with	FBto0000899	FBrf0256663		TOOL DATA from: FBal0391927
+FBti0229903_cas	tagged_with	FBto0000126	FBrf0256663		TOOL DATA from: FBal0391932
+FBti0229916_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0140111
+FBti0229916_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140111
+FBti0229916_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391939
+FBti0229916_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391952
+FBti0229917_cas	encodes_tool	FBto0000308			TOOL DATA from: FBtp0140111
+FBti0229917_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140111
+FBti0229917_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391940
+FBti0229917_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391953
+FBti0229918_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0229918_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0229918_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391951
+FBti0229918_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391956
+FBti0229919_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0229919_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0229919_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391954
+FBti0229919_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391957
+FBti0229920_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0229920_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0229920_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391955
+FBti0229920_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391958
+FBti0229987_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0229987_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0229988_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0229988_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0230144_cas	carries_tool	FBto0000349	FBrf0256867		TOOL DATA from: FBal0392341
+FBti0230304_cas	tagged_with	FBto0000099	FBrf0257330		TOOL DATA from: FBal0392526
+FBti0230305_cas	tagged_with	FBto0000118	FBrf0257331		TOOL DATA from: FBal0392527
+FBti0230317_cas	tagged_with	FBto0000044	FBrf0257396		TOOL DATA from: FBal0392544
+FBti0230324_cas	carries_tool	FBto0000349	FBrf0257404		TOOL DATA from: FBal0392558
+FBti0230324_cas	tagged_with	FBto0000027	FBrf0257404		TOOL DATA from: FBal0392558
+FBti0230325_cas	tagged_with	FBto0000093	FBrf0257405		TOOL DATA from: FBal0392559
+FBti0230356_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230356_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230357_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230357_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230358_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230358_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230359_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230359_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230360_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230360_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230361_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230361_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230362_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230362_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230363_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230363_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230364_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230364_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230365_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0230365_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0230366_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0230366_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0230367_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0230367_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0230368_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0230368_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0230369_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0230369_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0230370_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0230370_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0230371_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0230371_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0230372_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0230372_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0230373_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0230373_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0230374_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0230374_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0230375_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0230375_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0230376_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0230376_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0230453_cas	carries_tool	FBto0000356	FBrf0257237		TOOL DATA from: FBal0392815
+FBti0230462_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0230462_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0230462_cas	carries_tool	FBto0000349	FBrf0257345		TOOL DATA from: FBal0392824
+FBti0230462_cas	carries_tool	FBto0000375	FBrf0257345		TOOL DATA from: FBal0392824
+FBti0230462_cas	carries_tool	FBto0000349	FBrf0257345		TOOL DATA from: FBal0392826
+FBti0230462_cas	carries_tool	FBto0000375	FBrf0257345		TOOL DATA from: FBal0392826
+FBti0230503_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0230503_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0230507_cas	tagged_with	FBto0000063	FBrf0257271		TOOL DATA from: FBal0392877
+FBti0230508_cas	tagged_with	FBto0000522	FBrf0257271		TOOL DATA from: FBal0392878
+FBti0230516_cas	tagged_with	FBto0000093	FBrf0257196		TOOL DATA from: FBal0392889
+FBti0230517_cas	tagged_with	FBto0000027	FBrf0257196		TOOL DATA from: FBal0392890
+FBti0230518_cas	tagged_with	FBto0000027	FBrf0257196		TOOL DATA from: FBal0392891
+FBti0230523_cas	tagged_with	FBto0000083	FBrf0256925		TOOL DATA from: FBal0392898
+FBti0230523_cas	tagged_with	FBto0000118	FBrf0256925		TOOL DATA from: FBal0392898
+FBti0230524_cas	tagged_with	FBto0000083	FBrf0256925		TOOL DATA from: FBal0392899
+FBti0230524_cas	tagged_with	FBto0000118	FBrf0256925		TOOL DATA from: FBal0392899
+FBti0230525_cas	tagged_with	FBto0000083	FBrf0256925		TOOL DATA from: FBal0392900
+FBti0230525_cas	tagged_with	FBto0000118	FBrf0256925		TOOL DATA from: FBal0392900
+FBti0230536_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0230536_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0230537_cas	tagged_with	FBto0000027	FBrf0257433		TOOL DATA from: FBal0392917
+FBti0230552_cas	carries_tool	FBto0000349	FBrf0257275		TOOL DATA from: FBal0392937
+FBti0230552_cas	tagged_with	FBto0000118	FBrf0257275		TOOL DATA from: FBal0392937
+FBti0230553_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0230553_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0230570_cas	carries_tool	FBto0000349	FBrf0256895		TOOL DATA from: FBal0392963
+FBti0230570_cas	tagged_with	FBto0000031	FBrf0256895		TOOL DATA from: FBal0392963
+FBti0230579_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392984
+FBti0230579_cas	carries_tool	FBto0000356	FBrf0257506		TOOL DATA from: FBal0392984
+FBti0230580_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392985
+FBti0230580_cas	carries_tool	FBto0000356	FBrf0257506		TOOL DATA from: FBal0392985
+FBti0230581_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392986
+FBti0230582_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392987
+FBti0230582_cas	tagged_with	FBto0000093	FBrf0257506		TOOL DATA from: FBal0392987
+FBti0230583_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392988
+FBti0230583_cas	tagged_with	FBto0000077	FBrf0257506		TOOL DATA from: FBal0392988
+FBti0230629_cas	tagged_with	FBto0000027	FBrf0257295		TOOL DATA from: FBal0393037
+FBti0230630_cas	tagged_with	FBto0000335	FBrf0257295		TOOL DATA from: FBal0393044
+FBti0230631_cas	tagged_with	FBto0000335	FBrf0257295		TOOL DATA from: FBal0393047
+FBti0230733_cas	tagged_with	FBto0000076	FBrf0257587		TOOL DATA from: FBal0393171
+FBti0230733_cas	tagged_with	FBto0000093	FBrf0257587		TOOL DATA from: FBal0393171
+FBti0230734_cas	tagged_with	FBto0000076	FBrf0257587		TOOL DATA from: FBal0393173
+FBti0230734_cas	tagged_with	FBto0000093	FBrf0257587		TOOL DATA from: FBal0393173
+FBti0230735_cas	tagged_with	FBto0000076	FBrf0257587		TOOL DATA from: FBal0393174
+FBti0230735_cas	tagged_with	FBto0000093	FBrf0257587		TOOL DATA from: FBal0393174
+FBti0231865_cas	carries_tool	FBto0000349	FBrf0257538		TOOL DATA from: FBal0394281
+FBti0231865_cas	tagged_with	FBto0000031	FBrf0257538		TOOL DATA from: FBal0394281
+FBti0231868_cas	carries_tool	FBto0000349	FBrf0257837		TOOL DATA from: FBal0394286
+FBti0231868_cas	tagged_with	FBto0000027	FBrf0257837		TOOL DATA from: FBal0394286
+FBti0231869_cas	carries_tool	FBto0000349	FBrf0257837		TOOL DATA from: FBal0394287
+FBti0231869_cas	tagged_with	FBto0000118	FBrf0257837		TOOL DATA from: FBal0394287
+FBti0234537_cas	tagged_with	FBto0000077	FBrf0257829		TOOL DATA from: FBal0396468
+FBti0234601_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234601_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234602_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234602_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234603_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234603_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234604_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234604_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234605_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234605_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234606_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234606_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234607_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234607_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234608_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234608_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234609_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234609_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234610_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234610_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234611_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0234611_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0234625_cas	tagged_with	FBto0000031	FBrf0258084		TOOL DATA from: FBal0396685
+FBti0234628_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0234628_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0234628_cas	carries_tool	FBto0000356	FBrf0257759		TOOL DATA from: FBal0396688
+FBti0234630_cas	tagged_with	FBto0000077	FBrf0257759		TOOL DATA from: FBal0396690
+FBti0234632_cas	tagged_with	FBto0000063	FBrf0257759		TOOL DATA from: FBal0396692
+FBti0234633_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0234633_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0234633_cas	carries_tool	FBto0000356	FBrf0257759		TOOL DATA from: FBal0396697
+FBti0234642_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0234642_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0234642_cas	tagged_with	FBto0000031	FBrf0257726		TOOL DATA from: FBal0396719
+FBti0234648_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0234648_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0234648_cas				FTA: unable to add tool information from FBal0396730 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0234649_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0234649_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0234649_cas				FTA: unable to add tool information from FBal0396737 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0234650_cas	carries_tool	FBto0000318	FBrf0257868		TOOL DATA from: FBal0396738
+FBti0234651_cas	carries_tool	FBto0000318	FBrf0257868		TOOL DATA from: FBal0396739
+FBti0234651_cas	tagged_with	FBto0000076	FBrf0257868		TOOL DATA from: FBal0396739
+FBti0234652_cas	carries_tool	FBto0000318	FBrf0257868		TOOL DATA from: FBal0396747
+FBti0234652_cas	tagged_with	FBto0000077	FBrf0257868		TOOL DATA from: FBal0396747
+FBti0234653_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0234653_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0234666_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234666_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234667_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234667_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234668_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234668_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234669_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234669_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234670_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234670_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234671_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234671_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234672_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234672_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234673_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234673_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234674_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234674_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234675_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234675_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234676_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234676_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234677_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234677_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234678_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234678_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234679_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0234679_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0234680_cas	encodes_tool	FBto0000144			TOOL DATA from: FBtp0165199
+FBti0234680_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165199
+FBti0234927_cas	tagged_with	FBto0000118	FBrf0257896		TOOL DATA from: FBal0397055
+FBti0234928_cas	tagged_with	FBto0000077	FBrf0257600		TOOL DATA from: FBal0397057
+FBti0234932_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0234932_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0234932_cas	carries_tool	FBto0000349	FBrf0257935		TOOL DATA from: FBal0397065
+FBti0234932_cas	carries_tool	FBto0000349	FBrf0257935		TOOL DATA from: FBal0397066
+FBti0234947_cas	tagged_with	FBto0000102	FBrf0257635		TOOL DATA from: FBal0397127
+FBti0234961_cas	tagged_with	FBto0000027	FBrf0257501		TOOL DATA from: FBal0397136
+FBti0234962_cas	tagged_with	FBto0000027	FBrf0257501		TOOL DATA from: FBal0397137
+FBti0234974_cas				FTA: unable to add tool information from FBal0397152 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0234986_cas	carries_tool	FBto0000349	FBrf0257530		TOOL DATA from: FBal0397159
+FBti0234986_cas	tagged_with	FBto0000027	FBrf0257530		TOOL DATA from: FBal0397159
+FBti0235034_cas	tagged_with	FBto0000027	FBrf0257901		TOOL DATA from: FBal0397182
+FBti0235035_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0235035_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0235072_cas	carries_tool	FBto0000349	FBrf0257451		TOOL DATA from: FBal0397215
+FBti0235073_cas	carries_tool	FBto0000318			TOOL DATA from: FBtp0165470
+FBti0235162_cas	carries_tool	FBto0000318	FBrf0257867		TOOL DATA from: FBal0397365
+FBti0235162_cas	tagged_with	FBto0000027	FBrf0257867		TOOL DATA from: FBal0397365
+FBti0235163_cas	tagged_with	FBto0000093	FBrf0257735		TOOL DATA from: FBal0397376
+FBti0235164_cas	tagged_with	FBto0000093	FBrf0257735		TOOL DATA from: FBal0397377
+FBti0235165_cas	tagged_with	FBto0000093	FBrf0257735		TOOL DATA from: FBal0397384
+FBti0235172_cas	tagged_with	FBto0000031	FBrf0257765		TOOL DATA from: FBal0397397
+FBti0235172_cas	tagged_with	FBto0000077	FBrf0257765		TOOL DATA from: FBal0397397
+FBti0235195_cas	tagged_with	FBto0000031	FBrf0258079		TOOL DATA from: FBal0397427
+FBti0235205_cas	tagged_with	FBto0000077	FBrf0258142		TOOL DATA from: FBal0397452
+FBti0235206_cas	tagged_with	FBto0000077	FBrf0258142		TOOL DATA from: FBal0397453
+FBti0235207_cas	tagged_with	FBto0000077	FBrf0258142		TOOL DATA from: FBal0397454
+FBti0235208_cas	tagged_with	FBto0000077	FBrf0258142		TOOL DATA from: FBal0397455
+FBti0235211_cas	carries_tool	FBto0000349	FBrf0257791		TOOL DATA from: FBal0397465
+FBti0235211_cas	carries_tool	FBto0000356	FBrf0257791		TOOL DATA from: FBal0397465
+FBti0235212_cas				FTA: unable to add tool information from FBal0397466 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235225_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397502
+FBti0235225_cas	carries_tool	FBto0000356	FBrf0258102		TOOL DATA from: FBal0397502
+FBti0235226_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397503
+FBti0235226_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397503
+FBti0235227_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397504
+FBti0235227_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397504
+FBti0235228_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397505
+FBti0235229_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397506
+FBti0235229_cas	tagged_with	FBto0000118	FBrf0258102		TOOL DATA from: FBal0397506
+FBti0235230_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397507
+FBti0235230_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397507
+FBti0235230_cas	tagged_with	FBto0000118	FBrf0258102		TOOL DATA from: FBal0397507
+FBti0235231_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397508
+FBti0235231_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397508
+FBti0235232_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397509
+FBti0235232_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397509
+FBti0235233_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397510
+FBti0235233_cas	tagged_with	FBto0000070	FBrf0258102		TOOL DATA from: FBal0397510
+FBti0235234_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397511
+FBti0235234_cas	tagged_with	FBto0000070	FBrf0258102		TOOL DATA from: FBal0397511
+FBti0235234_cas	tagged_with	FBto0000118	FBrf0258102		TOOL DATA from: FBal0397511
+FBti0235235_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397512
+FBti0235235_cas	tagged_with	FBto0000117	FBrf0258102		TOOL DATA from: FBal0397512
+FBti0235235_cas	tagged_with	FBto0000638	FBrf0258102		TOOL DATA from: FBal0397512
+FBti0235236_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397513
+FBti0235236_cas	tagged_with	FBto0000117	FBrf0258102		TOOL DATA from: FBal0397513
+FBti0235236_cas	tagged_with	FBto0000118	FBrf0258102		TOOL DATA from: FBal0397513
+FBti0235322_cas	tagged_with	FBto0000077	FBrf0258148		TOOL DATA from: FBal0397658
+FBti0235323_cas	tagged_with	FBto0000076	FBrf0258148		TOOL DATA from: FBal0397659
+FBti0235323_cas	tagged_with	FBto0000077	FBrf0258148		TOOL DATA from: FBal0397659
+FBti0235324_cas	tagged_with	FBto0000076	FBrf0258148		TOOL DATA from: FBal0397660
+FBti0235324_cas	tagged_with	FBto0000077	FBrf0258148		TOOL DATA from: FBal0397660
+FBti0235401_cas				FTA: unable to add tool information from FBal0397815 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235402_cas				FTA: unable to add tool information from FBal0397816 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235403_cas				FTA: unable to add tool information from FBal0397817 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235404_cas				FTA: unable to add tool information from FBal0397818 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235411_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0235411_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0235459_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0235459_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0235470_cas	carries_tool	FBto0000349	FBrf0258355		TOOL DATA from: FBal0398033
+FBti0236724_cas	carries_tool	FBto0000349	FBrf0258418		TOOL DATA from: FBal0398824
+FBti0236742_cas	tagged_with	FBto0000063	FBrf0257086		TOOL DATA from: FBal0398860
+FBti0236743_cas				FTA: unable to add tool information from FBal0398861 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236744_cas				FTA: unable to add tool information from FBal0398862 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236745_cas				FTA: unable to add tool information from FBal0398863 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236746_cas				FTA: unable to add tool information from FBal0398864 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236747_cas				FTA: unable to add tool information from FBal0398865 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236748_cas				FTA: unable to add tool information from FBal0398866 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236753_cas	carries_tool	FBto0000349	FBrf0258340		TOOL DATA from: FBal0398877
+FBti0236753_cas	carries_tool	FBto0000356	FBrf0258340		TOOL DATA from: FBal0398877
+FBti0236754_cas	tagged_with	FBto0000027	FBrf0258450		TOOL DATA from: FBal0398878
+FBti0236755_cas				FTA: unable to add tool information from FBal0398879 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236756_cas	carries_tool	FBto0000349	FBrf0258392		TOOL DATA from: FBal0398883
+FBti0236757_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398884
+FBti0236757_cas	carries_tool	FBto0000356	FBrf0258594		TOOL DATA from: FBal0398884
+FBti0236758_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398885
+FBti0236759_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398886
+FBti0236760_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398887
+FBti0236761_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398888
+FBti0236762_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398889
+FBti0236763_cas				FTA: unable to add tool information from FBal0398890 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236764_cas				FTA: unable to add tool information from FBal0398891 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236765_cas	tagged_with	FBto0000389	FBrf0257573		TOOL DATA from: FBal0398894
+FBti0236765_cas	tagged_with	FBto0000785	FBrf0257573		TOOL DATA from: FBal0398894
+FBti0236773_cas	tagged_with	FBto0000922	FBrf0258431		TOOL DATA from: FBal0398908
+FBti0236779_cas				FTA: unable to add tool information from FBal0398930 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236796_cas	tagged_with	FBto0000076	FBrf0257972		TOOL DATA from: FBal0398944
+FBti0236846_cas	tagged_with	FBto0000048	FBrf0258633		TOOL DATA from: FBal0399054
+FBti0236847_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0236847_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0236850_cas	carries_tool	FBto0000349	FBrf0258633		TOOL DATA from: FBal0399058
+FBti0236850_cas	tagged_with	FBto0000077	FBrf0258633		TOOL DATA from: FBal0399058
+FBti0236850_cas	tagged_with	FBto0000093	FBrf0258633		TOOL DATA from: FBal0399058
+FBti0236856_cas	tagged_with	FBto0000027	FBrf0258683		TOOL DATA from: FBal0399068
+FBti0236857_cas	tagged_with	FBto0000027	FBrf0258683		TOOL DATA from: FBal0399069
+FBti0236863_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399087
+FBti0236863_cas	carries_tool	FBto0000356	FBrf0258384		TOOL DATA from: FBal0399087
+FBti0236864_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399088
+FBti0236864_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399088
+FBti0236865_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399089
+FBti0236865_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399089
+FBti0236865_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399089
+FBti0236866_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399090
+FBti0236866_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399090
+FBti0236866_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399090
+FBti0236867_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399091
+FBti0236867_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399091
+FBti0236867_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399091
+FBti0236868_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399092
+FBti0236868_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399092
+FBti0236868_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399092
+FBti0236869_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399093
+FBti0236869_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399093
+FBti0236869_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399093
+FBti0236873_cas	carries_tool	FBto0000356	FBrf0258505		TOOL DATA from: FBal0399103
+FBti0236874_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0236874_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0236874_cas	carries_tool	FBto0000349	FBrf0258468		TOOL DATA from: FBal0399106
+FBti0236874_cas	tagged_with	FBto0000079	FBrf0258468		TOOL DATA from: FBal0399106
+FBti0236874_cas	carries_tool	FBto0000349	FBrf0258468		TOOL DATA from: FBal0399115
+FBti0236874_cas	tagged_with	FBto0000079	FBrf0258468		TOOL DATA from: FBal0399115
+FBti0236875_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128005
+FBti0236875_cas	tool_uses	gene trap			TOOL DATA from: FBtp0128005
+FBti0236875_cas	carries_tool	FBto0000318	FBrf0258468		TOOL DATA from: FBal0399107
+FBti0236875_cas	carries_tool	FBto0000349	FBrf0258468		TOOL DATA from: FBal0399107
+FBti0236876_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128005
+FBti0236876_cas	tool_uses	gene trap			TOOL DATA from: FBtp0128005
+FBti0236876_cas	carries_tool	FBto0000318	FBrf0258468		TOOL DATA from: FBal0399108
+FBti0236876_cas	carries_tool	FBto0000349	FBrf0258468		TOOL DATA from: FBal0399108
+FBti0236885_cas	tagged_with	FBto0000031	FBrf0257653		TOOL DATA from: FBal0399129
+FBti0236895_cas	carries_tool	FBto0000349	FBrf0249106		TOOL DATA from: FBal0399154
+FBti0236895_cas	tagged_with	FBto0000118	FBrf0249106		TOOL DATA from: FBal0399154
+FBti0236896_cas	tagged_with	FBto0000063	FBrf0249106		TOOL DATA from: FBal0399157
+FBti0236897_cas	tagged_with	FBto0000063	FBrf0249106		TOOL DATA from: FBal0399158
+FBti0236898_cas	tagged_with	FBto0000063	FBrf0249106		TOOL DATA from: FBal0399159
+FBti0236926_cas	tagged_with	FBto0000102	FBrf0258581		TOOL DATA from: FBal0399187
+FBti0236959_cas	tagged_with	FBto0000076	FBrf0256909		TOOL DATA from: FBal0399249
+FBti0236972_cas	carries_tool	FBto0000349	FBrf0258590		TOOL DATA from: FBal0399292
+FBti0236979_cas	carries_tool	FBto0000349	FBrf0258192		TOOL DATA from: FBal0399319
+FBti0236980_cas	carries_tool	FBto0000349	FBrf0258192		TOOL DATA from: FBal0399320
+FBti0236981_cas	carries_tool	FBto0000349	FBrf0257529		TOOL DATA from: FBal0399322
+FBti0236981_cas	carries_tool	FBto0000356	FBrf0257529		TOOL DATA from: FBal0399322
+FBti0236992_cas	tagged_with	FBto0000126	FBrf0253702		TOOL DATA from: FBal0399375
+FBti0236998_cas	tagged_with	FBto0000927	FBrf0258443		TOOL DATA from: FBal0399386
+FBti0236999_cas	carries_tool	FBto0000349	FBrf0258443		TOOL DATA from: FBal0399387
+FBti0236999_cas	carries_tool	FBto0000356	FBrf0258443		TOOL DATA from: FBal0399387
+FBti0236999_cas	tagged_with	FBto0000102	FBrf0258443		TOOL DATA from: FBal0399387
+FBti0236999_cas	tagged_with	FBto0000927	FBrf0258443		TOOL DATA from: FBal0399387
+FBti0237013_cas	carries_tool	FBto0000349	FBrf0257674		TOOL DATA from: FBal0399409
+FBti0237013_cas	tagged_with	FBto0000389	FBrf0257674		TOOL DATA from: FBal0399409
+FBti0237014_cas	carries_tool	FBto0000349	FBrf0257674		TOOL DATA from: FBal0399410
+FBti0237014_cas	tagged_with	FBto0000389	FBrf0257674		TOOL DATA from: FBal0399410
+FBti0237015_cas	tagged_with	FBto0000118	FBrf0257535		TOOL DATA from: FBal0399421
+FBti0237016_cas	tagged_with	FBto0000063	FBrf0257535		TOOL DATA from: FBal0399424
+FBti0237026_cas	tagged_with	FBto0000031	FBrf0257425		TOOL DATA from: FBal0399441
+FBti0237027_cas	tagged_with	FBto0000118	FBrf0258777		TOOL DATA from: FBal0399451
+FBti0237028_cas	tagged_with	FBto0000118	FBrf0258777		TOOL DATA from: FBal0399452
+FBti0237035_cas				FTA: unable to add tool information from FBal0399483 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0237036_cas	carries_tool	FBto0000349	FBrf0258639		TOOL DATA from: FBal0399484
+FBti0237036_cas	carries_tool	FBto0000349	FBrf0258639		TOOL DATA from: FBal0399491
+FBti0237036_cas	tagged_with	FBto0000077	FBrf0258639		TOOL DATA from: FBal0399491
+FBti0237037_cas	tagged_with	FBto0000104	FBrf0258639		TOOL DATA from: FBal0399485
+FBti0237038_cas	tagged_with	FBto0000104	FBrf0258639		TOOL DATA from: FBal0399486
+FBti0237039_cas	tagged_with	FBto0000077	FBrf0258639		TOOL DATA from: FBal0399487
+FBti0237040_cas	tagged_with	FBto0000077	FBrf0258639		TOOL DATA from: FBal0399488
+FBti0237040_cas	tagged_with	FBto0000081	FBrf0258639		TOOL DATA from: FBal0399488
+FBti0237041_cas				FTA: unable to add tool information from FBal0399489 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0237042_cas	carries_tool	FBto0000349	FBrf0258639		TOOL DATA from: FBal0399490
+FBti0237042_cas	tagged_with	FBto0000077	FBrf0258639		TOOL DATA from: FBal0399490
+FBti0237043_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0237043_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0237044_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399496
+FBti0237044_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399496
+FBti0237045_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399500
+FBti0237045_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399500
+FBti0237046_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399504
+FBti0237046_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399504
+FBti0237047_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399508
+FBti0237047_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399508
+FBti0237048_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399512
+FBti0237048_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399512
+FBti0237049_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399516
+FBti0237049_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399516
+FBti0237050_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399520
+FBti0237050_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399520
+FBti0237051_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399524
+FBti0237051_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399524
+FBti0237052_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399528
+FBti0237052_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399528
+FBti0237053_cas	tagged_with	FBto0000516	FBrf0258634		TOOL DATA from: FBal0399529
+FBti0237130_cas	tagged_with	FBto0000063	FBrf0258821		TOOL DATA from: FBal0399611
+FBti0237161_cas	tagged_with	FBto0000036	FBrf0257294		TOOL DATA from: FBal0399646
+FBti0237161_cas	tagged_with	FBto0000645	FBrf0257294		TOOL DATA from: FBal0399646
+FBti0237162_cas	tagged_with	FBto0000036	FBrf0257294		TOOL DATA from: FBal0399647
+FBti0237162_cas	tagged_with	FBto0000307	FBrf0257294		TOOL DATA from: FBal0399647
+FBti0237312_cas	tagged_with	FBto0000063	FBrf0258745		TOOL DATA from: FBal0399878
+FBti0237313_cas	tagged_with	FBto0000063	FBrf0258745		TOOL DATA from: FBal0399879
+FBti0237323_cas	carries_tool	FBto0000349	FBrf0258849		TOOL DATA from: FBal0399912
+FBti0237323_cas	carries_tool	FBto0000356	FBrf0258849		TOOL DATA from: FBal0399912
+FBti0237391_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400006
+FBti0237391_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400006
+FBti0237391_cas	tagged_with	FBto0000077	FBrf0259117		TOOL DATA from: FBal0400006
+FBti0237392_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400007
+FBti0237392_cas	tagged_with	FBto0000077	FBrf0259117		TOOL DATA from: FBal0400007
+FBti0237393_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400008
+FBti0237393_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400008
+FBti0237393_cas	tagged_with	FBto0000077	FBrf0259117		TOOL DATA from: FBal0400008
+FBti0237394_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400009
+FBti0237394_cas	tagged_with	FBto0000077	FBrf0259117		TOOL DATA from: FBal0400009
+FBti0237395_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400010
+FBti0237395_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400010
+FBti0237395_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400010
+FBti0237396_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400011
+FBti0237396_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400011
+FBti0237397_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400012
+FBti0237397_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400012
+FBti0237397_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400012
+FBti0237398_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400013
+FBti0237398_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400013
+FBti0237399_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400015
+FBti0237399_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400015
+FBti0237399_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400015
+FBti0237400_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400016
+FBti0237400_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400016
+FBti0237401_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400017
+FBti0237401_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400017
+FBti0237401_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400017
+FBti0237402_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400018
+FBti0237402_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400018
+FBti0237403_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400019
+FBti0237403_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400019
+FBti0237403_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400019
+FBti0237404_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400020
+FBti0237404_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400020
+FBti0237405_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400021
+FBti0237405_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400021
+FBti0237405_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400021
+FBti0237406_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400022
+FBti0237406_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400022
+FBti0237407_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400023
+FBti0237407_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400023
+FBti0237407_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400023
+FBti0237408_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400024
+FBti0237408_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400024
+FBti0237409_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400025
+FBti0237409_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400025
+FBti0237409_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400025
+FBti0237410_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400026
+FBti0237410_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400026
+FBti0237411_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400027
+FBti0237411_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400027
+FBti0237411_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400027
+FBti0237412_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400028
+FBti0237412_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400028
+FBti0237413_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400029
+FBti0237413_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400029
+FBti0237413_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400029
+FBti0237414_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400030
+FBti0237414_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400030
+FBti0237415_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400031
+FBti0237415_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400031
+FBti0237415_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400031
+FBti0237416_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400032
+FBti0237416_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400032
+FBti0237417_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400033
+FBti0237417_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400033
+FBti0237417_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400033
+FBti0237418_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400034
+FBti0237418_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400034
+FBti0237419_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400035
+FBti0237419_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400035
+FBti0237419_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400035
+FBti0237420_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400036
+FBti0237420_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400036
+FBti0237421_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400041
+FBti0237494_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0237494_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0237495_cas	tagged_with	FBto0000118	FBrf0259036		TOOL DATA from: FBal0400151
+FBti0237496_cas	tagged_with	FBto0000031	FBrf0259036		TOOL DATA from: FBal0400152
+FBti0237497_cas	carries_tool	FBto0000349	FBrf0257534		TOOL DATA from: FBal0400162
+FBti0237497_cas	carries_tool	FBto0000356	FBrf0257534		TOOL DATA from: FBal0400162
+FBti0237498_cas	carries_tool	FBto0000349	FBrf0257534		TOOL DATA from: FBal0400163
+FBti0237498_cas	tagged_with	FBto0000126	FBrf0257534		TOOL DATA from: FBal0400163
+FBti0237507_cas	carries_tool	FBto0000356	FBrf0258889		TOOL DATA from: FBal0400166
+FBti0237508_cas				FTA: unable to add tool information from FBal0391660 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0237523_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0237523_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0237526_cas	carries_tool	FBto0000349	FBrf0258866		TOOL DATA from: FBal0400193
+FBti0237526_cas	carries_tool	FBto0000356	FBrf0258866		TOOL DATA from: FBal0400193
+FBti0237527_cas	carries_tool	FBto0000349	FBrf0258866		TOOL DATA from: FBal0400194
+FBti0237528_cas	tagged_with	FBto0000027	FBrf0258866		TOOL DATA from: FBal0400195
+FBti0237529_cas	tagged_with	FBto0000936	FBrf0258866		TOOL DATA from: FBal0400196
+FBti0237538_cas	tagged_with	FBto0000031	FBrf0258741		TOOL DATA from: FBal0400202
+FBti0237539_cas	carries_tool	FBto0000318	FBrf0258741		TOOL DATA from: FBal0400203
+FBti0237539_cas	tagged_with	FBto0000901	FBrf0258741		TOOL DATA from: FBal0400203
+FBti0237540_cas	carries_tool	FBto0000318	FBrf0258741		TOOL DATA from: FBal0400204
+FBti0237540_cas	tagged_with	FBto0000601	FBrf0258741		TOOL DATA from: FBal0400204
+FBti0237731_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400406
+FBti0237732_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400407
+FBti0237732_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400407
+FBti0237733_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400421
+FBti0237734_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400422
+FBti0237734_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400422
+FBti0237735_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400430
+FBti0237736_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400431
+FBti0237736_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400431
+FBti0237737_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400432
+FBti0237738_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400433
+FBti0237738_cas	tagged_with	FBto0000118	FBrf0258900		TOOL DATA from: FBal0400433
+FBti0237739_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400437
+FBti0237740_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400438
+FBti0237740_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400438
+FBti0237741_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400439
+FBti0237742_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400440
+FBti0237742_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400440
+FBti0237743_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400441
+FBti0237744_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400442
+FBti0237744_cas	tagged_with	FBto0000118	FBrf0258900		TOOL DATA from: FBal0400442
+FBti0237769_cas	tagged_with	FBto0000031	FBrf0259000		TOOL DATA from: FBal0400497
+FBti0237769_cas	tagged_with	FBto0000076	FBrf0259000		TOOL DATA from: FBal0400497
+FBti0237769_cas	tagged_with	FBto0000403	FBrf0259000		TOOL DATA from: FBal0400497
+FBti0237770_cas	tagged_with	FBto0000076	FBrf0259000		TOOL DATA from: FBal0400505
+FBti0237770_cas	tagged_with	FBto0000118	FBrf0259000		TOOL DATA from: FBal0400505
+FBti0237770_cas	tagged_with	FBto0000403	FBrf0259000		TOOL DATA from: FBal0400505
+FBti0237771_cas	tagged_with	FBto0000031	FBrf0259000		TOOL DATA from: FBal0400506
+FBti0237771_cas	tagged_with	FBto0000076	FBrf0259000		TOOL DATA from: FBal0400506
+FBti0237771_cas	tagged_with	FBto0000403	FBrf0259000		TOOL DATA from: FBal0400506
+FBti0237789_cas	carries_tool	FBto0000349	FBrf0259307		TOOL DATA from: FBal0400548
+FBti0237789_cas	carries_tool	FBto0000356	FBrf0259307		TOOL DATA from: FBal0400548
+FBti0237790_cas	carries_tool	FBto0000349	FBrf0259307		TOOL DATA from: FBal0400549
+FBti0237790_cas	carries_tool	FBto0000356	FBrf0259307		TOOL DATA from: FBal0400549
+FBti0237800_cas	carries_tool	FBto0000349	FBrf0258976		TOOL DATA from: FBal0400583
+FBti0237800_cas	carries_tool	FBto0000356	FBrf0258976		TOOL DATA from: FBal0400583
+FBti0237801_cas	carries_tool	FBto0000349	FBrf0258976		TOOL DATA from: FBal0400584
+FBti0237801_cas	carries_tool	FBto0000356	FBrf0258976		TOOL DATA from: FBal0400584
+FBti0237802_cas	carries_tool	FBto0000349	FBrf0258976		TOOL DATA from: FBal0400581
+FBti0237802_cas	carries_tool	FBto0000356	FBrf0258976		TOOL DATA from: FBal0400581
+FBti0237803_cas	carries_tool	FBto0000349	FBrf0258976		TOOL DATA from: FBal0400582
+FBti0237803_cas	carries_tool	FBto0000356	FBrf0258976		TOOL DATA from: FBal0400582
+FBti0237804_cas	carries_tool	FBto0000349	FBrf0257308		TOOL DATA from: FBal0400604
+FBti0237804_cas	carries_tool	FBto0000356	FBrf0257308		TOOL DATA from: FBal0400604
+FBti0237811_cas	tagged_with	FBto0000622	FBrf0257429		TOOL DATA from: FBal0400616
+FBti0237812_cas	tagged_with	FBto0000622	FBrf0257429		TOOL DATA from: FBal0400617
+FBti0237842_cas	tagged_with	FBto0000031	FBrf0259207		TOOL DATA from: FBal0400701
+FBti0237844_cas	carries_tool	FBto0000349	FBrf0259101		TOOL DATA from: FBal0400717
+FBti0237844_cas	tagged_with	FBto0000031	FBrf0259101		TOOL DATA from: FBal0400717
+FBti0237849_cas	carries_tool	FBto0000349	FBrf0259048		TOOL DATA from: FBal0400722
+FBti0237849_cas	tagged_with	FBto0000063	FBrf0259048		TOOL DATA from: FBal0400722
+FBti0238052_cas	tagged_with	FBto0000031	FBrf0230588		TOOL DATA from: FBal0401053
+FBti0238063_cas	tagged_with	FBto0000118	FBrf0259138		TOOL DATA from: FBal0401075
+FBti0238077_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0238077_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0238083_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0238083_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0238084_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0141341
+FBti0238084_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141341
+FBti0238085_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0116623
+FBti0238085_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0116623
+FBti0238103_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401180
+FBti0238103_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401180
+FBti0238104_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401181
+FBti0238104_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401181
+FBti0238105_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401182
+FBti0238105_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401182
+FBti0238106_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401183
+FBti0238106_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401183
+FBti0238107_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401184
+FBti0238107_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401184
+FBti0238108_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401185
+FBti0238108_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401185
+FBti0238109_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401186
+FBti0238109_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401187
+FBti0238389_cas	carries_tool	FBto0000349	FBrf0259229		TOOL DATA from: FBal0401679
+FBti0238389_cas	tagged_with	FBto0000118	FBrf0259229		TOOL DATA from: FBal0401679
+FBti0238390_cas	carries_tool	FBto0000349	FBrf0259229		TOOL DATA from: FBal0401680
+FBti0238390_cas	tagged_with	FBto0000030	FBrf0259229		TOOL DATA from: FBal0401680
+FBti0238396_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238396_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238400_cas	tagged_with	FBto0000077	FBrf0252098		TOOL DATA from: FBal0401731
+FBti0238401_cas	tagged_with	FBto0000027	FBrf0259266		TOOL DATA from: FBal0401752
+FBti0238401_cas	tagged_with	FBto0000076	FBrf0259266		TOOL DATA from: FBal0401752
+FBti0238402_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238402_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238402_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401794
+FBti0238402_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401868
+FBti0238403_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238403_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238403_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401795
+FBti0238403_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401872
+FBti0238404_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238404_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238404_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401796
+FBti0238404_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401876
+FBti0238405_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238405_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238405_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401797
+FBti0238405_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401878
+FBti0238406_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238406_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238406_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401798
+FBti0238406_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401882
+FBti0238407_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238407_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238407_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401799
+FBti0238407_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401887
+FBti0238408_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238408_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238408_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401800
+FBti0238408_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401891
+FBti0238409_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238409_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238409_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401801
+FBti0238409_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401895
+FBti0238410_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238410_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238410_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401802
+FBti0238410_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401898
+FBti0238411_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238411_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238411_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401803
+FBti0238411_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401900
+FBti0238412_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238412_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238412_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401804
+FBti0238412_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401903
+FBti0238413_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238413_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238413_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401805
+FBti0238413_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401907
+FBti0238414_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238414_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238414_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401806
+FBti0238414_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401911
+FBti0238415_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238415_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238415_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401807
+FBti0238415_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401915
+FBti0238416_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238416_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238416_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401808
+FBti0238416_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401921
+FBti0238417_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238417_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238417_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401809
+FBti0238417_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401925
+FBti0238418_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238418_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238418_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401810
+FBti0238418_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401929
+FBti0238419_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238419_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238419_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401811
+FBti0238419_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401869
+FBti0238420_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238420_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238420_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401812
+FBti0238420_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401879
+FBti0238421_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238421_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238421_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401813
+FBti0238421_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401883
+FBti0238422_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238422_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238422_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401814
+FBti0238422_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401888
+FBti0238423_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238423_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238423_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401815
+FBti0238423_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401892
+FBti0238424_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238424_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238424_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401816
+FBti0238424_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401896
+FBti0238425_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238425_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238425_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401817
+FBti0238425_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401901
+FBti0238426_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238426_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238426_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401818
+FBti0238426_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401904
+FBti0238427_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238427_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238427_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401819
+FBti0238427_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401908
+FBti0238428_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238428_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238428_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401820
+FBti0238428_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401912
+FBti0238429_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238429_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238429_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401821
+FBti0238429_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401916
+FBti0238430_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238430_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238430_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401822
+FBti0238430_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401922
+FBti0238431_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238431_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238431_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401823
+FBti0238431_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401926
+FBti0238432_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238432_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238432_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401824
+FBti0238432_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401930
+FBti0238433_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0168557
+FBti0238433_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0168557
+FBti0238433_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0168557
+FBti0238433_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401825
+FBti0238433_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401825
+FBti0238433_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401825
+FBti0238433_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401865
+FBti0238433_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401865
+FBti0238433_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401865
+FBti0238433_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401933
+FBti0238433_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401933
+FBti0238433_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401933
+FBti0238434_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0238434_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0238434_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401826
+FBti0238434_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401826
+FBti0238434_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401826
+FBti0238434_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401935
+FBti0238434_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401935
+FBti0238434_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401935
+FBti0238435_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0168557
+FBti0238435_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0168557
+FBti0238435_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0168557
+FBti0238435_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401827
+FBti0238435_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401827
+FBti0238435_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401827
+FBti0238435_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401867
+FBti0238435_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401867
+FBti0238435_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401867
+FBti0238435_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401936
+FBti0238435_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401936
+FBti0238435_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401936
+FBti0238436_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238436_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238436_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401829
+FBti0238436_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401870
+FBti0238437_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238437_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238437_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401830
+FBti0238437_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401873
+FBti0238438_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238438_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238438_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401831
+FBti0238438_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401874
+FBti0238439_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238439_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238439_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401832
+FBti0238439_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401877
+FBti0238440_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238440_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238440_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401833
+FBti0238440_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401880
+FBti0238441_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238441_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238441_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401834
+FBti0238441_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401884
+FBti0238442_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238442_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238442_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401835
+FBti0238442_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401889
+FBti0238443_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238443_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238443_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401836
+FBti0238443_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401893
+FBti0238444_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238444_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238444_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401837
+FBti0238444_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401897
+FBti0238445_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238445_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238445_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401838
+FBti0238445_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401899
+FBti0238446_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238446_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238446_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401839
+FBti0238446_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401902
+FBti0238447_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238447_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238447_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401840
+FBti0238447_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401905
+FBti0238448_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238448_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238448_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401841
+FBti0238448_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401909
+FBti0238449_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238449_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238449_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401842
+FBti0238449_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401913
+FBti0238450_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238450_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238450_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401843
+FBti0238450_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401917
+FBti0238451_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238451_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238451_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401844
+FBti0238451_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401919
+FBti0238452_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238452_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238452_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401845
+FBti0238452_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401923
+FBti0238453_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238453_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238453_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401846
+FBti0238453_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401927
+FBti0238454_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238454_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238454_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401847
+FBti0238454_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401931
+FBti0238455_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238455_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238455_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401848
+FBti0238455_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401871
+FBti0238456_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238456_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238456_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401849
+FBti0238456_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401875
+FBti0238457_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238457_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238457_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401850
+FBti0238457_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401885
+FBti0238458_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238458_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238458_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401851
+FBti0238458_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401890
+FBti0238459_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238459_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238459_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401852
+FBti0238459_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401894
+FBti0238460_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238460_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238460_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401853
+FBti0238460_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401906
+FBti0238461_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238461_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238461_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401854
+FBti0238461_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401910
+FBti0238462_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238462_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238462_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401855
+FBti0238462_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401914
+FBti0238463_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238463_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238463_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401856
+FBti0238463_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401918
+FBti0238464_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238464_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238464_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401857
+FBti0238464_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401920
+FBti0238465_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238465_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238465_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401858
+FBti0238465_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401924
+FBti0238466_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238466_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238466_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401859
+FBti0238466_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401928
+FBti0238467_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238467_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238467_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401860
+FBti0238467_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401932
+FBti0238468_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238468_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238468_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401861
+FBti0238468_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401881
+FBti0238469_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0238469_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0238469_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401866
+FBti0238469_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401866
+FBti0238469_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401866
+FBti0238469_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401934
+FBti0238469_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401934
+FBti0238469_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401934
+FBti0238504_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0238504_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0238544_cas	carries_tool	FBto0000349	FBrf0259433		TOOL DATA from: FBal0402027
+FBti0238681_cas				FTA: unable to add tool information from FBal0402217 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0238683_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0238683_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0238683_cas	carries_tool	FBto0000349	FBrf0259335		TOOL DATA from: FBal0402220
+FBti0238683_cas	carries_tool	FBto0000349	FBrf0259335		TOOL DATA from: FBal0402221
+FBti0238705_cas	tagged_with	FBto0000522	FBrf0259610		TOOL DATA from: FBal0402246
+FBti0238708_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238708_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238708_cas	carries_tool	FBto0000349	FBrf0259468		TOOL DATA from: FBal0402248
+FBti0238708_cas	carries_tool	FBto0000349	FBrf0259468		TOOL DATA from: FBal0402249
+FBti0238715_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238715_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238735_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238735_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238736_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238736_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238737_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0238737_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0238738_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238738_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238739_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238739_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238740_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238740_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238741_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238741_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238742_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0238742_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0238743_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0238743_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0238744_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238744_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238745_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238745_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238746_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0238746_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0238748_cas	tagged_with	FBto0000077	FBrf0259354		TOOL DATA from: FBal0402304
+FBti0238758_cas				FTA: unable to add tool information from FBal0385572 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0238767_cas	carries_tool	FBto0000349	FBrf0259550		TOOL DATA from: FBal0402337
+FBti0238767_cas	carries_tool	FBto0000356	FBrf0259550		TOOL DATA from: FBal0402337
+FBti0238767_cas	carries_tool	FBto0000349	FBrf0259550		TOOL DATA from: FBal0402338
+FBti0238767_cas	carries_tool	FBto0000356	FBrf0259550		TOOL DATA from: FBal0402338
+FBti0238768_cas	tagged_with	FBto0000063	FBrf0259445		TOOL DATA from: FBal0402346
+FBti0238770_cas	tagged_with	FBto0000031	FBrf0259669		TOOL DATA from: FBal0402363
+FBti0238771_cas	tagged_with	FBto0000031	FBrf0259669		TOOL DATA from: FBal0402364
+FBti0238793_cas	tagged_with	FBto0000063	FBrf0259481		TOOL DATA from: FBal0402405
+FBti0238794_cas	tagged_with	FBto0000063	FBrf0259481		TOOL DATA from: FBal0402408
+FBti0238795_cas	tagged_with	FBto0000039	FBrf0259481		TOOL DATA from: FBal0402410
+FBti0238795_cas	tagged_with	FBto0000389	FBrf0259481		TOOL DATA from: FBal0402410
+FBti0238866_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238866_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238866_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402484
+FBti0238866_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402484
+FBti0238866_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402820
+FBti0238866_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402820
+FBti0238867_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238867_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238867_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402486
+FBti0238867_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402486
+FBti0238867_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402821
+FBti0238867_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402821
+FBti0238868_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238868_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238868_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402488
+FBti0238868_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402488
+FBti0238868_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402822
+FBti0238868_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402822
+FBti0238869_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238869_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238869_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402493
+FBti0238869_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402493
+FBti0238869_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402823
+FBti0238869_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402823
+FBti0238870_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238870_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238870_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402496
+FBti0238870_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402496
+FBti0238870_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402824
+FBti0238870_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402824
+FBti0238871_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238871_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238871_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402498
+FBti0238871_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402498
+FBti0238871_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402825
+FBti0238871_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402825
+FBti0238872_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238872_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238872_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402500
+FBti0238872_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402500
+FBti0238872_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402826
+FBti0238872_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402826
+FBti0238873_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238873_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238873_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402502
+FBti0238873_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402502
+FBti0238873_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402827
+FBti0238873_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402827
+FBti0238874_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238874_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238874_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402504
+FBti0238874_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402504
+FBti0238874_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402828
+FBti0238874_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402828
+FBti0238875_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238875_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238875_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402506
+FBti0238875_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402506
+FBti0238875_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402829
+FBti0238875_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402829
+FBti0238876_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238876_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238876_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402508
+FBti0238876_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402508
+FBti0238876_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402830
+FBti0238876_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402830
+FBti0238877_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238877_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238877_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402510
+FBti0238877_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402510
+FBti0238877_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402831
+FBti0238877_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402831
+FBti0238878_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238878_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238878_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402512
+FBti0238878_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402512
+FBti0238878_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402832
+FBti0238878_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402832
+FBti0238879_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238879_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238879_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402514
+FBti0238879_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402514
+FBti0238879_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402833
+FBti0238879_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402833
+FBti0238880_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238880_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238880_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402516
+FBti0238880_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402516
+FBti0238880_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402834
+FBti0238880_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402834
+FBti0238881_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238881_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238881_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402518
+FBti0238881_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402518
+FBti0238881_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402835
+FBti0238881_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402835
+FBti0238882_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238882_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238882_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402520
+FBti0238882_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402520
+FBti0238882_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402836
+FBti0238882_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402836
+FBti0238883_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238883_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238883_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402523
+FBti0238883_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402523
+FBti0238883_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402837
+FBti0238883_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402837
+FBti0238884_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238884_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238884_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402525
+FBti0238884_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402525
+FBti0238884_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402838
+FBti0238884_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402838
+FBti0238885_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238885_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238885_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402527
+FBti0238885_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402527
+FBti0238885_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402839
+FBti0238885_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402839
+FBti0238886_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238886_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238886_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402529
+FBti0238886_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402529
+FBti0238886_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402840
+FBti0238886_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402840
+FBti0238887_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238887_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238887_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402534
+FBti0238887_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402534
+FBti0238887_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402841
+FBti0238887_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402841
+FBti0238888_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238888_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238888_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402536
+FBti0238888_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402536
+FBti0238888_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402842
+FBti0238888_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402842
+FBti0238889_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238889_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238889_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402540
+FBti0238889_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402540
+FBti0238889_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402843
+FBti0238889_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402843
+FBti0238890_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238890_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238890_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402542
+FBti0238890_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402542
+FBti0238890_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402844
+FBti0238890_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402844
+FBti0238891_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238891_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238891_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402544
+FBti0238891_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402544
+FBti0238891_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402845
+FBti0238891_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402845
+FBti0238892_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238892_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238892_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402547
+FBti0238892_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402547
+FBti0238892_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402846
+FBti0238892_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402846
+FBti0238893_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238893_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238893_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402549
+FBti0238893_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402549
+FBti0238893_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402847
+FBti0238893_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402847
+FBti0238894_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238894_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238894_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402551
+FBti0238894_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402551
+FBti0238894_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402848
+FBti0238894_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402848
+FBti0238895_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238895_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238895_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402553
+FBti0238895_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402553
+FBti0238895_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402849
+FBti0238895_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402849
+FBti0238896_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238896_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238896_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402555
+FBti0238896_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402555
+FBti0238896_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402850
+FBti0238896_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402850
+FBti0238897_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238897_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238897_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402558
+FBti0238897_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402558
+FBti0238897_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402851
+FBti0238897_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402851
+FBti0238898_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238898_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238898_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402560
+FBti0238898_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402560
+FBti0238898_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402852
+FBti0238898_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402852
+FBti0238899_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238899_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238899_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402562
+FBti0238899_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402562
+FBti0238899_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402853
+FBti0238899_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402853
+FBti0238900_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238900_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238900_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402566
+FBti0238900_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402566
+FBti0238900_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402854
+FBti0238900_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402854
+FBti0238901_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238901_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238901_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402568
+FBti0238901_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402568
+FBti0238901_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402855
+FBti0238901_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402855
+FBti0238902_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238902_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238902_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402571
+FBti0238902_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402571
+FBti0238902_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402856
+FBti0238902_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402856
+FBti0238903_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238903_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238903_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402573
+FBti0238903_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402573
+FBti0238903_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402857
+FBti0238903_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402857
+FBti0238904_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238904_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238904_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402575
+FBti0238904_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402575
+FBti0238904_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402858
+FBti0238904_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402858
+FBti0238905_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238905_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238905_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402578
+FBti0238905_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402578
+FBti0238905_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402859
+FBti0238905_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402859
+FBti0238906_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238906_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238906_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402580
+FBti0238906_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402580
+FBti0238906_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402860
+FBti0238906_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402860
+FBti0238907_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238907_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238907_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402582
+FBti0238907_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402582
+FBti0238907_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402861
+FBti0238907_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402861
+FBti0238908_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238908_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238908_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402584
+FBti0238908_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402584
+FBti0238908_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402862
+FBti0238908_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402862
+FBti0238909_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238909_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238909_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402586
+FBti0238909_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402586
+FBti0238909_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402863
+FBti0238909_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402863
+FBti0238910_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238910_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238910_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402588
+FBti0238910_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402588
+FBti0238910_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402864
+FBti0238910_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402864
+FBti0238911_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238911_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238911_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402591
+FBti0238911_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402591
+FBti0238911_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402865
+FBti0238911_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402865
+FBti0238912_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238912_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238912_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402593
+FBti0238912_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402593
+FBti0238912_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402866
+FBti0238912_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402866
+FBti0238913_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238913_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238913_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402599
+FBti0238913_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402599
+FBti0238913_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402867
+FBti0238913_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402867
+FBti0238914_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238914_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238914_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402601
+FBti0238914_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402601
+FBti0238914_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402868
+FBti0238914_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402868
+FBti0238915_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238915_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238915_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402603
+FBti0238915_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402603
+FBti0238915_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402869
+FBti0238915_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402869
+FBti0238916_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238916_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238916_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402607
+FBti0238916_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402607
+FBti0238916_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402870
+FBti0238916_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402870
+FBti0238917_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238917_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238917_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402611
+FBti0238917_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402611
+FBti0238917_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402871
+FBti0238917_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402871
+FBti0238918_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238918_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238918_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402613
+FBti0238918_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402613
+FBti0238918_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402872
+FBti0238918_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402872
+FBti0238919_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238919_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238919_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402615
+FBti0238919_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402615
+FBti0238919_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402873
+FBti0238919_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402873
+FBti0238920_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238920_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238920_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402619
+FBti0238920_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402619
+FBti0238920_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402874
+FBti0238920_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402874
+FBti0238921_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238921_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238921_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402621
+FBti0238921_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402621
+FBti0238921_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402875
+FBti0238921_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402875
+FBti0238922_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238922_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238922_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402623
+FBti0238922_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402623
+FBti0238922_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402876
+FBti0238922_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402876
+FBti0238923_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238923_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238923_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402625
+FBti0238923_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402625
+FBti0238923_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402877
+FBti0238923_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402877
+FBti0238924_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0238924_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0238924_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402626
+FBti0238924_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402953
+FBti0238925_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238925_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238925_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402628
+FBti0238925_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402628
+FBti0238925_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402878
+FBti0238925_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402878
+FBti0238926_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238926_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238926_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402633
+FBti0238926_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402633
+FBti0238926_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402879
+FBti0238926_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402879
+FBti0238927_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238927_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238927_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402635
+FBti0238927_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402635
+FBti0238927_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402880
+FBti0238927_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402880
+FBti0238928_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238928_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238928_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402637
+FBti0238928_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402637
+FBti0238928_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402881
+FBti0238928_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402881
+FBti0238929_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238929_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238929_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402639
+FBti0238929_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402639
+FBti0238929_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402882
+FBti0238929_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402882
+FBti0238930_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238930_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238930_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402641
+FBti0238930_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402641
+FBti0238930_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402883
+FBti0238930_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402883
+FBti0238931_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238931_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238931_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402643
+FBti0238931_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402643
+FBti0238931_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402884
+FBti0238931_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402884
+FBti0238932_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238932_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238932_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402645
+FBti0238932_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402645
+FBti0238932_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402885
+FBti0238932_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402885
+FBti0238933_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238933_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238933_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402649
+FBti0238933_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402649
+FBti0238933_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402886
+FBti0238933_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402886
+FBti0238934_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238934_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238934_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402656
+FBti0238934_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402656
+FBti0238934_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402887
+FBti0238934_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402887
+FBti0238935_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238935_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238935_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402659
+FBti0238935_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402659
+FBti0238935_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402888
+FBti0238935_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402888
+FBti0238936_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238936_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238936_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402662
+FBti0238936_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402662
+FBti0238936_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402889
+FBti0238936_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402889
+FBti0238937_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238937_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238937_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402664
+FBti0238937_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402664
+FBti0238937_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402890
+FBti0238937_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402890
+FBti0238938_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238938_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238938_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402666
+FBti0238938_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402666
+FBti0238938_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402891
+FBti0238938_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402891
+FBti0238939_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238939_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238939_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402668
+FBti0238939_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402668
+FBti0238939_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402892
+FBti0238939_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402892
+FBti0238940_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238940_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238940_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402673
+FBti0238940_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402673
+FBti0238940_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402893
+FBti0238940_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402893
+FBti0238941_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238941_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238941_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402676
+FBti0238941_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402676
+FBti0238941_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402894
+FBti0238941_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402894
+FBti0238942_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238942_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238942_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402679
+FBti0238942_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402679
+FBti0238942_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402895
+FBti0238942_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402895
+FBti0238943_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238943_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238943_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402683
+FBti0238943_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402683
+FBti0238943_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402896
+FBti0238943_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402896
+FBti0238944_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238944_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238944_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402685
+FBti0238944_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402685
+FBti0238944_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402897
+FBti0238944_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402897
+FBti0238945_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238945_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238945_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402687
+FBti0238945_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402687
+FBti0238945_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402898
+FBti0238945_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402898
+FBti0238946_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238946_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238946_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402690
+FBti0238946_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402690
+FBti0238946_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402899
+FBti0238946_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402899
+FBti0238947_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238947_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238947_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402692
+FBti0238947_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402692
+FBti0238947_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402900
+FBti0238947_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402900
+FBti0238948_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238948_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238948_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402696
+FBti0238948_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402696
+FBti0238948_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402901
+FBti0238948_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402901
+FBti0238949_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238949_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238949_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402698
+FBti0238949_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402698
+FBti0238949_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402902
+FBti0238949_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402902
+FBti0238950_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238950_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238950_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402700
+FBti0238950_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402700
+FBti0238950_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402903
+FBti0238950_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402903
+FBti0238951_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238951_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238951_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402703
+FBti0238951_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402703
+FBti0238951_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402904
+FBti0238951_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402904
+FBti0238952_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238952_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238952_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402707
+FBti0238952_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402707
+FBti0238952_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402905
+FBti0238952_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402905
+FBti0238953_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238953_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238953_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402710
+FBti0238953_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402710
+FBti0238953_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402906
+FBti0238953_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402906
+FBti0238954_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238954_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238954_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402712
+FBti0238954_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402712
+FBti0238954_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402907
+FBti0238954_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402907
+FBti0238955_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238955_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238955_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402716
+FBti0238955_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402716
+FBti0238955_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402908
+FBti0238955_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402908
+FBti0238956_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238956_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238956_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402722
+FBti0238956_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402722
+FBti0238956_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402909
+FBti0238956_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402909
+FBti0238957_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238957_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238957_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402724
+FBti0238957_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402724
+FBti0238957_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402910
+FBti0238957_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402910
+FBti0238958_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238958_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238958_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402727
+FBti0238958_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402727
+FBti0238958_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402911
+FBti0238958_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402911
+FBti0238959_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238959_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238959_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402729
+FBti0238959_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402729
+FBti0238959_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402912
+FBti0238959_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402912
+FBti0238960_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238960_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238960_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402731
+FBti0238960_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402731
+FBti0238960_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402913
+FBti0238960_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402913
+FBti0238961_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238961_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238961_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402735
+FBti0238961_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402735
+FBti0238961_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402914
+FBti0238961_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402914
+FBti0238962_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238962_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238962_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402737
+FBti0238962_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402737
+FBti0238962_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402915
+FBti0238962_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402915
+FBti0238963_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238963_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238963_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402740
+FBti0238963_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402740
+FBti0238963_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402916
+FBti0238963_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402916
+FBti0238964_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238964_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238964_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402742
+FBti0238964_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402742
+FBti0238964_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402917
+FBti0238964_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402917
+FBti0238965_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238965_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238965_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402744
+FBti0238965_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402744
+FBti0238965_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402918
+FBti0238965_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402918
+FBti0238966_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238966_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238966_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402746
+FBti0238966_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402746
+FBti0238966_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402919
+FBti0238966_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402919
+FBti0238967_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238967_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238967_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402749
+FBti0238967_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402749
+FBti0238967_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402920
+FBti0238967_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402920
+FBti0238968_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238968_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238968_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402752
+FBti0238968_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402752
+FBti0238968_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402921
+FBti0238968_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402921
+FBti0238969_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238969_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238969_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402755
+FBti0238969_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402755
+FBti0238969_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402922
+FBti0238969_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402922
+FBti0238970_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238970_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238970_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402759
+FBti0238970_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402759
+FBti0238970_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402923
+FBti0238970_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402923
+FBti0238971_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238971_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238971_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402761
+FBti0238971_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402761
+FBti0238971_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402924
+FBti0238971_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402924
+FBti0238972_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238972_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238972_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402763
+FBti0238972_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402763
+FBti0238972_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402925
+FBti0238972_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402925
+FBti0238973_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238973_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238973_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402765
+FBti0238973_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402765
+FBti0238973_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402926
+FBti0238973_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402926
+FBti0238974_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238974_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238974_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402768
+FBti0238974_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402768
+FBti0238974_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402927
+FBti0238974_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402927
+FBti0238975_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238975_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238975_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402771
+FBti0238975_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402771
+FBti0238975_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402928
+FBti0238975_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402928
+FBti0238976_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238976_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238976_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402774
+FBti0238976_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402774
+FBti0238976_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402929
+FBti0238976_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402929
+FBti0238977_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238977_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238977_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402777
+FBti0238977_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402777
+FBti0238977_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402930
+FBti0238977_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402930
+FBti0238978_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238978_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238978_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402779
+FBti0238978_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402779
+FBti0238978_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402931
+FBti0238978_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402931
+FBti0238979_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238979_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238979_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402781
+FBti0238979_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402781
+FBti0238979_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402932
+FBti0238979_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402932
+FBti0238980_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238980_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238980_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402784
+FBti0238980_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402784
+FBti0238980_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402933
+FBti0238980_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402933
+FBti0238981_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238981_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238981_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402786
+FBti0238981_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402786
+FBti0238981_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402934
+FBti0238981_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402934
+FBti0238982_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238982_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238982_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402790
+FBti0238982_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402790
+FBti0238982_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402935
+FBti0238982_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402935
+FBti0238983_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238983_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238983_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402792
+FBti0238983_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402792
+FBti0238983_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402936
+FBti0238983_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402936
+FBti0238984_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238984_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238984_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402796
+FBti0238984_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402796
+FBti0238984_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402937
+FBti0238984_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402937
+FBti0238985_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238985_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238985_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402798
+FBti0238985_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402798
+FBti0238985_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402938
+FBti0238985_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402938
+FBti0238986_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238986_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238986_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402800
+FBti0238986_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402800
+FBti0238986_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402939
+FBti0238986_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402939
+FBti0238987_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238987_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238987_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402803
+FBti0238987_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402803
+FBti0238987_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402940
+FBti0238987_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402940
+FBti0238988_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238988_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238988_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402805
+FBti0238988_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402805
+FBti0238988_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402941
+FBti0238988_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402941
+FBti0238989_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238989_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238989_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402807
+FBti0238989_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402807
+FBti0238989_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402942
+FBti0238989_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402942
+FBti0238990_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238990_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238990_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402809
+FBti0238990_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402809
+FBti0238990_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402943
+FBti0238990_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402943
+FBti0238991_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238991_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238991_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402811
+FBti0238991_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402811
+FBti0238991_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402944
+FBti0238991_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402944
+FBti0238992_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238992_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238992_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402813
+FBti0238992_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402813
+FBti0238992_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402945
+FBti0238992_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402945
+FBti0238993_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238993_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238993_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402815
+FBti0238993_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402815
+FBti0238993_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402946
+FBti0238993_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402946
+FBti0238994_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0143820
+FBti0238994_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0143820
+FBti0238994_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402819
+FBti0238994_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402819
+FBti0238994_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402947
+FBti0238994_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402947
+FBti0239341_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0239341_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0239341_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403122
+FBti0239341_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403125
+FBti0239342_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0239342_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0239342_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403123
+FBti0239342_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403126
+FBti0239343_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0239343_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0239343_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403124
+FBti0239343_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403127
+FBti0239344_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0239344_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0239344_cas	carries_tool	FBto0000318	FBrf0259812		TOOL DATA from: FBal0403128
+FBti0239344_cas	carries_tool	FBto0000345	FBrf0259812		TOOL DATA from: FBal0403128
+FBti0239344_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403128
+FBti0239344_cas	carries_tool	FBto0000318	FBrf0259812		TOOL DATA from: FBal0403130
+FBti0239344_cas	carries_tool	FBto0000345	FBrf0259812		TOOL DATA from: FBal0403130
+FBti0239344_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403130
+FBti0239345_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0239345_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0239345_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403129
+FBti0239345_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403131
+FBti0239355_cas	carries_tool	FBto0000318	FBrf0259520		TOOL DATA from: FBal0403150
+FBti0239355_cas	tagged_with	FBto0000076	FBrf0259520		TOOL DATA from: FBal0403150
+FBti0239356_cas	encodes_tool	FBto0000140			TOOL DATA from: FBtp0128008
+FBti0239356_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128008
+FBti0239356_cas	carries_tool	FBto0000349	FBrf0250180		TOOL DATA from: FBal0403171
+FBti0239356_cas	carries_tool	FBto0000349	FBrf0250180		TOOL DATA from: FBal0403172
+FBti0239364_cas	tagged_with	FBto0000077	FBrf0259319		TOOL DATA from: FBal0403255
+FBti0239440_cas	tagged_with	FBto0000077	FBrf0243163		TOOL DATA from: FBal0403392
+FBti0239441_cas	tagged_with	FBto0000014	FBrf0243937		TOOL DATA from: FBal0403393
+FBti0239442_cas	tagged_with	FBto0000014	FBrf0243937		TOOL DATA from: FBal0403394
+FBti0239443_cas	tagged_with	FBto0000014	FBrf0243937		TOOL DATA from: FBal0403395
+FBti0239444_cas	tagged_with	FBto0000118	FBrf0243937		TOOL DATA from: FBal0403396
+FBti0239484_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239484_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239485_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239485_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239486_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0239486_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0239487_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0239487_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0239488_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0239488_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0239489_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239489_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239490_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239490_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239491_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0239491_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0239492_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0239492_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0239493_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239493_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239494_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0239494_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0239495_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0239495_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0239496_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239496_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239497_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0239497_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0239498_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239498_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239499_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239499_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239500_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239500_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239501_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239501_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239502_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239502_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239503_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0239503_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0239504_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0239504_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0239505_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239505_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239506_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239506_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239507_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239507_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239508_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239508_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239509_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239509_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239510_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239510_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239511_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239511_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239512_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239512_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239513_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239513_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239514_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239514_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239515_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239515_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239516_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239516_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239517_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239517_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239518_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239518_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239519_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239519_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239520_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239520_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239521_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239521_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239522_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239522_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239523_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0239523_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0239524_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239524_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239528_cas	tagged_with	FBto0000076	FBrf0259912		TOOL DATA from: FBal0403640
+FBti0239529_cas	carries_tool	FBto0000349	FBrf0253579		TOOL DATA from: FBal0403641
+FBti0239529_cas	carries_tool	FBto0000356	FBrf0253579		TOOL DATA from: FBal0403641
+FBti0239530_cas				FTA: unable to add tool information from FBal0403642 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403645 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403647 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239531_cas				FTA: unable to add tool information from FBal0403643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239532_cas				FTA: unable to add tool information from FBal0403644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239532_cas				FTA: unable to add tool information from FBal0403653 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239533_cas				FTA: unable to add tool information from FBal0403645 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239534_cas				FTA: unable to add tool information from FBal0403646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239535_cas				FTA: unable to add tool information from FBal0403647 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239536_cas	carries_tool	FBto0000349	FBrf0253579		TOOL DATA from: FBal0403649
+FBti0239536_cas	carries_tool	FBto0000356	FBrf0253579		TOOL DATA from: FBal0403649
+FBti0239537_cas				FTA: unable to add tool information from FBal0403650 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403651 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403652 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403653 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403654 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403655 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403656 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239538_cas				FTA: unable to add tool information from FBal0403651 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239539_cas				FTA: unable to add tool information from FBal0403652 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239540_cas				FTA: unable to add tool information from FBal0403654 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239541_cas				FTA: unable to add tool information from FBal0403655 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239542_cas				FTA: unable to add tool information from FBal0403656 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239543_cas				FTA: unable to add tool information from FBal0403657 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239544_cas				FTA: unable to add tool information from FBal0403658 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403661 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403662 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403663 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403664 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403665 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239546_cas				FTA: unable to add tool information from FBal0403662 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239547_cas				FTA: unable to add tool information from FBal0403663 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239548_cas				FTA: unable to add tool information from FBal0403664 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239549_cas				FTA: unable to add tool information from FBal0403665 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239555_cas	tagged_with	FBto0000077	FBrf0259596		TOOL DATA from: FBal0403667
+FBti0239564_cas	carries_tool	FBto0000349	FBrf0259569		TOOL DATA from: FBal0403677
+FBti0239565_cas	carries_tool	FBto0000349	FBrf0259569		TOOL DATA from: FBal0403678
+FBti0239566_cas	carries_tool	FBto0000349	FBrf0259569		TOOL DATA from: FBal0403679
+FBti0239567_cas	carries_tool	FBto0000349	FBrf0234540		TOOL DATA from: FBal0403753
+FBti0239567_cas	tagged_with	FBto0000389	FBrf0234540		TOOL DATA from: FBal0403753
+FBti0239611_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403808
+FBti0239611_cas	carries_tool	FBto0000356	FBrf0239437		TOOL DATA from: FBal0403808
+FBti0239612_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403809
+FBti0239613_cas	carries_tool	FBto0000318	FBrf0239437		TOOL DATA from: FBal0403810
+FBti0239613_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403810
+FBti0239613_cas	tagged_with	FBto0000009	FBrf0239437		TOOL DATA from: FBal0403810
+FBti0239614_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403811
+FBti0239614_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403814
+FBti0239615_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403812
+FBti0239616_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403813
+FBti0239633_cas	carries_tool	FBto0000356	FBrf0239945		TOOL DATA from: FBal0403834
+FBti0239634_cas	tagged_with	FBto0000039	FBrf0239945		TOOL DATA from: FBal0403835
+FBti0239634_cas	tagged_with	FBto0000389	FBrf0239945		TOOL DATA from: FBal0403835
+FBti0239683_cas	carries_tool	FBto0000349	FBrf0255958		TOOL DATA from: FBal0404045
+FBti0239684_cas	carries_tool	FBto0000349	FBrf0255958		TOOL DATA from: FBal0404046
+FBti0239685_cas	carries_tool	FBto0000349	FBrf0258248		TOOL DATA from: FBal0404073
+FBti0239685_cas	carries_tool	FBto0000356	FBrf0258248		TOOL DATA from: FBal0404073
+FBti0239781_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0239781_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0239781_cas	tagged_with	FBto0000318	FBrf0260008		TOOL DATA from: FBal0404409
+FBti0239781_cas	tagged_with	FBto0000345	FBrf0260008		TOOL DATA from: FBal0404409
+FBti0239781_cas	tagged_with	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404409
+FBti0239781_cas	tagged_with	FBto0000318	FBrf0260008		TOOL DATA from: FBal0404412
+FBti0239781_cas	tagged_with	FBto0000345	FBrf0260008		TOOL DATA from: FBal0404412
+FBti0239781_cas	tagged_with	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404412
+FBti0239782_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0239782_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0239782_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404410
+FBti0239782_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404413
+FBti0239783_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0239783_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0239783_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404411
+FBti0239783_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404414
+FBti0239784_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0239784_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0239784_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404415
+FBti0239784_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404417
+FBti0239785_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0239785_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0239785_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404416
+FBti0239785_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404418
+FBti0239786_cas	carries_tool	FBto0000356	FBrf0259727		TOOL DATA from: FBal0404420
+FBti0239787_cas	tagged_with	FBto0000585	FBrf0259727		TOOL DATA from: FBal0404421
+FBti0239788_cas	tagged_with	FBto0000585	FBrf0259727		TOOL DATA from: FBal0404424
+FBti0239789_cas	tagged_with	FBto0000585	FBrf0259727		TOOL DATA from: FBal0404423
+FBti0239790_cas	tagged_with	FBto0000031	FBrf0259713		TOOL DATA from: FBal0404425
+FBti0239791_cas				FTA: unable to add tool information from FBal0404426 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239792_cas	carries_tool	FBto0000349	FBrf0259693		TOOL DATA from: FBal0404427
+FBti0239792_cas	carries_tool	FBto0000356	FBrf0259693		TOOL DATA from: FBal0404427
+FBti0239793_cas				FTA: unable to add tool information from FBal0404428 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239794_cas				FTA: unable to add tool information from FBal0404429 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239795_cas				FTA: unable to add tool information from FBal0404430 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239835_cas	carries_tool	FBto0000318			TOOL DATA from: FBtp0165470
+FBti0239843_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0239843_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0239844_cas	tagged_with	FBto0000077	FBrf0259771		TOOL DATA from: FBal0404527
+FBti0239845_cas	carries_tool	FBto0000349	FBrf0259747		TOOL DATA from: FBal0404529
+FBti0239845_cas	tagged_with	FBto0000077	FBrf0259747		TOOL DATA from: FBal0404529
+FBti0239863_cas	carries_tool	FBto0000349	FBrf0259998		TOOL DATA from: FBal0404579
+FBti0239863_cas	carries_tool	FBto0000356	FBrf0259998		TOOL DATA from: FBal0404579
+FBti0239863_cas	tagged_with	FBto0000121	FBrf0259998		TOOL DATA from: FBal0404579
+FBti0239868_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404585
+FBti0239869_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404586
+FBti0239870_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404587
+FBti0239871_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404588
+FBti0239872_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404589
+FBti0239873_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404590
+FBti0239874_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404591
+FBti0239875_cas	tagged_with	FBto0000076	FBrf0259853		TOOL DATA from: FBal0404596
+FBti0239877_cas				FTA: unable to add tool information from FBal0404594 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239877_cas				FTA: unable to add tool information from FBal0404595 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239878_cas	tagged_with	FBto0000027	FBrf0259950		TOOL DATA from: FBal0404599
+FBti0239880_cas	carries_tool	FBto0000349	FBrf0259943		TOOL DATA from: FBal0404618
+FBti0239880_cas	carries_tool	FBto0000356	FBrf0259943		TOOL DATA from: FBal0404618
+FBti0239881_cas	carries_tool	FBto0000349	FBrf0259943		TOOL DATA from: FBal0404619
+FBti0239881_cas	carries_tool	FBto0000356	FBrf0259943		TOOL DATA from: FBal0404619
+FBti0239962_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239962_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239963_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0239963_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0239964_cas				FTA: unable to add tool information from FBal0404833 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0240012_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404878
+FBti0240012_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404878
+FBti0240012_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404878
+FBti0240013_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404879
+FBti0240013_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404879
+FBti0240014_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404880
+FBti0240014_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404880
+FBti0240014_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404880
+FBti0240015_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404881
+FBti0240015_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404881
+FBti0240016_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404882
+FBti0240016_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404882
+FBti0240016_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404882
+FBti0240017_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404883
+FBti0240017_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404883
+FBti0240018_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404884
+FBti0240018_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404884
+FBti0240018_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404884
+FBti0240019_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404885
+FBti0240019_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404885
+FBti0240020_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404886
+FBti0240020_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404886
+FBti0240020_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404886
+FBti0240021_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404887
+FBti0240021_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404887
+FBti0240022_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404888
+FBti0240022_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404888
+FBti0240022_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404888
+FBti0240023_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404889
+FBti0240023_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404889
+FBti0240024_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404890
+FBti0240024_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404890
+FBti0240024_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404890
+FBti0240025_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404891
+FBti0240025_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404891
+FBti0240026_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404892
+FBti0240026_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404892
+FBti0240026_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404892
+FBti0240027_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404893
+FBti0240027_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404893
+FBti0240110_cas	tagged_with	FBto0000063	FBrf0260068		TOOL DATA from: FBal0405043
+FBti0240126_cas	tagged_with	FBto0000638	FBrf0260205		TOOL DATA from: FBal0405061
+FBti0240131_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405068
+FBti0240132_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405069
+FBti0240133_cas	tagged_with	FBto0000541	FBrf0260212		TOOL DATA from: FBal0405070
+FBti0240134_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405071
+FBti0240135_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405072
+FBti0240136_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405073
+FBti0240137_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405074
+FBti0240138_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405075
+FBti0240139_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405076
+FBti0240140_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405077
+FBti0240141_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405078
+FBti0240142_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405079
+FBti0240143_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405080
+FBti0240144_cas	tagged_with	FBto0000126	FBrf0260212		TOOL DATA from: FBal0405081
+FBti0240145_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405082
+FBti0240146_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405083
+FBti0240170_cas				FTA: unable to add tool information from FBal0405123 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0240170_cas				FTA: unable to add tool information from FBal0405124 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0240171_cas	tagged_with	FBto0000031	FBrf0260123		TOOL DATA from: FBal0405125
+FBti0240172_cas	tagged_with	FBto0000076	FBrf0260014		TOOL DATA from: FBal0405128
+FBti0240172_cas	tagged_with	FBto0000077	FBrf0260014		TOOL DATA from: FBal0405128
+FBti0244400_cas				FTA: unable to add tool information from FBal0405203 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0244402_cas	tagged_with	FBto0000936	FBrf0260098		TOOL DATA from: FBal0405217
+FBti0244403_cas	tagged_with	FBto0000936	FBrf0260098		TOOL DATA from: FBal0405218
+FBti0244419_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0244419_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0244420_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0244420_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0244421_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0244421_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0244422_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0244422_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0244423_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0244423_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0244425_cas	carries_tool	FBto0000318	FBrf0260208		TOOL DATA from: FBal0405244
+FBti0244426_cas	carries_tool	FBto0000318	FBrf0260208		TOOL DATA from: FBal0405245
+FBti0244431_cas	carries_tool	FBto0000318	FBrf0260208		TOOL DATA from: FBal0405250
+FBti0244433_cas	carries_tool	FBto0000349	FBrf0260208		TOOL DATA from: FBal0405252
+FBti0244433_cas	carries_tool	FBto0000356	FBrf0260208		TOOL DATA from: FBal0405252
+FBti0244442_cas	tagged_with	FBto0000076	FBrf0260166		TOOL DATA from: FBal0405273
+FBti0244442_cas	tagged_with	FBto0000077	FBrf0260166		TOOL DATA from: FBal0405273
+FBti0244443_cas	tagged_with	FBto0000076	FBrf0260166		TOOL DATA from: FBal0405274
+FBti0244443_cas	tagged_with	FBto0000077	FBrf0260166		TOOL DATA from: FBal0405274
+FBti0244448_cas	tagged_with	FBto0000027	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244448_cas	tagged_with	FBto0000076	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244448_cas	tagged_with	FBto0000088	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244448_cas	tagged_with	FBto0000287	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244448_cas	tagged_with	FBto0000341	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244453_cas	tagged_with	FBto0000077	FBrf0258187		TOOL DATA from: FBal0405295
+FBti0244454_cas	tagged_with	FBto0000077	FBrf0258187		TOOL DATA from: FBal0405296
+FBti0247797_cas	tagged_with	FBto0000623	FBrf0257180		TOOL DATA from: FBal0405375
+FBti0247804_cas	carries_tool	FBto0000349	FBrf0257043		TOOL DATA from: FBal0405382
+FBti0247805_cas	carries_tool	FBto0000349	FBrf0257043		TOOL DATA from: FBal0405383
+FBti0247806_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0247806_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0247806_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405386
+FBti0247806_cas	carries_tool	FBto0000356	FBrf0260325		TOOL DATA from: FBal0405386
+FBti0247806_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405392
+FBti0247806_cas	carries_tool	FBto0000356	FBrf0260325		TOOL DATA from: FBal0405392
+FBti0247807_cas	encodes_tool	FBto0000143			TOOL DATA from: FBtp0132059
+FBti0247807_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0132059
+FBti0247807_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405387
+FBti0247807_cas	carries_tool	FBto0000356	FBrf0260325		TOOL DATA from: FBal0405387
+FBti0247807_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405398
+FBti0247807_cas	carries_tool	FBto0000356	FBrf0260325		TOOL DATA from: FBal0405398
+FBti0247808_cas	tagged_with	FBto0000031	FBrf0260325		TOOL DATA from: FBal0405393
+FBti0247809_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405397
+FBti0247810_cas	tagged_with	FBto0000031	FBrf0260325		TOOL DATA from: FBal0405399
+FBti0247829_cas	carries_tool	FBto0000356	FBrf0260193		TOOL DATA from: FBal0405407
+FBti0247843_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247843_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247843_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405421
+FBti0247843_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405430
+FBti0247844_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247844_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247844_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405422
+FBti0247844_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405431
+FBti0247845_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247845_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247845_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405423
+FBti0247845_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405432
+FBti0247846_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247846_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247846_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405424
+FBti0247846_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405433
+FBti0247847_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247847_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247847_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405425
+FBti0247847_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405434
+FBti0247848_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247848_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247848_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405426
+FBti0247848_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405435
+FBti0247849_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247849_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247849_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405427
+FBti0247849_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405436
+FBti0247850_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247850_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247850_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405428
+FBti0247850_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405437
+FBti0247851_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0247851_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0247851_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405429
+FBti0247851_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405441
+FBti0247852_cas				FTA: unable to add tool information from FBal0405440 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0247853_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247853_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247854_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0247854_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0247864_cas	tagged_with	FBto0000516	FBrf0260345		TOOL DATA from: FBal0405479
+FBti0248000_cas	carries_tool	FBto0000356	FBrf0260492		TOOL DATA from: FBal0405672
+FBti0248001_cas	tagged_with	FBto0000077	FBrf0260492		TOOL DATA from: FBal0405673
+FBti0248002_cas	tagged_with	FBto0000077	FBrf0260492		TOOL DATA from: FBal0405674
+FBti0248003_cas	tagged_with	FBto0000077	FBrf0260492		TOOL DATA from: FBal0405675
+FBti0248015_cas	carries_tool	FBto0000318	FBrf0260379		TOOL DATA from: FBal0405688
+FBti0248015_cas	carries_tool	FBto0000904	FBrf0260379		TOOL DATA from: FBal0405688
+FBti0248016_cas	encodes_tool	FBto0000907			TOOL DATA from: FBtp0161476
+FBti0248016_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161476
+FBti0248017_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0248017_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0248018_cas	encodes_tool	FBto0000908			TOOL DATA from: FBtp0161477
+FBti0248018_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0161477
+FBti0248027_cas	carries_tool	FBto0000318	FBrf0260479		TOOL DATA from: FBal0405713
+FBti0248028_cas	carries_tool	FBto0000318	FBrf0260479		TOOL DATA from: FBal0405714
+FBti0248034_cas	tagged_with	FBto0000070	FBrf0260317		TOOL DATA from: FBal0405733
+FBti0248037_cas	carries_tool	FBto0000318	FBrf0260549		TOOL DATA from: FBal0405768
+FBti0248038_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248038_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248039_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0248039_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0248041_cas	tagged_with	FBto0000093	FBrf0260397		TOOL DATA from: FBal0405782
+FBti0248041_cas	tagged_with	FBto0000403	FBrf0260397		TOOL DATA from: FBal0405782
+FBti0248058_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248058_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248058_cas	carries_tool	FBto0000318	FBrf0260396		TOOL DATA from: FBal0405842
+FBti0248058_cas	carries_tool	FBto0000356	FBrf0260396		TOOL DATA from: FBal0405842
+FBti0248058_cas	carries_tool	FBto0000318	FBrf0260396		TOOL DATA from: FBal0405845
+FBti0248058_cas	carries_tool	FBto0000356	FBrf0260396		TOOL DATA from: FBal0405845
+FBti0248059_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248059_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248072_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405886
+FBti0248073_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405887
+FBti0248074_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405888
+FBti0248075_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405889
+FBti0248076_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405890
+FBti0248077_cas	tagged_with	FBto0000104	FBrf0260621		TOOL DATA from: FBal0405891
+FBti0248078_cas				FTA: unable to add tool information from FBal0405892 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248113_cas	tagged_with	FBto0000077	FBrf0260221		TOOL DATA from: FBal0405984
+FBti0248114_cas	tagged_with	FBto0000077	FBrf0260221		TOOL DATA from: FBal0405987
+FBti0248123_cas				FTA: unable to add tool information from FBal0406034 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248124_cas				FTA: unable to add tool information from FBal0406035 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248125_cas				FTA: unable to add tool information from FBal0406036 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248137_cas	carries_tool	FBto0000031	FBrf0243812		TOOL DATA from: FBal0406048
+FBti0248138_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0248138_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0248159_cas	tagged_with	FBto0000077	FBrf0260629		TOOL DATA from: FBal0406072
+FBti0248159_cas	tagged_with	FBto0000083	FBrf0260629		TOOL DATA from: FBal0406072
+FBti0248160_cas	tagged_with	FBto0000093	FBrf0260484		TOOL DATA from: FBal0406074
+FBti0248161_cas	tagged_with	FBto0000093	FBrf0260484		TOOL DATA from: FBal0406075
+FBti0248162_cas	tagged_with	FBto0000093	FBrf0260484		TOOL DATA from: FBal0406076
+FBti0248163_cas	tagged_with	FBto0000121	FBrf0260484		TOOL DATA from: FBal0406077
+FBti0248164_cas	tagged_with	FBto0000522	FBrf0260484		TOOL DATA from: FBal0406078
+FBti0248186_cas	tagged_with	FBto0000027	FBrf0260703		TOOL DATA from: FBal0406106
+FBti0248187_cas				FTA: unable to add tool information from FBal0406116 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248197_cas				FTA: unable to add tool information from FBal0406129 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248198_cas				FTA: unable to add tool information from FBal0406130 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248199_cas	tagged_with	FBto0001007	FBrf0260195		TOOL DATA from: FBal0406131
+FBti0248200_cas	tagged_with	FBto0001007	FBrf0260195		TOOL DATA from: FBal0406132
+FBti0248201_cas	tagged_with	FBto0001007	FBrf0260195		TOOL DATA from: FBal0406133
+FBti0248202_cas	tagged_with	FBto0001007	FBrf0260195		TOOL DATA from: FBal0406134
+FBti0248205_cas				FTA: unable to add tool information from FBal0406137 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248206_cas				FTA: unable to add tool information from FBal0406138 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248207_cas				FTA: unable to add tool information from FBal0406139 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248208_cas				FTA: unable to add tool information from FBal0406140 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248209_cas				FTA: unable to add tool information from FBal0406141 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248211_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248211_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248212_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248212_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248213_cas	encodes_tool	FBto0000777			TOOL DATA from: FBtp0171321
+FBti0248213_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0171321
+FBti0248214_cas	encodes_tool	FBto0000777			TOOL DATA from: FBtp0171321
+FBti0248214_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0171321
+FBti0248220_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248220_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248221_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248221_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248222_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248222_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248223_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248223_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248224_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248224_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248225_cas	encodes_tool	FBto0000161			TOOL DATA from: FBtp0171320
+FBti0248225_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0171320
+FBti0248226_cas	encodes_tool	FBto0000161			TOOL DATA from: FBtp0171320
+FBti0248226_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0171320
+FBti0248247_cas	tagged_with	FBto0000102	FBrf0256977		TOOL DATA from: FBal0406220
+FBti0248261_cas	tagged_with	FBto0000076	FBrf0260259		TOOL DATA from: FBal0406249
+FBti0248261_cas	tagged_with	FBto0000077	FBrf0260259		TOOL DATA from: FBal0406249
+FBti0248262_cas	tagged_with	FBto0000076	FBrf0260259		TOOL DATA from: FBal0406250
+FBti0248262_cas	tagged_with	FBto0000077	FBrf0260259		TOOL DATA from: FBal0406250
+FBti0248263_cas	tagged_with	FBto0000077	FBrf0260618		TOOL DATA from: FBal0406273
+FBti0248263_cas	tagged_with	FBto0000936	FBrf0260618		TOOL DATA from: FBal0406273
+FBti0248264_cas	tagged_with	FBto0000077	FBrf0260618		TOOL DATA from: FBal0406275
+FBti0248264_cas	tagged_with	FBto0000936	FBrf0260618		TOOL DATA from: FBal0406275
+FBti0248266_cas	tagged_with	FBto0000063	FBrf0260618		TOOL DATA from: FBal0406277
+FBti0248267_cas	carries_tool	FBto0000349	FBrf0260618		TOOL DATA from: FBal0406278
+FBti0248269_cas	tagged_with	FBto0000118	FBrf0260618		TOOL DATA from: FBal0406280
+FBti0248271_cas	tagged_with	FBto0000063	FBrf0260618		TOOL DATA from: FBal0406282
+FBti0248273_cas	tagged_with	FBto0000063	FBrf0260618		TOOL DATA from: FBal0406284
+FBti0248291_cas	encodes_tool	FBto0000385			TOOL DATA from: FBtp0171399
+FBti0248291_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0171399
+FBti0248319_cas				FTA: unable to add tool information from FBal0406444 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248320_cas	tagged_with	FBto0000093	FBrf0260878		TOOL DATA from: FBal0406445
+FBti0248326_cas	carries_tool	FBto0000349	FBrf0260416		TOOL DATA from: FBal0406462
+FBti0248327_cas	tagged_with	FBto0000031	FBrf0260738		TOOL DATA from: FBal0406481
+FBti0248328_cas	tagged_with	FBto0000031	FBrf0260738		TOOL DATA from: FBal0406482
+FBti0248350_cas	tagged_with	FBto0000070	FBrf0261147		TOOL DATA from: FBal0406527
+FBti0248350_cas	tagged_with	FBto0000077	FBrf0261147		TOOL DATA from: FBal0406527
+FBti0248351_cas	tagged_with	FBto0000031	FBrf0260924		TOOL DATA from: FBal0406535
+FBti0248352_cas	carries_tool	FBto0000349	FBrf0260937		TOOL DATA from: FBal0406544
+FBti0248352_cas	tagged_with	FBto0000063	FBrf0260937		TOOL DATA from: FBal0406544
+FBti0248355_cas				FTA: unable to add tool information from FBal0406556 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248356_cas				FTA: unable to add tool information from FBal0406559 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248358_cas				FTA: unable to add tool information from FBal0406581 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248359_cas				FTA: unable to add tool information from FBal0406582 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248419_cas	carries_tool	FBto0000349	FBrf0260910		TOOL DATA from: FBal0406708
+FBti0248419_cas	tagged_with	FBto0000118	FBrf0260910		TOOL DATA from: FBal0406708
+FBti0248422_cas	carries_tool	FBto0000349	FBrf0260993		TOOL DATA from: FBal0406715
+FBti0248422_cas	carries_tool	FBto0000356	FBrf0260993		TOOL DATA from: FBal0406715
+FBti0248423_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406716
+FBti0248425_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406718
+FBti0248426_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406719
+FBti0248427_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406720
+FBti0248428_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406721
+FBti0248429_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406722
+FBti0248430_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406723
+FBti0248431_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406724
+FBti0248432_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406725
+FBti0248433_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406726
+FBti0248434_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406727
+FBti0248445_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0248445_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0248456_cas				FTA: unable to add tool information from FBal0406752 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248480_cas	tagged_with	FBto0000027	FBrf0261242		TOOL DATA from: FBal0406766
+FBti0248515_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248515_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248515_cas	carries_tool	FBto0000349	FBrf0261245		TOOL DATA from: FBal0406845
+FBti0248515_cas	carries_tool	FBto0000349	FBrf0261245		TOOL DATA from: FBal0406846
+FBti0248524_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0248524_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0248524_cas	carries_tool	FBto0000349	FBrf0260984		TOOL DATA from: FBal0406892
+FBti0248524_cas	tagged_with	FBto0000093	FBrf0260984		TOOL DATA from: FBal0406892
+FBti0248524_cas	carries_tool	FBto0000349	FBrf0260984		TOOL DATA from: FBal0406894
+FBti0248524_cas	tagged_with	FBto0000093	FBrf0260984		TOOL DATA from: FBal0406894
+FBti0248525_cas	encodes_tool	FBto0000153			TOOL DATA from: FBtp0140110
+FBti0248525_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140110
+FBti0248525_cas	carries_tool	FBto0000349	FBrf0260984		TOOL DATA from: FBal0406893
+FBti0248525_cas	tagged_with	FBto0000093	FBrf0260984		TOOL DATA from: FBal0406893
+FBti0248525_cas	carries_tool	FBto0000349	FBrf0260984		TOOL DATA from: FBal0406895
+FBti0248525_cas	tagged_with	FBto0000093	FBrf0260984		TOOL DATA from: FBal0406895
+FBti0248526_cas	tagged_with	FBto0000077	FBrf0261201		TOOL DATA from: FBal0406908
+FBti0248527_cas	carries_tool	FBto0000349	FBrf0261422		TOOL DATA from: FBal0406935
+FBti0248527_cas	tagged_with	FBto0000031	FBrf0261422		TOOL DATA from: FBal0406935
+FBti0248528_cas	carries_tool	FBto0000349	FBrf0261422		TOOL DATA from: FBal0406936
+FBti0248528_cas	carries_tool	FBto0000356	FBrf0261422		TOOL DATA from: FBal0406936
+FBti0248529_cas	carries_tool	FBto0000349	FBrf0261422		TOOL DATA from: FBal0406938
+FBti0248529_cas	tagged_with	FBto0000093	FBrf0261422		TOOL DATA from: FBal0406938
+FBti0248535_cas	tagged_with	FBto0000118	FBrf0261231		TOOL DATA from: FBal0406995
+FBti0248536_cas	tagged_with	FBto0000027	FBrf0261231		TOOL DATA from: FBal0406996
+FBti0248537_cas				FTA: unable to add tool information from FBal0407004 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248538_cas	tagged_with	FBto0000027	FBrf0261312		TOOL DATA from: FBal0407018
+FBti0248539_cas	carries_tool	FBto0000323	FBrf0261312		TOOL DATA from: FBal0407020
+FBti0248539_cas	tagged_with	FBto0000936	FBrf0261312		TOOL DATA from: FBal0407020
+FBti0248540_cas	carries_tool	FBto0000323	FBrf0261312		TOOL DATA from: FBal0407021
+FBti0248540_cas	tagged_with	FBto0000936	FBrf0261312		TOOL DATA from: FBal0407021
+FBti0248542_cas	carries_tool	FBto0000349	FBrf0261483		TOOL DATA from: FBal0407025
+FBti0248543_cas	carries_tool	FBto0000349	FBrf0261483		TOOL DATA from: FBal0407027
+FBti0248544_cas	carries_tool	FBto0000349	FBrf0261483		TOOL DATA from: FBal0407028
+FBti0248545_cas	carries_tool	FBto0000349	FBrf0261483		TOOL DATA from: FBal0407029
+FBti0248546_cas	tagged_with	FBto0000063	FBrf0261536		TOOL DATA from: FBal0407034
+FBti0248585_cas	tagged_with	FBto0000093	FBrf0261351		TOOL DATA from: FBal0407101
+FBti0248604_cas	tagged_with	FBto0000063	FBrf0261515		TOOL DATA from: FBal0407132
+FBti0248605_cas	tagged_with	FBto0000063	FBrf0261515		TOOL DATA from: FBal0407133
+FBti0248653_cas	tagged_with	FBto0000031	FBrf0261159		TOOL DATA from: FBal0407194
+FBti0248654_cas	tagged_with	FBto0000031	FBrf0261159		TOOL DATA from: FBal0407195
+FBti0248655_cas	tagged_with	FBto0000031	FBrf0261159		TOOL DATA from: FBal0407196
+FBti0248656_cas	tagged_with	FBto0000031	FBrf0261159		TOOL DATA from: FBal0407197
+FBti0248663_cas	tagged_with	FBto0000077	FBrf0261647		TOOL DATA from: FBal0407221
+FBti0248663_cas	tagged_with	FBto0000601	FBrf0261647		TOOL DATA from: FBal0407221
+FBti0248664_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407231
+FBti0248664_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407231
+FBti0248665_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407232
+FBti0248665_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407232
+FBti0248666_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407233
+FBti0248666_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407233
+FBti0248667_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407234
+FBti0248667_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407234
+FBti0248668_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407235
+FBti0248668_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407235
+FBti0248669_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407236
+FBti0248669_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407236
+FBti0248691_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248691_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248692_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248692_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248723_cas	carries_tool	FBto0000318	FBrf0261580		TOOL DATA from: FBal0407315
+FBti0248723_cas	tagged_with	FBto0000027	FBrf0261580		TOOL DATA from: FBal0407315
+FBti0248738_cas	carries_tool	FBto0000349	FBrf0261567		TOOL DATA from: FBal0407321
+FBti0248739_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248739_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248739_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407338
+FBti0248739_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407359
+FBti0248740_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248740_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248740_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407339
+FBti0248740_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407361
+FBti0248741_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248741_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248741_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407340
+FBti0248741_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407373
+FBti0248742_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248742_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248742_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407341
+FBti0248742_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407374
+FBti0248743_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248743_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248743_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407342
+FBti0248743_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407365
+FBti0248744_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248744_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248744_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407343
+FBti0248744_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407367
+FBti0248745_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248745_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248745_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407344
+FBti0248745_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407369
+FBti0248746_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248746_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248746_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407345
+FBti0248746_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407363
+FBti0248747_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0248747_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0248747_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407346
+FBti0248747_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407371
+FBti0248748_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248748_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248748_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407347
+FBti0248748_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407358
+FBti0248749_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248749_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248749_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407348
+FBti0248749_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407372
+FBti0248750_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248750_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248750_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407349
+FBti0248750_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407360
+FBti0248751_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248751_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248751_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407350
+FBti0248751_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407362
+FBti0248752_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248752_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248752_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407351
+FBti0248752_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407364
+FBti0248753_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248753_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248753_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407352
+FBti0248753_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407375
+FBti0248754_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248754_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248754_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407353
+FBti0248754_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407366
+FBti0248755_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248755_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248755_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407354
+FBti0248755_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407368
+FBti0248756_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248756_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248756_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407355
+FBti0248756_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407376
+FBti0248757_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248757_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248757_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407356
+FBti0248757_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407377
+FBti0248758_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0248758_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0248758_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407357
+FBti0248758_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407370
+FBti0248814_cas	carries_tool	FBto0000349	FBrf0244833		TOOL DATA from: FBal0407507
+FBti0248851_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0248851_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0248852_cas	carries_tool	FBto0000318	FBrf0261576		TOOL DATA from: FBal0407558
+FBti0248853_cas	carries_tool	FBto0000318	FBrf0261576		TOOL DATA from: FBal0407559
+FBti0248854_cas	carries_tool	FBto0000318	FBrf0261576		TOOL DATA from: FBal0407560
+FBti0248855_cas	carries_tool	FBto0000318	FBrf0261576		TOOL DATA from: FBal0407561
+FBti0248856_cas	tagged_with	FBto0000076	FBrf0261576		TOOL DATA from: FBal0407562
+FBti0248856_cas	tagged_with	FBto0000077	FBrf0261576		TOOL DATA from: FBal0407562
+FBti0248857_cas	tagged_with	FBto0000076	FBrf0261576		TOOL DATA from: FBal0407563
+FBti0248857_cas	tagged_with	FBto0000077	FBrf0261576		TOOL DATA from: FBal0407563
+FBti0248858_cas	tagged_with	FBto0000063	FBrf0261576		TOOL DATA from: FBal0407564
+FBti0248859_cas	tagged_with	FBto0000076	FBrf0261576		TOOL DATA from: FBal0407565
+FBti0248859_cas	tagged_with	FBto0000077	FBrf0261576		TOOL DATA from: FBal0407565
+FBti0249051_cas	tagged_with	FBto0000126	FBrf0261233		TOOL DATA from: FBal0407734
+FBti0249051_cas	tagged_with	FBto0000522	FBrf0261233		TOOL DATA from: FBal0407734
+FBti0249052_cas	carries_tool	FBto0000318	FBrf0261233		TOOL DATA from: FBal0407735
+FBti0249052_cas	tagged_with	FBto0000126	FBrf0261233		TOOL DATA from: FBal0407735
+FBti0249053_cas	tagged_with	FBto0000126	FBrf0261233		TOOL DATA from: FBal0407736
+FBti0249066_cas	tagged_with	FBto0000077	FBrf0260494		TOOL DATA from: FBal0407745
+FBti0249068_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0249068_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0249068_cas	carries_tool	FBto0000349	FBrf0261632		TOOL DATA from: FBal0407748
+FBti0249069_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407758
+FBti0249070_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407759
+FBti0249071_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407760
+FBti0249072_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407761
+FBti0249073_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407762
+FBti0249074_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407763
+FBti0249075_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407764
+FBti0249076_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407765
+FBti0249077_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407766
+FBti0249078_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407767
+FBti0249079_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407768
+FBti0249080_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407769
+FBti0249081_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407770
+FBti0249082_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407771
+FBti0249083_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407772
+FBti0249084_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407773
+FBti0249085_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407774
+FBti0249086_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407775
+FBti0249087_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407776
+FBti0249088_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407777
+FBti0249089_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407778
+FBti0249090_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407779
+FBti0249091_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407780
+FBti0249092_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407781
+FBti0249093_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407782
+FBti0249094_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407783
+FBti0249095_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407784
+FBti0249096_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407785
+FBti0249097_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407786
+FBti0249098_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407787
+FBti0249099_cas	tagged_with	FBto0000869	FBrf0261627		TOOL DATA from: FBal0407791
+FBti0249100_cas	tagged_with	FBto0000869	FBrf0261627		TOOL DATA from: FBal0407792
+FBti0249101_cas	tagged_with	FBto0000063	FBrf0261627		TOOL DATA from: FBal0407793
+FBti0249102_cas	tagged_with	FBto0000063	FBrf0261627		TOOL DATA from: FBal0407794
+FBti0249103_cas	tagged_with	FBto0000063	FBrf0261627		TOOL DATA from: FBal0407795
+FBti0249104_cas	tagged_with	FBto0000063	FBrf0261627		TOOL DATA from: FBal0407796
+FBti0249106_cas	tagged_with	FBto0000118	FBrf0261523		TOOL DATA from: FBal0407816
+FBti0249128_cas	tagged_with	FBto0000126	FBrf0261873		TOOL DATA from: FBal0407880
+FBti0249129_cas	carries_tool	FBto0000318	FBrf0261873		TOOL DATA from: FBal0407881
+FBti0249129_cas	carries_tool	FBto0000318	FBrf0261873		TOOL DATA from: FBal0407882
+FBti0249129_cas	tagged_with	FBto0000226	FBrf0261873		TOOL DATA from: FBal0407882
+FBti0249137_cas	carries_tool	FBto0000318	FBrf0261442		TOOL DATA from: FBal0407886
+FBti0249137_cas	tagged_with	FBto0000031	FBrf0261442		TOOL DATA from: FBal0407886
+FBti0249137_cas	tagged_with	FBto0000079	FBrf0261442		TOOL DATA from: FBal0407886
+FBti0249137_cas	tagged_with	FBto0000242	FBrf0261442		TOOL DATA from: FBal0407886
+FBti0249138_cas	carries_tool	FBto0000318	FBrf0261442		TOOL DATA from: FBal0407887
+FBti0249138_cas	tagged_with	FBto0000031	FBrf0261442		TOOL DATA from: FBal0407887
+FBti0249138_cas	tagged_with	FBto0000079	FBrf0261442		TOOL DATA from: FBal0407887
+FBti0249138_cas	tagged_with	FBto0000242	FBrf0261442		TOOL DATA from: FBal0407887
+FBti0249139_cas	carries_tool	FBto0000318	FBrf0261442		TOOL DATA from: FBal0407888
+FBti0249139_cas	tagged_with	FBto0000031	FBrf0261442		TOOL DATA from: FBal0407888
+FBti0249139_cas	tagged_with	FBto0000079	FBrf0261442		TOOL DATA from: FBal0407888
+FBti0249139_cas	tagged_with	FBto0000242	FBrf0261442		TOOL DATA from: FBal0407888
+FBti0249140_cas	tagged_with	FBto0000076	FBrf0261766		TOOL DATA from: FBal0407889
+FBti0249140_cas	tagged_with	FBto0000077	FBrf0261766		TOOL DATA from: FBal0407889
+FBti0249141_cas	tagged_with	FBto0000076	FBrf0261766		TOOL DATA from: FBal0407893
+FBti0249142_cas	tagged_with	FBto0000076	FBrf0261766		TOOL DATA from: FBal0407895
+FBti0249142_cas	tagged_with	FBto0000077	FBrf0261766		TOOL DATA from: FBal0407895
+FBti0249143_cas	tagged_with	FBto0000076	FBrf0261766		TOOL DATA from: FBal0407896
+FBti0249143_cas	tagged_with	FBto0000077	FBrf0261766		TOOL DATA from: FBal0407896
+FBti0249144_cas	tagged_with	FBto0000077	FBrf0261950		TOOL DATA from: FBal0407897
+FBti0249148_cas	carries_tool	FBto0000318	FBrf0261824		TOOL DATA from: FBal0407911
+FBti0249149_cas	carries_tool	FBto0000318	FBrf0261824		TOOL DATA from: FBal0407912
+FBti0249149_cas	tagged_with	FBto0000426	FBrf0261824		TOOL DATA from: FBal0407912
+FBti0249150_cas	carries_tool	FBto0000318	FBrf0261824		TOOL DATA from: FBal0407913
+FBti0249150_cas	tagged_with	FBto0000426	FBrf0261824		TOOL DATA from: FBal0407913
+FBti0249151_cas	carries_tool	FBto0000318	FBrf0261824		TOOL DATA from: FBal0407914
+FBti0249152_cas	tagged_with	FBto0000375	FBrf0261824		TOOL DATA from: FBal0407915
+FBti0249156_cas	tagged_with	FBto0000077	FBrf0261717		TOOL DATA from: FBal0407950
+FBti0249169_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407963
+FBti0249169_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407963
+FBti0249170_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407964
+FBti0249170_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407964
+FBti0249171_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407965
+FBti0249171_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407965
+FBti0249172_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407966
+FBti0249172_cas	tagged_with	FBto0000093	FBrf0260932		TOOL DATA from: FBal0407966
+FBti0249173_cas				FTA: unable to add tool information from FBal0407967 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249174_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407968
+FBti0249174_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407968
+FBti0249175_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407969
+FBti0249175_cas	tagged_with	FBto0000027	FBrf0260932		TOOL DATA from: FBal0407969
+FBti0249175_cas	tagged_with	FBto0000076	FBrf0260932		TOOL DATA from: FBal0407969
+FBti0249175_cas	tagged_with	FBto0000092	FBrf0260932		TOOL DATA from: FBal0407969
+FBti0249176_cas				FTA: unable to add tool information from FBal0407970 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249177_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407971
+FBti0249177_cas	tagged_with	FBto0000027	FBrf0260932		TOOL DATA from: FBal0407971
+FBti0249177_cas	tagged_with	FBto0000076	FBrf0260932		TOOL DATA from: FBal0407971
+FBti0249177_cas	tagged_with	FBto0000092	FBrf0260932		TOOL DATA from: FBal0407971
+FBti0249178_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407972
+FBti0249178_cas	tagged_with	FBto0000093	FBrf0260932		TOOL DATA from: FBal0407972
+FBti0249179_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407973
+FBti0249179_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407973
+FBti0249179_cas	tagged_with	FBto0001030	FBrf0260932		TOOL DATA from: FBal0407973
+FBti0249180_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407974
+FBti0249180_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407974
+FBti0249181_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407975
+FBti0249181_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407975
+FBti0249182_cas				FTA: unable to add tool information from FBal0407976 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249183_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407977
+FBti0249183_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407977
+FBti0249184_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407978
+FBti0249184_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407978
+FBti0249185_cas				FTA: unable to add tool information from FBal0407979 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249186_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407980
+FBti0249186_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407980
+FBti0249187_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407981
+FBti0249187_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407981
+FBti0249188_cas				FTA: unable to add tool information from FBal0407982 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249189_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407983
+FBti0249189_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407983
+FBti0249190_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407984
+FBti0249190_cas	tagged_with	FBto0000009	FBrf0260932		TOOL DATA from: FBal0407984
+FBti0249191_cas				FTA: unable to add tool information from FBal0407985 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249192_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407986
+FBti0249192_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407986
+FBti0249193_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407987
+FBti0249193_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407987
+FBti0249194_cas				FTA: unable to add tool information from FBal0407988 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249195_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407989
+FBti0249195_cas	tagged_with	FBto0000027	FBrf0260932		TOOL DATA from: FBal0407989
+FBti0249195_cas	tagged_with	FBto0000076	FBrf0260932		TOOL DATA from: FBal0407989
+FBti0249195_cas	tagged_with	FBto0000092	FBrf0260932		TOOL DATA from: FBal0407989
+FBti0249196_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407990
+FBti0249196_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407990
+FBti0249197_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407991
+FBti0249197_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407991
+FBti0249198_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407992
+FBti0249199_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407993
+FBti0249200_cas				FTA: unable to add tool information from FBal0407994 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249201_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407995
+FBti0249201_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407995
+FBti0249202_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407996
+FBti0249202_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407996
+FBti0249203_cas				FTA: unable to add tool information from FBal0407997 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249204_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407998
+FBti0249204_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407998
+FBti0249205_cas				FTA: unable to add tool information from FBal0407999 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249206_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0408000
+FBti0249206_cas	tagged_with	FBto0000027	FBrf0260932		TOOL DATA from: FBal0408000
+FBti0249206_cas	tagged_with	FBto0000076	FBrf0260932		TOOL DATA from: FBal0408000
+FBti0249206_cas	tagged_with	FBto0000092	FBrf0260932		TOOL DATA from: FBal0408000
+FBti0249207_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0408001
+FBti0249207_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0408001
+FBti0249208_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0408002
+FBti0249208_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0408002
+FBti0249209_cas	carries_tool	FBto0000349	FBrf0242827		TOOL DATA from: FBal0407962
+FBti0249209_cas	tagged_with	FBto0000077	FBrf0232782|FBrf0242827		TOOL DATA from: FBal0407962
+FBti0249213_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408008
+FBti0249214_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408009
+FBti0249215_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408013
+FBti0249217_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408012
+FBti0249218_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408014
+FBti0249252_cas	tagged_with	FBto0000063	FBrf0261967		TOOL DATA from: FBal0408076
+FBti0249281_cas	tagged_with	FBto0000048	FBrf0261549		TOOL DATA from: FBal0408145
+FBti0249281_cas	tagged_with	FBto0000076	FBrf0261549		TOOL DATA from: FBal0408145
+FBti0249281_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408145
+FBti0249282_cas	tagged_with	FBto0000048	FBrf0261549		TOOL DATA from: FBal0408146
+FBti0249282_cas	tagged_with	FBto0000076	FBrf0261549		TOOL DATA from: FBal0408146
+FBti0249282_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408146
+FBti0249283_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408147
+FBti0249284_cas	tagged_with	FBto0000048	FBrf0261549		TOOL DATA from: FBal0408148
+FBti0249284_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408148
+FBti0249285_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408149
+FBti0249285_cas	tagged_with	FBto0000208	FBrf0261549		TOOL DATA from: FBal0408149
+FBti0249317_cas	tagged_with	FBto0000118	FBrf0262127		TOOL DATA from: FBal0408222
+FBti0249318_cas				FTA: unable to add tool information from FBal0408238 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249319_cas				FTA: unable to add tool information from FBal0408261 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249321_cas				FTA: unable to add tool information from FBal0408274 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249334_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0249334_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0249334_cas	tagged_with	FBto0000081	FBrf0261898		TOOL DATA from: FBal0408294
+FBti0249334_cas	tagged_with	FBto0000899	FBrf0261898		TOOL DATA from: FBal0408294
+FBti0249361_cas	tagged_with	FBto0000076	FBrf0262050		TOOL DATA from: FBal0408339
+FBti0249361_cas	tagged_with	FBto0000077	FBrf0262050		TOOL DATA from: FBal0408339
+FBti0249362_cas	carries_tool	FBto0000349	FBrf0262100		TOOL DATA from: FBal0408341
+FBti0249363_cas	tagged_with	FBto0000077	FBrf0262100		TOOL DATA from: FBal0408343
+FBti0249364_cas	tagged_with	FBto0000077	FBrf0262100		TOOL DATA from: FBal0408344
+FBti0419130_cas	tagged_with	FBto0000077	FBrf0261730		TOOL DATA from: FBal0408455
+FBti0419131_cas	tagged_with	FBto0000118	FBrf0261730		TOOL DATA from: FBal0408456
+FBti0419132_cas	tagged_with	FBto0000077	FBrf0261730		TOOL DATA from: FBal0408457
+FBti0419133_cas	tagged_with	FBto0000077	FBrf0261730		TOOL DATA from: FBal0408458
+FBti0419134_cas	tagged_with	FBto0000077	FBrf0261730		TOOL DATA from: FBal0408459
+FBti0419135_cas	tagged_with	FBto0000027	FBrf0261730		TOOL DATA from: FBal0408460
+FBti0419198_cas	tagged_with	FBto0000063	FBrf0262484		TOOL DATA from: FBal0408573
+FBti0419210_cas	carries_tool	FBto0000349	FBrf0262293		TOOL DATA from: FBal0408582
+FBti0419210_cas	carries_tool	FBto0000356	FBrf0262293		TOOL DATA from: FBal0408582
+FBti0419211_cas	tagged_with	FBto0000027	FBrf0262293		TOOL DATA from: FBal0408584
+FBti0419214_cas	tagged_with	FBto0000031	FBrf0262159		TOOL DATA from: FBal0408586
+FBti0419215_cas	tagged_with	FBto0000076	FBrf0262159		TOOL DATA from: FBal0408587
+FBti0419216_cas	tagged_with	FBto0000623	FBrf0262485		TOOL DATA from: FBal0408588
+FBti0419386_cas	tagged_with	FBto0000093	FBrf0262206		TOOL DATA from: FBal0408648
+FBti0419386_cas	tagged_with	FBto0000118	FBrf0262206		TOOL DATA from: FBal0408648
+FBti0419402_cas	tagged_with	FBto0000099	FBrf0262110		TOOL DATA from: FBal0408712
+FBti0419404_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0419404_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0419558_cas	tagged_with	FBto0000076	FBrf0262201		TOOL DATA from: FBal0408788
+FBti0419564_cas	carries_tool	FBto0000356			TOOL DATA from: FBtp0129389
+FBti0419564_cas	tool_uses	docking element			TOOL DATA from: FBtp0129389
+FBti0419570_cas	tagged_with	FBto0000027	FBrf0262242		TOOL DATA from: FBal0408817
+FBti0419699_cas	carries_tool	FBto0000349	FBrf0262205		TOOL DATA from: FBal0408874
+FBti0419701_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408887
+FBti0419705_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408894
+FBti0419708_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408899
+FBti0419712_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408906
+FBti0419715_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408909
+FBti0419761_cas	tagged_with	FBto0000789	FBrf0260923		TOOL DATA from: FBal0409000
+FBti0419762_cas	tagged_with	FBto0000118	FBrf0260923		TOOL DATA from: FBal0409001
+FBti0419762_cas	tagged_with	FBto0000789	FBrf0260923		TOOL DATA from: FBal0409001
+FBti0419763_cas	tagged_with	FBto0000389	FBrf0260923		TOOL DATA from: FBal0409004
+FBti0419764_cas	tagged_with	FBto0000389	FBrf0260923		TOOL DATA from: FBal0409005
+FBti0419776_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0419776_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0419776_cas	carries_tool	FBto0000349	FBrf0262294		TOOL DATA from: FBal0409020
+FBti0419777_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0419777_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0419777_cas	carries_tool	FBto0000349	FBrf0262294		TOOL DATA from: FBal0409021
+FBti0419778_cas	encodes_tool	FBto0000140			TOOL DATA from: FBtp0128008
+FBti0419778_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128008
+FBti0419778_cas	carries_tool	FBto0000349	FBrf0262294		TOOL DATA from: FBal0409022
+FBti0419779_cas	encodes_tool	FBto0000140			TOOL DATA from: FBtp0128008
+FBti0419779_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128008
+FBti0419779_cas	carries_tool	FBto0000349	FBrf0262294		TOOL DATA from: FBal0409023
+FBti0419790_cas	tagged_with	FBto0000027	FBrf0260765		TOOL DATA from: FBal0409046
+FBti0419791_cas	tagged_with	FBto0000027	FBrf0260765		TOOL DATA from: FBal0409047
+FBti0419792_cas	tagged_with	FBto0000027	FBrf0260765		TOOL DATA from: FBal0409048
+FBti0419793_cas	tagged_with	FBto0000027	FBrf0260765		TOOL DATA from: FBal0409049
+FBti0419794_cas	carries_tool	FBto0000356	FBrf0260765		TOOL DATA from: FBal0409050
+FBti0419795_cas	tagged_with	FBto0000077	FBrf0260765		TOOL DATA from: FBal0409051
+FBti0419796_cas	tagged_with	FBto0000077	FBrf0260765		TOOL DATA from: FBal0409052
+FBti0419797_cas	tagged_with	FBto0000077	FBrf0260765		TOOL DATA from: FBal0409053
+FBti0419798_cas	tagged_with	FBto0000077	FBrf0260765		TOOL DATA from: FBal0409054
+FBti0419808_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0116623
+FBti0419808_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0116623
+FBti0419809_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0141341
+FBti0419809_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141341
+FBti0419817_cas	tagged_with	FBto0000077	FBrf0262360		TOOL DATA from: FBal0409072
+FBti0419817_cas	tagged_with	FBto0000081	FBrf0262360		TOOL DATA from: FBal0409072
+FBti0419817_cas	tagged_with	FBto0000239	FBrf0262360		TOOL DATA from: FBal0409072
+FBti0419817_cas	tagged_with	FBto0000341	FBrf0262360		TOOL DATA from: FBal0409072
+FBti0419818_cas	tagged_with	FBto0000077	FBrf0262360		TOOL DATA from: FBal0409073
+FBti0419818_cas	tagged_with	FBto0000888	FBrf0262360		TOOL DATA from: FBal0409073
+FBti0419819_cas	tagged_with	FBto0000126	FBrf0262360		TOOL DATA from: FBal0409074
+FBti0419820_cas	tagged_with	FBto0000077	FBrf0262360		TOOL DATA from: FBal0409077
+FBti0419917_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409087
+FBti0419917_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409087
+FBti0419918_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409088
+FBti0419918_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409088
+FBti0419919_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409089
+FBti0419919_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409089
+FBti0419920_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409090
+FBti0419920_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409090
+FBti0419921_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409091
+FBti0419921_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409091
+FBti0419922_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409092
+FBti0419922_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409092
+FBti0419923_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409093
+FBti0419923_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409093
+FBti0420009_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409210
+FBti0420009_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409210
+FBti0420010_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409212
+FBti0420010_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409212
+FBti0420011_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409213
+FBti0420011_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409213
+FBti0420012_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409214
+FBti0420012_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409214
+FBti0420013_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409215
+FBti0420013_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409215
+FBti0420014_cas	tagged_with	FBto0000093	FBrf0262689		TOOL DATA from: FBal0409218
+FBti0420014_cas	tagged_with	FBto0000589	FBrf0262689		TOOL DATA from: FBal0409218
+FBti0420015_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0420015_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0420015_cas	carries_tool	FBto0000345	FBrf0262689		TOOL DATA from: FBal0409216
+FBti0420015_cas	carries_tool	FBto0000349	FBrf0262689		TOOL DATA from: FBal0409216
+FBti0420015_cas	carries_tool	FBto0000356	FBrf0262689		TOOL DATA from: FBal0409216
+FBti0420015_cas	carries_tool	FBto0000345	FBrf0262689		TOOL DATA from: FBal0409217
+FBti0420015_cas	carries_tool	FBto0000349	FBrf0262689		TOOL DATA from: FBal0409217
+FBti0420015_cas	carries_tool	FBto0000356	FBrf0262689		TOOL DATA from: FBal0409217
+FBti0420020_cas	tagged_with	FBto0000076	FBrf0262750		TOOL DATA from: FBal0409223
+FBti0420022_cas				FTA: unable to add tool information from FBal0409225 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0420022_cas				FTA: unable to add tool information from FBal0409227 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0420058_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420058_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420059_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420059_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420060_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420060_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420061_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420061_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420062_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420062_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420063_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420063_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420064_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420064_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420065_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420065_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420066_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420066_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420067_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420067_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420068_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420068_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420069_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420069_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420070_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420070_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420071_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420071_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420072_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420072_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420073_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420073_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420074_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420074_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420075_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420075_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420076_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420076_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420076_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409269
+FBti0420076_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409299
+FBti0420077_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420077_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420078_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420078_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420078_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409271
+FBti0420078_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409301
+FBti0420079_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420079_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420080_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420080_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420080_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409273
+FBti0420080_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409303
+FBti0420081_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420081_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420082_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420082_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420082_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409275
+FBti0420082_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409305
+FBti0420083_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420083_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420084_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420084_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420084_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409277
+FBti0420084_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409297
+FBti0420085_cas	encodes_tool	FBto0000168			TOOL DATA from: FBtp0147466
+FBti0420085_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0147466
+FBti0420090_cas	tagged_with	FBto0000031	FBrf0262719		TOOL DATA from: FBal0409320
+FBti0420091_cas	tagged_with	FBto0000582	FBrf0262719		TOOL DATA from: FBal0409321
+FBti0420093_cas	carries_tool	FBto0000356	FBrf0262719		TOOL DATA from: FBal0409323
+FBti0420122_cas	tagged_with	FBto0000389	FBrf0262715		TOOL DATA from: FBal0409342
+FBti0420123_cas	tagged_with	FBto0000389	FBrf0262715		TOOL DATA from: FBal0409343
+FBti0420124_cas	encodes_tool	FBto0000310			TOOL DATA from: FBtp0173663
+FBti0420124_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0173663
+FBti0420138_cas	carries_tool	FBto0000326	FBrf0262580		TOOL DATA from: FBal0409361
+FBti0420139_cas	carries_tool	FBto0000326	FBrf0262580		TOOL DATA from: FBal0409362
+FBti0420139_cas	tagged_with	FBto0000093	FBrf0262580		TOOL DATA from: FBal0409362
+FBti0420140_cas	carries_tool	FBto0000326	FBrf0262580		TOOL DATA from: FBal0409363
+FBti0420141_cas	carries_tool	FBto0000326	FBrf0262580		TOOL DATA from: FBal0409364
+FBti0420141_cas	tagged_with	FBto0000079	FBrf0262580		TOOL DATA from: FBal0409364
+FBti0420144_cas	tagged_with	FBto0000601	FBrf0262601		TOOL DATA from: FBal0409370
+FBti0420145_cas	tagged_with	FBto0000121	FBrf0262601		TOOL DATA from: FBal0409371
+FBti0420146_cas	tagged_with	FBto0000077	FBrf0262601		TOOL DATA from: FBal0409372
+FBti0420206_cas	carries_tool	FBto0000318	FBrf0262907		TOOL DATA from: FBal0409401
+FBti0420206_cas	tagged_with	FBto0000077	FBrf0262907		TOOL DATA from: FBal0409401
+FBti0420210_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0420210_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0420211_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0420211_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0420325_cas	tagged_with	FBto0000076	FBrf0262872		TOOL DATA from: FBal0409512
+FBti0420326_cas	tagged_with	FBto0000076	FBrf0262872		TOOL DATA from: FBal0409513
+FBti0420327_cas	tagged_with	FBto0000076	FBrf0262872		TOOL DATA from: FBal0409514
+FBti0420328_cas	tagged_with	FBto0000076	FBrf0262872		TOOL DATA from: FBal0409515
+FBti0420370_cas	tagged_with	FBto0000030	FBrf0262579		TOOL DATA from: FBal0409557
+FBti0420370_cas	tagged_with	FBto0000077	FBrf0262579		TOOL DATA from: FBal0409557
+FBti0420373_cas	tagged_with	FBto0000093	FBrf0226720		TOOL DATA from: FBal0409562
+FBti0420374_cas	tagged_with	FBto0000093	FBrf0226720		TOOL DATA from: FBal0409563
+FBti0420375_cas	tagged_with	FBto0000093	FBrf0226720		TOOL DATA from: FBal0409564
+FBti0420377_cas	carries_tool	FBto0000323	FBrf0262698		TOOL DATA from: FBal0409566
+FBti0420377_cas	tagged_with	FBto0000093	FBrf0262698		TOOL DATA from: FBal0409566
+FBti0420378_cas	tagged_with	FBto0001048	FBrf0262395		TOOL DATA from: FBal0409567
+FBti0420446_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409656
+FBti0420446_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409656
+FBti0420446_cas	encodes_tool	FBto0000536	FBrf0263013		TOOL DATA from: FBal0409661
+FBti0420446_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409661
+FBti0420446_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409661
+FBti0420447_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409657
+FBti0420447_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409657
+FBti0420447_cas	encodes_tool	FBto0000536	FBrf0263013		TOOL DATA from: FBal0409662
+FBti0420447_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409662
+FBti0420447_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409662
+FBti0420448_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409658
+FBti0420448_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409658
+FBti0420448_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409667
+FBti0420448_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409667
+FBti0420449_cas	encodes_tool	FBto0000536	FBrf0263013		TOOL DATA from: FBal0409664
+FBti0420449_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409664
+FBti0420450_cas	tagged_with	FBto0000063	FBrf0263013		TOOL DATA from: FBal0409660
+FBti0420451_cas	encodes_tool	FBto0000536	FBrf0263013		TOOL DATA from: FBal0409663
+FBti0420451_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409663
+FBti0420451_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409663
+FBti0420451_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409665
+FBti0420451_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409665
+FBti0420452_cas	encodes_tool	FBto0000638	FBrf0263013		TOOL DATA from: FBal0409666
+FBti0420452_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409666
+FBti0420452_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409666
+FBti0420452_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409668
+FBti0420452_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409668
+FBti0420504_cas	tagged_with	FBto0000077	FBrf0263106		TOOL DATA from: FBal0409680
+FBti0420505_cas	carries_tool	FBto0000349	FBrf0262155		TOOL DATA from: FBal0402065
+FBti0420505_cas	tagged_with	FBto0000076	FBrf0262155		TOOL DATA from: FBal0402065
+FBti0420506_cas	carries_tool	FBto0000349	FBrf0262155		TOOL DATA from: FBal0409707
+FBti0420509_cas	tagged_with	FBto0000076	FBrf0262421		TOOL DATA from: FBal0409711
+FBti0420509_cas	tagged_with	FBto0000093	FBrf0262421		TOOL DATA from: FBal0409711
+FBti0420509_cas	tagged_with	FBto0000118	FBrf0262421		TOOL DATA from: FBal0409711
+FBti0420522_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420522_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420522_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409724
+FBti0420522_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409724
+FBti0420522_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409770
+FBti0420522_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409770
+FBti0420523_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420523_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420523_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409725
+FBti0420523_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409725
+FBti0420523_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409773
+FBti0420523_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409773
+FBti0420524_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420524_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420524_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409726
+FBti0420524_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409726
+FBti0420524_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409776
+FBti0420524_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409776
+FBti0420525_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420525_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420525_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409727
+FBti0420525_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409727
+FBti0420525_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409778
+FBti0420525_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409778
+FBti0420526_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420526_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420527_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420527_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420528_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420528_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420529_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420529_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420530_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420530_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420531_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420531_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420532_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420532_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420533_cas	encodes_tool	FBto0000146			TOOL DATA from: FBtp0135338
+FBti0420533_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0135338
+FBti0420533_cas	carries_tool	FBto0000349	FBrf0262569		TOOL DATA from: FBal0409735
+FBti0420533_cas	carries_tool	FBto0000349	FBrf0262569		TOOL DATA from: FBal0409752
+FBti0420543_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0420543_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0420544_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0420544_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0420544_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409746
+FBti0420544_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409746
+FBti0420544_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409771
+FBti0420544_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409771
+FBti0420545_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0420545_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0420545_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409747
+FBti0420545_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409747
+FBti0420545_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409774
+FBti0420545_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409774
+FBti0420546_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0420546_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0420546_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409748
+FBti0420546_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409748
+FBti0420546_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409777
+FBti0420546_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409777
+FBti0420547_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0420547_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0420547_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409749
+FBti0420547_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409749
+FBti0420547_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409779
+FBti0420547_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409779
+FBti0420548_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0420548_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0420548_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409750
+FBti0420548_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409750
+FBti0420548_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409781
+FBti0420548_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409781
+FBti0420549_cas	encodes_tool	FBto0000166			TOOL DATA from: FBtp0140112
+FBti0420549_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0140112
+FBti0420549_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409751
+FBti0420549_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409751
+FBti0420549_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409783
+FBti0420549_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409783
+FBti0420550_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0420550_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0420550_cas	carries_tool	FBto0000349	FBrf0262569		TOOL DATA from: FBal0409753
+FBti0420550_cas	carries_tool	FBto0000349	FBrf0262569		TOOL DATA from: FBal0409768
+FBti0420558_cas	tagged_with	FBto0000601	FBrf0262977		TOOL DATA from: FBal0409807
+FBti0420579_cas	tagged_with	FBto0000076	FBrf0262726		TOOL DATA from: FBal0409834
+FBti0420580_cas	tagged_with	FBto0000076	FBrf0262726		TOOL DATA from: FBal0409835
+FBti0420582_cas	tagged_with	FBto0000809	FBrf0262699		TOOL DATA from: FBal0409837
+FBti0420605_cas	tagged_with	FBto0000638	FBrf0262915		TOOL DATA from: FBal0409880
+FBti0420606_cas	tagged_with	FBto0000638	FBrf0262915		TOOL DATA from: FBal0409881
+FBti0420607_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409882
+FBti0420607_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409882
+FBti0420607_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409882
+FBti0420608_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409885
+FBti0420608_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409885
+FBti0420608_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409885
+FBti0420609_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409889
+FBti0420609_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409889
+FBti0420609_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409889
+FBti0420610_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409895
+FBti0420610_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409895
+FBti0420610_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409895
+FBti0420611_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409900
+FBti0420611_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409900
+FBti0420611_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409900
+FBti0420612_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409903
+FBti0420612_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409903
+FBti0420612_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409903
+FBti0420613_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409904
+FBti0420613_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409904
+FBti0420613_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409904
+FBti0420614_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409905
+FBti0420614_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409905
+FBti0420614_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409905
+FBti0420713_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0420713_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0420713_cas	carries_tool	FBto0000318	FBrf0263184		TOOL DATA from: FBal0409924
+FBti0420713_cas	tagged_with	FBto0000079	FBrf0263184		TOOL DATA from: FBal0409924
+FBti0420713_cas	tagged_with	FBto0000242	FBrf0263184		TOOL DATA from: FBal0409924
+FBti0420714_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0420714_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0420714_cas	carries_tool	FBto0000318	FBrf0263184		TOOL DATA from: FBal0409925
+FBti0420714_cas	tagged_with	FBto0000079	FBrf0263184		TOOL DATA from: FBal0409925
+FBti0420714_cas	tagged_with	FBto0000242	FBrf0263184		TOOL DATA from: FBal0409925
+FBti0420715_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0420715_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0420715_cas	tagged_with	FBto0000079	FBrf0263184		TOOL DATA from: FBal0409926
+FBti0420715_cas	tagged_with	FBto0000242	FBrf0263184		TOOL DATA from: FBal0409926
+FBti0420717_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0420717_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0420717_cas	carries_tool	FBto0000318	FBrf0263184		TOOL DATA from: FBal0409928
+FBti0420719_cas	encodes_tool	FBto0000031			TOOL DATA from: FBtp0099205
+FBti0420719_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099205
+FBti0420726_cas	tagged_with	FBto0000099	FBrf0263151		TOOL DATA from: FBal0409960
+FBti0420726_cas	tagged_with	FBto0000643	FBrf0263151		TOOL DATA from: FBal0409960
+FBti0420727_cas	tagged_with	FBto0000643	FBrf0263151		TOOL DATA from: FBal0409961
+FBti0420728_cas	tagged_with	FBto0000099	FBrf0263151		TOOL DATA from: FBal0409962
+FBti0420728_cas	tagged_with	FBto0000643	FBrf0263151		TOOL DATA from: FBal0409962
+FBti0420729_cas	tagged_with	FBto0000643	FBrf0263151		TOOL DATA from: FBal0409963
+FBti0420740_cas	tagged_with	FBto0000027	FBrf0263020		TOOL DATA from: FBal0409974
+FBti0420873_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0410046
+FBti0420873_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0410046
+FBti0420873_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0410046
+FBti0420874_cas	tagged_with	FBto0000031	FBrf0262106		TOOL DATA from: FBal0410051
+FBti0420877_cas	carries_tool	FBto0000349	FBrf0263175		TOOL DATA from: FBal0410060
+FBti0420878_cas	carries_tool	FBto0000349	FBrf0263175		TOOL DATA from: FBal0410066
+FBti0420884_cas	tagged_with	FBto0000027	FBrf0263149		TOOL DATA from: FBal0410067
+FBti0420885_cas	tagged_with	FBto0000638	FBrf0263149		TOOL DATA from: FBal0410068
+FBti0420886_cas	tagged_with	FBto0000118	FBrf0263149		TOOL DATA from: FBal0410069
+FBti0420887_cas	tagged_with	FBto0000077	FBrf0263114		TOOL DATA from: FBal0410070
+FBti0420932_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0420932_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0420933_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0141597
+FBti0420933_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0141597
+FBti0420936_cas	tagged_with	FBto0000076	FBrf0263276		TOOL DATA from: FBal0410145
+FBti0420936_cas	tagged_with	FBto0000077	FBrf0263276		TOOL DATA from: FBal0410145
+FBti0420937_cas	tagged_with	FBto0000076	FBrf0263276		TOOL DATA from: FBal0410146
+FBti0420937_cas	tagged_with	FBto0000077	FBrf0263276		TOOL DATA from: FBal0410146
+FBti0420980_cas	carries_tool	FBto0000349	FBrf0263431		TOOL DATA from: FBal0410149
+FBti0420980_cas	carries_tool	FBto0000356	FBrf0263431		TOOL DATA from: FBal0410149
+FBti0420981_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0420981_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0420982_cas	tagged_with	FBto0000077	FBrf0263319		TOOL DATA from: FBal0410153
+FBti0420983_cas	tagged_with	FBto0000077	FBrf0263319		TOOL DATA from: FBal0410154
+FBti0420984_cas	tagged_with	FBto0000092	FBrf0263319		TOOL DATA from: FBal0410156
+FBti0421002_cas	tagged_with	FBto0000044	FBrf0263200		TOOL DATA from: FBal0410174
+FBti0421003_cas	tagged_with	FBto0000044	FBrf0263200		TOOL DATA from: FBal0410175
+FBti0421004_cas	tagged_with	FBto0000044	FBrf0263621		TOOL DATA from: FBal0410176
+FBti0421004_cas	tagged_with	FBto0000076	FBrf0263621		TOOL DATA from: FBal0410176
+FBti0421005_cas	tagged_with	FBto0000389	FBrf0263621		TOOL DATA from: FBal0410177
+FBti0421006_cas	carries_tool	FBto0000349	FBrf0263217		TOOL DATA from: FBal0410178
+FBti0421006_cas	tagged_with	FBto0000102	FBrf0263217		TOOL DATA from: FBal0410178
+FBti0421077_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128005
+FBti0421077_cas	tool_uses	gene trap			TOOL DATA from: FBtp0128005
+FBti0421085_cas	carries_tool	FBto0000349	FBrf0263252		TOOL DATA from: FBal0410266
+FBti0421085_cas	carries_tool	FBto0000356	FBrf0263252		TOOL DATA from: FBal0410266
+FBti0421086_cas	tagged_with	FBto0000027	FBrf0263252		TOOL DATA from: FBal0410267
+FBti0421087_cas	tagged_with	FBto0000076	FBrf0263252		TOOL DATA from: FBal0410284
+FBti0421092_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0421092_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0421142_cas	carries_tool	FBto0000349	FBrf0263225		TOOL DATA from: FBal0410328
+FBti0421142_cas	tagged_with	FBto0000076	FBrf0263225		TOOL DATA from: FBal0410328
+FBti0421142_cas	tagged_with	FBto0000077	FBrf0263225		TOOL DATA from: FBal0410328
+FBti0421143_cas	carries_tool	FBto0000349	FBrf0263225		TOOL DATA from: FBal0410329
+FBti0421144_cas	carries_tool	FBto0000349	FBrf0263225		TOOL DATA from: FBal0410330
+FBti0421145_cas	carries_tool	FBto0000349	FBrf0263225		TOOL DATA from: FBal0410331
+FBti0421145_cas	tagged_with	FBto0000076	FBrf0263225		TOOL DATA from: FBal0410331
+FBti0421145_cas	tagged_with	FBto0000077	FBrf0263225		TOOL DATA from: FBal0410331
+FBti0421157_cas	tagged_with	FBto0000077	FBrf0263525		TOOL DATA from: FBal0410382
+FBti0421210_cas	tagged_with	FBto0000027	FBrf0263477		TOOL DATA from: FBal0410393
+FBti0421211_cas	tagged_with	FBto0000076	FBrf0262257		TOOL DATA from: FBal0410396
+FBti0421242_cas	encodes_tool	FBto0000184			TOOL DATA from: FBtp0165198
+FBti0421242_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0165198
+FBti0421245_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421245_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421246_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421246_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421247_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421247_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421248_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421248_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421249_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421249_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421250_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421250_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421251_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421251_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421252_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421252_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421253_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421253_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421254_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421254_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421255_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421255_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421256_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421256_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421257_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421257_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421258_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421258_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421259_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421259_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421260_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421260_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421261_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421261_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421262_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421262_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421263_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421263_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421264_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421264_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421265_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410502
+FBti0421266_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410503
+FBti0421267_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410504
+FBti0421268_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410505
+FBti0421269_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410506
+FBti0421270_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410507
+FBti0421271_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410508
+FBti0421272_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410509
+FBti0421273_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410510
+FBti0421274_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410511
+FBti0421275_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410512
+FBti0421276_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410513
+FBti0421277_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410514
+FBti0421278_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410515
+FBti0421279_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410516
+FBti0421280_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410517
+FBti0421281_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410518
+FBti0421282_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410519
+FBti0421283_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410520
+FBti0421284_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410521
+FBti0421285_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410522
+FBti0421285_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410522
+FBti0421286_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410523
+FBti0421286_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410523
+FBti0421287_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410524
+FBti0421287_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410524
+FBti0421288_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410525
+FBti0421288_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410525
+FBti0421289_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410526
+FBti0421289_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410526
+FBti0421290_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410527
+FBti0421290_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410527
+FBti0421291_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410528
+FBti0421291_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410528
+FBti0421337_cas	tagged_with	FBto0000093	FBrf0263937		TOOL DATA from: FBal0410566
+FBti0421338_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0128006
+FBti0421338_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128006
+FBti0421339_cas	encodes_tool	FBto0000158			TOOL DATA from: FBtp0099210
+FBti0421339_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099210
+FBti0421375_cas	tagged_with	FBto0000126	FBrf0264045		TOOL DATA from: FBal0410596
+FBti0421433_cas	tagged_with	FBto0000027	FBrf0263903		TOOL DATA from: FBal0410623
+FBti0421439_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421439_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421440_cas	carries_tool	FBto0000318	FBrf0263805		TOOL DATA from: FBal0410635
+FBti0421483_cas	tagged_with	FBto0000063	FBrf0264007		TOOL DATA from: FBal0410662
+FBti0421506_cas	carries_tool	FBto0000349	FBrf0263983		TOOL DATA from: FBal0410693
+FBti0421506_cas	tagged_with	FBto0000126	FBrf0263983		TOOL DATA from: FBal0410693
+FBti0421507_cas	carries_tool	FBto0000349	FBrf0263983		TOOL DATA from: FBal0410695
+FBti0421507_cas	tagged_with	FBto0000126	FBrf0263983		TOOL DATA from: FBal0410695
+FBti0421508_cas	tagged_with	FBto0000070	FBrf0263976		TOOL DATA from: FBal0410705
+FBti0421509_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410709
+FBti0421509_cas	tagged_with	FBto0000929	FBrf0263639		TOOL DATA from: FBal0410709
+FBti0421510_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410710
+FBti0421510_cas	tagged_with	FBto0000055	FBrf0263639		TOOL DATA from: FBal0410710
+FBti0421511_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410711
+FBti0421511_cas	tagged_with	FBto0000004	FBrf0263639		TOOL DATA from: FBal0410711
+FBti0421512_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410712
+FBti0421512_cas	tagged_with	FBto0000118	FBrf0263639		TOOL DATA from: FBal0410712
+FBti0421513_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410713
+FBti0421513_cas	tagged_with	FBto0000118	FBrf0263639		TOOL DATA from: FBal0410713
+FBti0421514_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410714
+FBti0421514_cas	tagged_with	FBto0000929	FBrf0263639		TOOL DATA from: FBal0410714
+FBti0421515_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410715
+FBti0421515_cas	tagged_with	FBto0000929	FBrf0263639		TOOL DATA from: FBal0410715
+FBti0421516_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410716
+FBti0421516_cas	tagged_with	FBto0000929	FBrf0263639		TOOL DATA from: FBal0410716
+FBti0421538_cas	carries_tool	FBto0000349	FBrf0264230		TOOL DATA from: FBal0410747
+FBti0421538_cas	tagged_with	FBto0000027	FBrf0264230		TOOL DATA from: FBal0410747
+FBti0421539_cas	tagged_with	FBto0000070	FBrf0263931		TOOL DATA from: FBal0410758
+FBti0421639_cas	carries_tool	FBto0000349	FBrf0264199		TOOL DATA from: FBal0410821
+FBti0421639_cas	tagged_with	FBto0000077	FBrf0264199		TOOL DATA from: FBal0410821
+FBti0421640_cas	tagged_with	FBto0000076	FBrf0264199		TOOL DATA from: FBal0410822
+FBti0421641_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410823
+FBti0421641_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410823
+FBti0421641_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410823
+FBti0421641_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410823
+FBti0421642_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410824
+FBti0421642_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410824
+FBti0421642_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410824
+FBti0421642_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410824
+FBti0421643_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410826
+FBti0421643_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410826
+FBti0421643_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410826
+FBti0421643_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410826
+FBti0421644_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410829
+FBti0421644_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410829
+FBti0421644_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410829
+FBti0421644_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410829
+FBti0421645_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410830
+FBti0421645_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410830
+FBti0421645_cas	tagged_with	FBto0000076	FBrf0264384		TOOL DATA from: FBal0410830
+FBti0421645_cas	tagged_with	FBto0000093	FBrf0264384		TOOL DATA from: FBal0410830
+FBti0421646_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410832
+FBti0421646_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410832
+FBti0421646_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410832
+FBti0421646_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410832
+FBti0421647_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410836
+FBti0421647_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410836
+FBti0421647_cas	tagged_with	FBto0000076	FBrf0264384		TOOL DATA from: FBal0410836
+FBti0421647_cas	tagged_with	FBto0000093	FBrf0264384		TOOL DATA from: FBal0410836
+FBti0421648_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410837
+FBti0421648_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410837
+FBti0421648_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410837
+FBti0421648_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410837
+FBti0421649_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410838
+FBti0421649_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410838
+FBti0421649_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410838
+FBti0421649_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410838
+FBti0421650_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410839
+FBti0421650_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410839
+FBti0421650_cas	tagged_with	FBto0000076	FBrf0264384		TOOL DATA from: FBal0410839
+FBti0421650_cas	tagged_with	FBto0000093	FBrf0264384		TOOL DATA from: FBal0410839
+FBti0421656_cas	carries_tool	FBto0000318	FBrf0264585		TOOL DATA from: FBal0410848
+FBti0421656_cas	carries_tool	FBto0000349	FBrf0264585		TOOL DATA from: FBal0410848
+FBti0421656_cas	tagged_with	FBto0000076	FBrf0264585		TOOL DATA from: FBal0410848
+FBti0421656_cas	tagged_with	FBto0000093	FBrf0264585		TOOL DATA from: FBal0410848
+FBti0421657_cas	carries_tool	FBto0000318	FBrf0264585		TOOL DATA from: FBal0410849
+FBti0421657_cas	carries_tool	FBto0000349	FBrf0264585		TOOL DATA from: FBal0410849
+FBti0421657_cas	tagged_with	FBto0000076	FBrf0264585		TOOL DATA from: FBal0410849
+FBti0421657_cas	tagged_with	FBto0000093	FBrf0264585		TOOL DATA from: FBal0410849
+FBti0421658_cas	carries_tool	FBto0000318	FBrf0264585		TOOL DATA from: FBal0410850
+FBti0421658_cas	carries_tool	FBto0000349	FBrf0264585		TOOL DATA from: FBal0410850
+FBti0421658_cas	tagged_with	FBto0000077	FBrf0264585		TOOL DATA from: FBal0410850
+FBti0421658_cas	tagged_with	FBto0000079	FBrf0264585		TOOL DATA from: FBal0410850
+FBti0421663_cas	tagged_with	FBto0000335	FBrf0264200		TOOL DATA from: FBal0410855
+FBti0421664_cas	carries_tool	FBto0000349	FBrf0264200		TOOL DATA from: FBal0410856
+FBti0421664_cas	tagged_with	FBto0000126	FBrf0264200		TOOL DATA from: FBal0410856
+FBti0421665_cas	tagged_with	FBto0000118	FBrf0263770		TOOL DATA from: FBal0410857
+FBti0421666_cas	tagged_with	FBto0000077	FBrf0264375		TOOL DATA from: FBal0410867
+FBti0421667_cas	tagged_with	FBto0000077	FBrf0264375		TOOL DATA from: FBal0410868
+FBti0421670_cas	tagged_with	FBto0000027	FBrf0264269		TOOL DATA from: FBal0410871
+FBti0421726_cas	carries_tool	FBto0000349	FBrf0264409		TOOL DATA from: FBal0410896
+FBti0421726_cas	carries_tool	FBto0000356	FBrf0264409		TOOL DATA from: FBal0410896
+FBti0421727_cas	tagged_with	FBto0000077	FBrf0264409		TOOL DATA from: FBal0410898
+FBti0421728_cas	tagged_with	FBto0000077	FBrf0264409		TOOL DATA from: FBal0410899
+FBti0421729_cas	tagged_with	FBto0000077	FBrf0264435		TOOL DATA from: FBal0410901
+FBti0421740_cas	carries_tool	FBto0000349	FBrf0264327		TOOL DATA from: FBal0410928
+FBti0421740_cas	tagged_with	FBto0000027	FBrf0264327		TOOL DATA from: FBal0410928
+FBti0421740_cas	tagged_with	FBto0001064	FBrf0264327		TOOL DATA from: FBal0410928
+FBti0421741_cas	carries_tool	FBto0000349	FBrf0264327		TOOL DATA from: FBal0410929
+FBti0421741_cas	tagged_with	FBto0000027	FBrf0264327		TOOL DATA from: FBal0410929
+FBti0421741_cas	tagged_with	FBto0001064	FBrf0264327		TOOL DATA from: FBal0410929
+FBti0421742_cas	carries_tool	FBto0000349	FBrf0264327		TOOL DATA from: FBal0410930
+FBti0421742_cas	tagged_with	FBto0000027	FBrf0264327		TOOL DATA from: FBal0410930
+FBti0421742_cas	tagged_with	FBto0001064	FBrf0264327		TOOL DATA from: FBal0410930
+FBti0421743_cas	carries_tool	FBto0000349	FBrf0264327		TOOL DATA from: FBal0410931
+FBti0421743_cas	tagged_with	FBto0000027	FBrf0264327		TOOL DATA from: FBal0410931
+FBti0421743_cas	tagged_with	FBto0001064	FBrf0264327		TOOL DATA from: FBal0410931
+FBti0421754_cas	tagged_with	FBto0000027	FBrf0264536		TOOL DATA from: FBal0410943
+FBti0421817_cas	tagged_with	FBto0000403	FBrf0264213		TOOL DATA from: FBal0410979
+FBti0421819_cas	carries_tool	FBto0000349	FBrf0264549		TOOL DATA from: FBal0410987
+FBti0421872_cas	carries_tool	FBto0000349	FBrf0264660		TOOL DATA from: FBal0411045
+FBti0421872_cas	tagged_with	FBto0000936	FBrf0264660		TOOL DATA from: FBal0411045
+FBti0421873_cas	tagged_with	FBto0000936	FBrf0264660		TOOL DATA from: FBal0411046
+FBti0421874_cas	carries_tool	FBto0000349	FBrf0264019		TOOL DATA from: FBal0411047
+FBti0421874_cas	carries_tool	FBto0000356	FBrf0264019		TOOL DATA from: FBal0411047
+FBti0421875_cas	carries_tool	FBto0000349	FBrf0264019		TOOL DATA from: FBal0411048
+FBti0421875_cas	carries_tool	FBto0000356	FBrf0264019		TOOL DATA from: FBal0411048
+FBti0421876_cas	tagged_with	FBto0000077	FBrf0264019		TOOL DATA from: FBal0411049
+FBti0421880_cas	tagged_with	FBto0000027	FBrf0264511		TOOL DATA from: FBal0411058
+FBti0421881_cas	tagged_with	FBto0000027	FBrf0264511		TOOL DATA from: FBal0411062
+FBti0421882_cas	carries_tool	FBto0000349	FBrf0246291		TOOL DATA from: FBal0411068
+FBti0421944_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0421944_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0421945_cas	encodes_tool	FBto0000118			TOOL DATA from: FBtp0099211
+FBti0421945_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099211
+FBti0421946_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0128007
+FBti0421946_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0128007
+FBti0421947_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0421947_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204
+FBti0421949_cas	tagged_with	FBto0000081	FBrf0264515		TOOL DATA from: FBal0411092
+FBti0421951_cas	carries_tool	FBto0000349	FBrf0264472		TOOL DATA from: FBal0411095
+FBti0421952_cas	carries_tool	FBto0000356	FBrf0264083		TOOL DATA from: FBal0411102
+FBti0421953_cas	encodes_tool	FBto0000027			TOOL DATA from: FBtp0099213
+FBti0421953_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099213
+FBti0421954_cas	encodes_tool	FBto0000791			TOOL DATA from: FBtp0150465
+FBti0421954_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0150465
+FBti0421955_cas	tagged_with	FBto0000601	FBrf0264081		TOOL DATA from: FBal0411111
+FBti0421956_cas	carries_tool	FBto0000356	FBrf0264081		TOOL DATA from: FBal0411112
+FBti0421960_cas	tagged_with	FBto0000102	FBrf0264151		TOOL DATA from: FBal0411114
+FBti0421961_cas	tagged_with	FBto0000102	FBrf0264151		TOOL DATA from: FBal0411116
+FBti0421962_cas	tagged_with	FBto0000601	FBrf0264151		TOOL DATA from: FBal0411117
+FBti0421999_cas	tagged_with	FBto0000027	FBrf0264645		TOOL DATA from: FBal0411131
+FBti0422000_cas	tagged_with	FBto0000027	FBrf0264645		TOOL DATA from: FBal0411132
+FBti0422001_cas	tagged_with	FBto0000027	FBrf0264645		TOOL DATA from: FBal0411133
+FBti0422004_cas	tagged_with	FBto0000516	FBrf0264025		TOOL DATA from: FBal0411142
+FBti0422005_cas	tagged_with	FBto0000790	FBrf0264025		TOOL DATA from: FBal0411143
+FBti0422006_cas	tagged_with	FBto0001067	FBrf0264025		TOOL DATA from: FBal0411145
+FBti0422007_cas	tagged_with	FBto0001068	FBrf0264025		TOOL DATA from: FBal0411146
+FBti0422011_cas	tagged_with	FBto0000014	FBrf0264020		TOOL DATA from: FBal0411154
+FBti0422012_cas	tagged_with	FBto0000014	FBrf0264020		TOOL DATA from: FBal0411155
+FBti0422013_cas	tagged_with	FBto0000014	FBrf0264020		TOOL DATA from: FBal0411156
+FBti0422040_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411180
+FBti0422041_cas	tagged_with	FBto0000031	FBrf0264543		TOOL DATA from: FBal0411181
+FBti0422042_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411182
+FBti0422043_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411183
+FBti0422044_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411184
+FBti0422045_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411185
+FBti0422046_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411186
+FBti0422047_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411187
+FBti0422052_cas	tagged_with	FBto0000077	FBrf0264207		TOOL DATA from: FBal0411235
+FBti0422053_cas	carries_tool	FBto0000318	FBrf0264207		TOOL DATA from: FBal0411236
+FBti0422054_cas	carries_tool	FBto0000318	FBrf0264207		TOOL DATA from: FBal0411237
+FBti0422054_cas	tagged_with	FBto0000077	FBrf0264207		TOOL DATA from: FBal0411237
+FBti0422063_cas	tagged_with	FBto0000336	FBrf0264745		TOOL DATA from: FBal0411251
+FBti0422064_cas	tagged_with	FBto0000336	FBrf0264745		TOOL DATA from: FBal0411252
+FBti0422073_cas	carries_tool	FBto0000349	FBrf0239915		TOOL DATA from: FBal0411260
+FBti0422073_cas	carries_tool	FBto0000356	FBrf0239915		TOOL DATA from: FBal0411260
+FBti0422075_cas	tagged_with	FBto0000027	FBrf0264833		TOOL DATA from: FBal0411264
+FBti0422242_cas	carries_tool	FBto0000349	FBrf0264798		TOOL DATA from: FBal0411336
+FBti0422244_cas	carries_tool	FBto0000349	FBrf0264820		TOOL DATA from: FBal0411340
+FBti0422244_cas	tagged_with	FBto0000070	FBrf0264820		TOOL DATA from: FBal0411340
+FBti0422246_cas	tagged_with	FBto0000031	FBrf0264317		TOOL DATA from: FBal0411342
+FBti0422247_cas	tagged_with	FBto0000031	FBrf0264317		TOOL DATA from: FBal0411343
+FBti0422248_cas	tagged_with	FBto0000031	FBrf0264317		TOOL DATA from: FBal0411344
+FBti0422326_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411508
+FBti0422326_cas	tagged_with	FBto0000118	FBrf0264723		TOOL DATA from: FBal0411508
+FBti0422327_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411509
+FBti0422327_cas	tagged_with	FBto0000118	FBrf0264723		TOOL DATA from: FBal0411509
+FBti0422328_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411510
+FBti0422328_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411510
+FBti0422329_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411511
+FBti0422329_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411511
+FBti0422330_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411512
+FBti0422330_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411512
+FBti0422331_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411513
+FBti0422331_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411513
+FBti0422332_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411514
+FBti0422332_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411514
+FBti0422333_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411515
+FBti0422333_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411515
+FBti0422334_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411516
+FBti0422334_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411516
+FBti0422335_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411517
+FBti0422335_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411517
+FBti0422336_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411521
+FBti0422336_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411521
+FBti0422337_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411523
+FBti0422337_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411523
+FBti0422338_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411525
+FBti0422338_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411525
+FBti0422339_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411529
+FBti0422339_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411529
+FBti0422340_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411530
+FBti0422340_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411530
+FBti0422341_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411531
+FBti0422341_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411531
+FBti0422342_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411532
+FBti0422342_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411532
+FBti0422343_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411533
+FBti0422343_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411533
+FBti0422344_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411534
+FBti0422344_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411534
+FBti0422345_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411536
+FBti0422345_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411536
+FBti0422347_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411538
+FBti0422347_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411538
+FBti0422348_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411539
+FBti0422348_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411539
+FBti0422349_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411541
+FBti0422349_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411541
+FBti0422350_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411542
+FBti0422350_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411542
+FBti0422374_cas	encodes_tool	FBto0000155			TOOL DATA from: FBtp0126682
+FBti0422374_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0126682
+FBti0422374_cas	carries_tool	FBto0000349	FBrf0264950		TOOL DATA from: FBal0411570
+FBti0422374_cas	carries_tool	FBto0000349	FBrf0264950		TOOL DATA from: FBal0411571
+FBti0422375_cas	encodes_tool	FBto0000135			TOOL DATA from: FBtp0099204
+FBti0422375_cas	tool_uses	promoter trap			TOOL DATA from: FBtp0099204

--- a/docs/FTA-182/FTA-182_output_with_additional_refs.txt
+++ b/docs/FTA-182/FTA-182_output_with_additional_refs.txt
@@ -1,0 +1,9857 @@
+#cassette	component type or tool_uses	tool or CV term	pub_curies	internal_note	where tool data came from
+FBti0167947_cas	tagged_with	FBto0000027	FBrf0225747		TOOL DATA from: FBal0302198
+FBti0167948_cas	carries_tool	FBto0000349	FBrf0227064|FBrf0227617		TOOL DATA from: FBal0301888
+FBti0167949_cas	encodes_tool	FBto0000031	FBrf0227617		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0167949_cas	tool_uses	promoter trap	FBrf0227617		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0167950_cas	encodes_tool	FBto0000135	FBrf0227617		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0167950_cas	tool_uses	promoter trap	FBrf0227617		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0167951_cas	carries_tool	FBto0000349	FBrf0227617		TOOL DATA from: FBal0302732
+FBti0167951_cas	carries_tool	FBto0000356	FBrf0227617		TOOL DATA from: FBal0302732
+FBti0167953_cas	carries_tool	FBto0000318	FBrf0206395		TOOL DATA from: FBal0219603
+FBti0167953_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219603
+FBti0167953_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219603
+FBti0167954_cas	carries_tool	FBto0000318	FBrf0206395		TOOL DATA from: FBal0219602
+FBti0167954_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219602
+FBti0167954_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219602
+FBti0168130_cas	tagged_with	FBto0000031	FBrf0227964		TOOL DATA from: FBal0304195
+FBti0168172_cas	encodes_tool	FBto0000159	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168172_cas	tool_uses	promoter trap	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168172_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304286
+FBti0168172_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304292
+FBti0168173_cas	encodes_tool	FBto0000159	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168173_cas	tool_uses	promoter trap	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168173_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304288
+FBti0168173_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304293
+FBti0168174_cas	encodes_tool	FBto0000159	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168174_cas	tool_uses	promoter trap	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168174_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304289
+FBti0168174_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304294
+FBti0168175_cas	encodes_tool	FBto0000159	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168175_cas	tool_uses	promoter trap	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168175_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304290
+FBti0168175_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304295
+FBti0168176_cas	encodes_tool	FBto0000159	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168176_cas	tool_uses	promoter trap	FBrf0227698		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168176_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304291
+FBti0168176_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0326391
+FBti0168177_cas	encodes_tool	FBto0000135	FBrf0227698		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168177_cas	tool_uses	promoter trap	FBrf0227698		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168177_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304287
+FBti0168177_cas	carries_tool	FBto0000349	FBrf0228945		TOOL DATA from: FBal0304297
+FBti0168251_cas	tagged_with	FBto0000079	FBrf0212671		TOOL DATA from: FBal0285816
+FBti0168252_cas	encodes_tool	FBto0000135	FBrf0190566		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168252_cas	tool_uses	promoter trap	FBrf0190566		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168254_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290697
+FBti0168255_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290693
+FBti0168256_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290696
+FBti0168257_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290691
+FBti0168257_cas	carries_tool	FBto0000356	FBrf0222897		TOOL DATA from: FBal0290691
+FBti0168258_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290692
+FBti0168258_cas	carries_tool	FBto0000356	FBrf0222897		TOOL DATA from: FBal0290692
+FBti0168259_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290700
+FBti0168260_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290698
+FBti0168261_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290699
+FBti0168262_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290694
+FBti0168263_cas	carries_tool	FBto0000349	FBrf0222897		TOOL DATA from: FBal0290695
+FBti0168264_cas	carries_tool	FBto0000349	FBrf0206292		TOOL DATA from: FBal0299596
+FBti0168265_cas	carries_tool	FBto0000349	FBrf0206292		TOOL DATA from: FBal0299597
+FBti0168266_cas	carries_tool	FBto0000349	FBrf0206292		TOOL DATA from: FBal0299598
+FBti0168271_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247443
+FBti0168272_cas	carries_tool	FBto0000356	FBrf0207169		TOOL DATA from: FBal0247440
+FBti0168272_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247440
+FBti0168273_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247445
+FBti0168274_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247444
+FBti0168275_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247441
+FBti0168276_cas	tagged_with	FBto0000093	FBrf0207169		TOOL DATA from: FBal0247442
+FBti0168281_cas	carries_tool	FBto0000318	FBrf0227185		TOOL DATA from: FBal0301552
+FBti0168281_cas	carries_tool	FBto0000356	FBrf0227185		TOOL DATA from: FBal0301552
+FBti0168282_cas	tagged_with	FBto0000077	FBrf0227185		TOOL DATA from: FBal0301551
+FBti0168283_cas	carries_tool	FBto0000318	FBrf0227185		TOOL DATA from: FBal0301553
+FBti0168283_cas	carries_tool	FBto0000356	FBrf0227185		TOOL DATA from: FBal0301553
+FBti0168286_cas				FTA: unable to add tool information from FBal0258331 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168288_cas	carries_tool	FBto0000349	FBrf0220990		TOOL DATA from: FBal0296113
+FBti0168289_cas				FTA: unable to add tool information from FBal0296114 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168290_cas	carries_tool	FBto0000349	FBrf0220990		TOOL DATA from: FBal0296115
+FBti0168293_cas	carries_tool	FBto0000349	FBrf0213095		TOOL DATA from: FBal0258132
+FBti0168294_cas	carries_tool	FBto0000349	FBrf0213095		TOOL DATA from: FBal0258131
+FBti0168296_cas	carries_tool	FBto0000349	FBrf0227107		TOOL DATA from: FBal0302850
+FBti0168297_cas	encodes_tool	FBto0000135	FBrf0221993		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168297_cas	tool_uses	promoter trap	FBrf0221993		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168297_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285936
+FBti0168297_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285936
+FBti0168297_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285940
+FBti0168297_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285940
+FBti0168298_cas	encodes_tool	FBto0000135	FBrf0221993		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168298_cas	tool_uses	promoter trap	FBrf0221993		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168298_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285934
+FBti0168298_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285934
+FBti0168298_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285939
+FBti0168298_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285939
+FBti0168299_cas	encodes_tool	FBto0000135	FBrf0221993		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168299_cas	tool_uses	promoter trap	FBrf0221993		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168299_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285938
+FBti0168299_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285938
+FBti0168299_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285942
+FBti0168299_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285942
+FBti0168300_cas	encodes_tool	FBto0000135	FBrf0221993		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168300_cas	tool_uses	promoter trap	FBrf0221993		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168300_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285937
+FBti0168300_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285937
+FBti0168300_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0285941
+FBti0168300_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0285941
+FBti0168301_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219599
+FBti0168301_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219599
+FBti0168302_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219600
+FBti0168302_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219600
+FBti0168303_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219597
+FBti0168303_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219597
+FBti0168304_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219595
+FBti0168304_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219595
+FBti0168305_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219598
+FBti0168305_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219598
+FBti0168306_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219596
+FBti0168306_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219596
+FBti0168307_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219601
+FBti0168307_cas	tagged_with	FBto0000045	FBrf0206395		TOOL DATA from: FBal0219601
+FBti0168308_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219609
+FBti0168309_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219605
+FBti0168310_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219607
+FBti0168311_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219606
+FBti0168312_cas	carries_tool	FBto0000349	FBrf0206395		TOOL DATA from: FBal0219608
+FBti0168313_cas	encodes_tool	FBto0000135	FBrf0207448		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168313_cas	tool_uses	promoter trap	FBrf0207448		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168314_cas	carries_tool	FBto0000356	FBrf0214460		TOOL DATA from: FBal0284721
+FBti0168321_cas				FTA: unable to add tool information from FBal0285379 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168324_cas	encodes_tool	FBto0000135	FBrf0188142		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168324_cas	tool_uses	promoter trap	FBrf0188142		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168325_cas	carries_tool	FBto0000349	FBrf0217785		TOOL DATA from: FBal0267901
+FBti0168325_cas	carries_tool	FBto0000356	FBrf0217785		TOOL DATA from: FBal0267901
+FBti0168326_cas	carries_tool	FBto0000349	FBrf0217785		TOOL DATA from: FBal0267900
+FBti0168326_cas	carries_tool	FBto0000356	FBrf0217785		TOOL DATA from: FBal0267900
+FBti0168329_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263893
+FBti0168329_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263893
+FBti0168330_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263889
+FBti0168330_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263889
+FBti0168331_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263894
+FBti0168331_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263894
+FBti0168332_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263891
+FBti0168332_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263891
+FBti0168333_cas	carries_tool	FBto0000349	FBrf0215272		TOOL DATA from: FBal0263887
+FBti0168333_cas	carries_tool	FBto0000356	FBrf0215272		TOOL DATA from: FBal0263887
+FBti0168334_cas	tagged_with	FBto0000077	FBrf0226803		TOOL DATA from: FBal0301091
+FBti0168335_cas	tagged_with	FBto0000077	FBrf0226803		TOOL DATA from: FBal0301090
+FBti0168336_cas	encodes_tool	FBto0000027	FBrf0105495		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168336_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168336_cas	tagged_with	FBto0000291	FBrf0213278		TOOL DATA from: FBal0258329
+FBti0168337_cas	carries_tool	FBto0000349	FBrf0224710		TOOL DATA from: FBal0297980
+FBti0168338_cas	carries_tool	FBto0000349	FBrf0224710		TOOL DATA from: FBal0297978
+FBti0168339_cas	carries_tool	FBto0000349	FBrf0224710		TOOL DATA from: FBal0297979
+FBti0168340_cas	encodes_tool	FBto0000135	FBrf0219961		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168340_cas	tool_uses	promoter trap	FBrf0219961		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168343_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0215825
+FBti0168344_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0215824
+FBti0168345_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0215827
+FBti0168346_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0215826
+FBti0168347_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304355
+FBti0168348_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304356
+FBti0168349_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304357
+FBti0168350_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304358
+FBti0168351_cas	carries_tool	FBto0000318	FBrf0205027		TOOL DATA from: FBal0304359
+FBti0168364_cas	encodes_tool	FBto0000135	FBrf0207727		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168364_cas	tool_uses	promoter trap	FBrf0207727		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168364_cas	carries_tool	FBto0000318	FBrf0207727		TOOL DATA from: FBal0243962
+FBti0168364_cas	carries_tool	FBto0000318	FBrf0207727		TOOL DATA from: FBal0243964
+FBti0168365_cas	encodes_tool	FBto0000135	FBrf0207727		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168365_cas	tool_uses	promoter trap	FBrf0207727		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168367_cas	carries_tool	FBto0000356	FBrf0207727		TOOL DATA from: FBal0243958
+FBti0168368_cas	carries_tool	FBto0000345	FBrf0207727		TOOL DATA from: FBal0243961
+FBti0168375_cas				FTA: unable to add tool information from FBal0302628 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168378_cas	carries_tool	FBto0000318	FBrf0223447		TOOL DATA from: FBal0297878
+FBti0168378_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297878
+FBti0168378_cas	tagged_with	FBto0000081	FBrf0223447		TOOL DATA from: FBal0297878
+FBti0168379_cas	encodes_tool	FBto0000118	FBrf0223447		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168379_cas	tool_uses	promoter trap	FBrf0223447		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168379_cas	carries_tool	FBto0000320	FBrf0223447		TOOL DATA from: FBal0297877
+FBti0168379_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297877
+FBti0168379_cas	carries_tool	FBto0000356	FBrf0223447		TOOL DATA from: FBal0297877
+FBti0168379_cas	carries_tool	FBto0000320	FBrf0223447		TOOL DATA from: FBal0297880
+FBti0168379_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297880
+FBti0168379_cas	carries_tool	FBto0000356	FBrf0223447		TOOL DATA from: FBal0297880
+FBti0168379_cas	tagged_with	FBto0000205	FBrf0223447		TOOL DATA from: FBal0297880
+FBti0168380_cas	encodes_tool	FBto0000167	FBrf0223447		TOOL DATA from: FBtp0099206, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168380_cas	tool_uses	promoter trap	FBrf0223447		TOOL DATA from: FBtp0099206, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168380_cas	carries_tool	FBto0000318	FBrf0223447		TOOL DATA from: FBal0297879
+FBti0168380_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297879
+FBti0168380_cas	carries_tool	FBto0000318	FBrf0223447		TOOL DATA from: FBal0297885
+FBti0168380_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297885
+FBti0168381_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297882
+FBti0168381_cas	tagged_with	FBto0000077	FBrf0223447		TOOL DATA from: FBal0297882
+FBti0168382_cas	carries_tool	FBto0000318	FBrf0223447|FBrf0223769		TOOL DATA from: FBal0297883
+FBti0168382_cas	carries_tool	FBto0000349	FBrf0223447|FBrf0223769		TOOL DATA from: FBal0297883
+FBti0168383_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0297884
+FBti0168383_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0297884
+FBti0168383_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0297884
+FBti0168383_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0297884
+FBti0168384_cas	encodes_tool	FBto0000135	FBrf0223447		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168384_cas	tool_uses	promoter trap	FBrf0223447		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168384_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297874
+FBti0168384_cas	carries_tool	FBto0000349	FBrf0223447		TOOL DATA from: FBal0297876
+FBti0168385_cas	tagged_with	FBto0000065	FBrf0226212		TOOL DATA from: FBal0298753
+FBti0168393_cas	carries_tool	FBto0000349	FBrf0227448		TOOL DATA from: FBal0302651
+FBti0168394_cas	carries_tool	FBto0000349	FBrf0227448		TOOL DATA from: FBal0302650
+FBti0168395_cas	encodes_tool	FBto0000135	FBrf0219612		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168395_cas	tool_uses	promoter trap	FBrf0219612		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168396_cas	carries_tool	FBto0000349	FBrf0205704		TOOL DATA from: FBal0264684
+FBti0168397_cas	carries_tool	FBto0000349	FBrf0205704		TOOL DATA from: FBal0264686
+FBti0168399_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286279
+FBti0168400_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286277
+FBti0168401_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286278
+FBti0168402_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286274
+FBti0168403_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286275
+FBti0168404_cas	carries_tool	FBto0000318	FBrf0209048		TOOL DATA from: FBal0286276
+FBti0168405_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0191252
+FBti0168405_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0191252
+FBti0168406_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0189625
+FBti0168406_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0189625
+FBti0168407_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0190085
+FBti0168408_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0190371
+FBti0168408_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0190371
+FBti0168409_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0190295
+FBti0168409_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0190295
+FBti0168410_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0190109
+FBti0168411_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0191136
+FBti0168412_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0179807
+FBti0168413_cas	carries_tool	FBto0000318	FBrf0191487		TOOL DATA from: FBal0189853
+FBti0168413_cas	carries_tool	FBto0000904	FBrf0191487		TOOL DATA from: FBal0189853
+FBti0168422_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301947
+FBti0168423_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301921
+FBti0168424_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301910
+FBti0168425_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301946
+FBti0168426_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301926
+FBti0168427_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168427_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168427_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301935
+FBti0168428_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301943
+FBti0168428_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301943
+FBti0168429_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301922
+FBti0168429_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301922
+FBti0168430_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301902
+FBti0168431_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301952
+FBti0168432_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301951
+FBti0168432_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301951
+FBti0168433_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301924
+FBti0168434_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301895
+FBti0168434_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301895
+FBti0168434_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301896
+FBti0168434_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301896
+FBti0168435_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301901
+FBti0168435_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301901
+FBti0168436_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168436_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168436_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301927
+FBti0168437_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168437_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168437_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301905
+FBti0168438_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301907
+FBti0168439_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301925
+FBti0168439_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301925
+FBti0168440_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301950
+FBti0168441_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168441_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168441_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301948
+FBti0168442_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301945
+FBti0168443_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301915
+FBti0168444_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301908
+FBti0168444_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301908
+FBti0168445_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301912
+FBti0168447_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301932
+FBti0168448_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301918
+FBti0168448_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301918
+FBti0168449_cas				FTA: unable to add tool information from FBal0301939 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168450_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168450_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168450_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301936
+FBti0168451_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301929
+FBti0168452_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301889
+FBti0168453_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301937
+FBti0168453_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301937
+FBti0168454_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301914
+FBti0168454_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301914
+FBti0168455_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301938
+FBti0168455_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301938
+FBti0168456_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301934
+FBti0168457_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301892
+FBti0168457_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301893
+FBti0168458_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301928
+FBti0168459_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168459_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168459_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301944
+FBti0168460_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301933
+FBti0168461_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301903
+FBti0168462_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168462_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168462_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301906
+FBti0168463_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301899
+FBti0168463_cas	carries_tool	FBto0000349	FBrf0258709		TOOL DATA from: FBal0400742
+FBti0168464_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301953
+FBti0168465_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301911
+FBti0168466_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0287802
+FBti0168466_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0287802
+FBti0168467_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301909
+FBti0168468_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301894
+FBti0168469_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301920
+FBti0168470_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301904
+FBti0168471_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301890
+FBti0168471_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301891
+FBti0168472_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168472_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168472_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301887
+FBti0168473_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301916
+FBti0168474_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301949
+FBti0168474_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301949
+FBti0168475_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301917
+FBti0168476_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301930
+FBti0168477_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301940
+FBti0168478_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301941
+FBti0168479_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301897
+FBti0168479_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301898
+FBti0168480_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301913
+FBti0168480_cas	carries_tool	FBto0000356	FBrf0227064		TOOL DATA from: FBal0301913
+FBti0168481_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301900
+FBti0168482_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168482_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168482_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301942
+FBti0168483_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301919
+FBti0168484_cas	carries_tool	FBto0000349	FBrf0227064		TOOL DATA from: FBal0301923
+FBti0168485_cas	carries_tool	FBto0000349	FBrf0222578|FBrf0227064		TOOL DATA from: FBal0290289
+FBti0168497_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168497_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168498_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168498_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168499_cas	encodes_tool	FBto0000135	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168499_cas	tool_uses	promoter trap	FBrf0227064		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168500_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0299787
+FBti0168501_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0299788
+FBti0168502_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0299786
+FBti0168503_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0304361
+FBti0168504_cas	carries_tool	FBto0000349	FBrf0226246		TOOL DATA from: FBal0304362
+FBti0168514_cas	encodes_tool	FBto0000135	FBrf0219887		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168514_cas	tool_uses	promoter trap	FBrf0219887		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168514_cas	carries_tool	FBto0000349	FBrf0219887		TOOL DATA from: FBal0290263
+FBti0168516_cas	carries_tool	FBto0000349	FBrf0204932		TOOL DATA from: FBal0301954
+FBti0168517_cas	carries_tool	FBto0000349	FBrf0225135		TOOL DATA from: FBal0296653
+FBti0168517_cas	carries_tool	FBto0000356	FBrf0225135		TOOL DATA from: FBal0296653
+FBti0168522_cas	encodes_tool	FBto0000309	FBrf0105495		TOOL DATA from: FBtp0127592, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168522_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0127592, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168523_cas	encodes_tool	FBto0000031	FBrf0204359		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168523_cas	tool_uses	promoter trap	FBrf0204359		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168532_cas	tagged_with	FBto0000079	FBrf0191277		TOOL DATA from: FBal0260875
+FBti0168533_cas	tagged_with	FBto0000079	FBrf0191277		TOOL DATA from: FBal0260876
+FBti0168533_cas	tagged_with	FBto0000093	FBrf0191277		TOOL DATA from: FBal0260876
+FBti0168533_cas	tagged_with	FBto0000217	FBrf0191277		TOOL DATA from: FBal0260876
+FBti0168534_cas	carries_tool	FBto0000904	FBrf0168031		TOOL DATA from: FBal0304363
+FBti0168535_cas	carries_tool	FBto0000904	FBrf0168031		TOOL DATA from: FBal0304364
+FBti0168536_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293689
+FBti0168537_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293693
+FBti0168538_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293691
+FBti0168539_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293687
+FBti0168540_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293698
+FBti0168541_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293697
+FBti0168542_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293695
+FBti0168543_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293696
+FBti0168544_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293688
+FBti0168545_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293699
+FBti0168546_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293690
+FBti0168547_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293692
+FBti0168548_cas	carries_tool	FBto0000349	FBrf0222226		TOOL DATA from: FBal0293694
+FBti0168550_cas	carries_tool	FBto0000349	FBrf0213236		TOOL DATA from: FBal0269848
+FBti0168551_cas	carries_tool	FBto0000349	FBrf0213236		TOOL DATA from: FBal0269849
+FBti0168552_cas	carries_tool	FBto0000349	FBrf0213236		TOOL DATA from: FBal0298344
+FBti0168552_cas	tagged_with	FBto0000077	FBrf0213236		TOOL DATA from: FBal0298344
+FBti0168560_cas				FTA: unable to add tool information from FBal0247903 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168561_cas				FTA: unable to add tool information from FBal0247917 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168562_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247918
+FBti0168562_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247918
+FBti0168563_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247921
+FBti0168563_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247921
+FBti0168564_cas				FTA: unable to add tool information from FBal0247920 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168565_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247908
+FBti0168565_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247908
+FBti0168566_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247909
+FBti0168566_cas	tagged_with	FBto0000057	FBrf0208027		TOOL DATA from: FBal0247909
+FBti0168567_cas	tagged_with	FBto0000118	FBrf0208027		TOOL DATA from: FBal0247911
+FBti0168568_cas				FTA: unable to add tool information from FBal0247906 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168569_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247907
+FBti0168569_cas	carries_tool	FBto0000356	FBrf0208027		TOOL DATA from: FBal0247907
+FBti0168570_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247910
+FBti0168570_cas	tagged_with	FBto0000121	FBrf0208027		TOOL DATA from: FBal0247910
+FBti0168571_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247915
+FBti0168571_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247915
+FBti0168572_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247913
+FBti0168572_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247913
+FBti0168573_cas				FTA: unable to add tool information from FBal0247912 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168574_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247914
+FBti0168574_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247914
+FBti0168575_cas	carries_tool	FBto0000349	FBrf0208027		TOOL DATA from: FBal0247905
+FBti0168575_cas	tagged_with	FBto0000031	FBrf0208027		TOOL DATA from: FBal0247905
+FBti0168576_cas				FTA: unable to add tool information from FBal0247904 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168581_cas	encodes_tool	FBto0000135	FBrf0216424		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168581_cas	tool_uses	promoter trap	FBrf0216424		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168582_cas	encodes_tool	FBto0000135	FBrf0200334		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168582_cas	tool_uses	promoter trap	FBrf0200334		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168582_cas	carries_tool	FBto0000349	FBrf0200334		TOOL DATA from: FBal0210949
+FBti0168583_cas	encodes_tool	FBto0000135	FBrf0200334		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168583_cas	tool_uses	promoter trap	FBrf0200334		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168583_cas	carries_tool	FBto0000349	FBrf0200334		TOOL DATA from: FBal0210948
+FBti0168589_cas				FTA: unable to add tool information from FBal0301001 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168592_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243800
+FBti0168593_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243798
+FBti0168594_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243810
+FBti0168595_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243822
+FBti0168596_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243802
+FBti0168597_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243824
+FBti0168598_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243818
+FBti0168599_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243812
+FBti0168600_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243838
+FBti0168601_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243840
+FBti0168602_cas	tagged_with	FBto0000077	FBrf0209892		TOOL DATA from: FBal0243807
+FBti0168605_cas	encodes_tool	FBto0000135	FBrf0211074		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168605_cas	tool_uses	promoter trap	FBrf0211074		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168606_cas	encodes_tool	FBto0000135	FBrf0211074		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168606_cas	tool_uses	promoter trap	FBrf0211074		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168608_cas	encodes_tool	FBto0000158	FBrf0220977		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168608_cas	tool_uses	promoter trap	FBrf0220977		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168609_cas				FTA: unable to add tool information from FBal0299770 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168610_cas	encodes_tool	FBto0000135	FBrf0205753		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168610_cas	tool_uses	promoter trap	FBrf0205753		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168616_cas	encodes_tool	FBto0000135	FBrf0222497		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168616_cas	tool_uses	promoter trap	FBrf0222497		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168616_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290239
+FBti0168616_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290247
+FBti0168617_cas	encodes_tool	FBto0000135	FBrf0222497		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168617_cas	tool_uses	promoter trap	FBrf0222497		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168617_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290240
+FBti0168617_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290248
+FBti0168618_cas	encodes_tool	FBto0000135	FBrf0222497		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168618_cas	tool_uses	promoter trap	FBrf0222497		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168618_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290241
+FBti0168618_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290249
+FBti0168619_cas	carries_tool	FBto0000349	FBrf0222497		TOOL DATA from: FBal0290242
+FBti0168620_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296337
+FBti0168621_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296338
+FBti0168622_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296340
+FBti0168623_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296341
+FBti0168624_cas	tagged_with	FBto0000079	FBrf0224028		TOOL DATA from: FBal0296339
+FBti0168628_cas	encodes_tool	FBto0000135	FBrf0210735		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168628_cas	tool_uses	promoter trap	FBrf0210735		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168630_cas	encodes_tool	FBto0000135	FBrf0216517		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168630_cas	tool_uses	promoter trap	FBrf0216517		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168630_cas	carries_tool	FBto0000349	FBrf0216517		TOOL DATA from: FBal0283188
+FBti0168630_cas	carries_tool	FBto0000349	FBrf0216517		TOOL DATA from: FBal0283192
+FBti0168635_cas	encodes_tool	FBto0000020	FBrf0191190		TOOL DATA from: FBtp0099208, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168635_cas	tool_uses	promoter trap	FBrf0191190		TOOL DATA from: FBtp0099208, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168638_cas				FTA: unable to add tool information from FBal0301058 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168639_cas				FTA: unable to add tool information from FBal0301059 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168640_cas	carries_tool	FBto0000349	FBrf0218332		TOOL DATA from: FBal0268456
+FBti0168641_cas	encodes_tool	FBto0000135	FBrf0210397		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168641_cas	tool_uses	promoter trap	FBrf0210397		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168641_cas	carries_tool	FBto0000318	FBrf0210397		TOOL DATA from: FBal0267700
+FBti0168641_cas	carries_tool	FBto0000318	FBrf0210397		TOOL DATA from: FBal0277019
+FBti0168644_cas	carries_tool	FBto0000349	FBrf0216958		TOOL DATA from: FBal0267506
+FBti0168645_cas	tagged_with	FBto0000031	FBrf0227091		TOOL DATA from: FBal0302059
+FBti0168645_cas	tagged_with	FBto0000076	FBrf0227091		TOOL DATA from: FBal0302059
+FBti0168646_cas	carries_tool	FBto0000356	FBrf0227091		TOOL DATA from: FBal0302056
+FBti0168647_cas	carries_tool	FBto0000356	FBrf0227091		TOOL DATA from: FBal0302055
+FBti0168648_cas	tagged_with	FBto0000092	FBrf0227091		TOOL DATA from: FBal0302057
+FBti0168648_cas	tagged_with	FBto0000093	FBrf0227091		TOOL DATA from: FBal0302057
+FBti0168649_cas	carries_tool	FBto0000318	FBrf0227091		TOOL DATA from: FBal0302058
+FBti0168649_cas	tagged_with	FBto0000092	FBrf0227091		TOOL DATA from: FBal0302058
+FBti0168649_cas	tagged_with	FBto0000093	FBrf0227091		TOOL DATA from: FBal0302058
+FBti0168650_cas	carries_tool	FBto0000356	FBrf0227091		TOOL DATA from: FBal0302054
+FBti0168651_cas	carries_tool	FBto0000356	FBrf0227091		TOOL DATA from: FBal0302060
+FBti0168652_cas	carries_tool	FBto0000349	FBrf0210726		TOOL DATA from: FBal0248458
+FBti0168653_cas	carries_tool	FBto0000349	FBrf0210726		TOOL DATA from: FBal0248457
+FBti0168654_cas	carries_tool	FBto0000349	FBrf0216391		TOOL DATA from: FBal0265170
+FBti0168655_cas	carries_tool	FBto0000349	FBrf0216391		TOOL DATA from: FBal0265172
+FBti0168656_cas	encodes_tool	FBto0000118	FBrf0226155		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168656_cas	tool_uses	promoter trap	FBrf0226155		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168656_cas	carries_tool	FBto0000320	FBrf0226155		TOOL DATA from: FBal0298265
+FBti0168656_cas	carries_tool	FBto0000349	FBrf0226155		TOOL DATA from: FBal0298265
+FBti0168656_cas	carries_tool	FBto0000356	FBrf0226155		TOOL DATA from: FBal0298265
+FBti0168656_cas	carries_tool	FBto0000320	FBrf0226155		TOOL DATA from: FBal0298271
+FBti0168656_cas	carries_tool	FBto0000349	FBrf0226155		TOOL DATA from: FBal0298271
+FBti0168656_cas	carries_tool	FBto0000356	FBrf0226155		TOOL DATA from: FBal0298271
+FBti0168656_cas	tagged_with	FBto0000205	FBrf0226155		TOOL DATA from: FBal0298271
+FBti0168657_cas	carries_tool	FBto0000349	FBrf0226155		TOOL DATA from: FBal0298266
+FBti0168657_cas	carries_tool	FBto0000356	FBrf0226155		TOOL DATA from: FBal0298266
+FBti0168658_cas	carries_tool	FBto0000349	FBrf0226155		TOOL DATA from: FBal0298267
+FBti0168659_cas	encodes_tool	FBto0000030	FBrf0194402		TOOL DATA from: FBtp0099202, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168659_cas	tool_uses	promoter trap	FBrf0194402		TOOL DATA from: FBtp0099202, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168661_cas	carries_tool	FBto0000318	FBrf0202837		TOOL DATA from: FBal0241951
+FBti0168662_cas	carries_tool	FBto0000349	FBrf0217508		TOOL DATA from: FBal0280288
+FBti0168663_cas	carries_tool	FBto0000349	FBrf0217508		TOOL DATA from: FBal0280289
+FBti0168664_cas	carries_tool	FBto0000349	FBrf0217508		TOOL DATA from: FBal0280287
+FBti0168665_cas	encodes_tool	FBto0000135	FBrf0191488		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168665_cas	tool_uses	promoter trap	FBrf0191488		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168665_cas	carries_tool	FBto0000349	FBrf0191488		TOOL DATA from: FBal0189843
+FBti0168665_cas	carries_tool	FBto0000349	FBrf0191488		TOOL DATA from: FBal0190445
+FBti0168666_cas	encodes_tool	FBto0000135	FBrf0191488		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168666_cas	tool_uses	promoter trap	FBrf0191488		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168666_cas	carries_tool	FBto0000349	FBrf0191488		TOOL DATA from: FBal0179808
+FBti0168666_cas	carries_tool	FBto0000349	FBrf0191488		TOOL DATA from: FBal0276838
+FBti0168668_cas	carries_tool	FBto0000318	FBrf0187655		TOOL DATA from: FBal0191200
+FBti0168668_cas	carries_tool	FBto0000904	FBrf0187655		TOOL DATA from: FBal0191200
+FBti0168669_cas				FTA: unable to add tool information from FBal0192050 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168671_cas	encodes_tool	FBto0000027	FBrf0210824		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168671_cas	tool_uses	promoter trap	FBrf0210824		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168673_cas				FTA: unable to add tool information from FBal0302938 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168674_cas				FTA: unable to add tool information from FBal0298847 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168676_cas	encodes_tool	FBto0000159	FBrf0209580		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168676_cas	tool_uses	promoter trap	FBrf0209580		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168677_cas	carries_tool	FBto0000349	FBrf0201956		TOOL DATA from: FBal0219056
+FBti0168678_cas	tagged_with	FBto0000027	FBrf0224269		TOOL DATA from: FBal0295033
+FBti0168681_cas	tagged_with	FBto0000077	FBrf0210736		TOOL DATA from: FBal0246663
+FBti0168682_cas	carries_tool	FBto0000349	FBrf0226802		TOOL DATA from: FBal0302045
+FBti0168683_cas				FTA: unable to add tool information from FBal0302044 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168684_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293729
+FBti0168685_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293726
+FBti0168686_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293727
+FBti0168686_cas	tagged_with	FBto0000009	FBrf0222114		TOOL DATA from: FBal0293727
+FBti0168687_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293728
+FBti0168688_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0297274
+FBti0168688_cas	carries_tool	FBto0000356	FBrf0222114		TOOL DATA from: FBal0297274
+FBti0168689_cas	carries_tool	FBto0000349	FBrf0222114		TOOL DATA from: FBal0293730
+FBti0168689_cas	tagged_with	FBto0000009	FBrf0222114		TOOL DATA from: FBal0293730
+FBti0168690_cas	encodes_tool	FBto0000167	FBrf0223769		TOOL DATA from: FBtp0099206, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168690_cas	tool_uses	promoter trap	FBrf0223769		TOOL DATA from: FBtp0099206, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168690_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298328
+FBti0168690_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298328
+FBti0168690_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298331
+FBti0168690_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298331
+FBti0168691_cas	encodes_tool	FBto0000135	FBrf0223769		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168691_cas	tool_uses	promoter trap	FBrf0223769		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168691_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298272
+FBti0168691_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298326
+FBti0168692_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298327
+FBti0168692_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298327
+FBti0168693_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298325
+FBti0168693_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298325
+FBti0168693_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298325
+FBti0168693_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298325
+FBti0168694_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298329
+FBti0168694_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298329
+FBti0168694_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298329
+FBti0168694_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298329
+FBti0168695_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298330
+FBti0168695_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298330
+FBti0168695_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298330
+FBti0168696_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298269
+FBti0168696_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298269
+FBti0168696_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298269
+FBti0168696_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298269
+FBti0168697_cas	carries_tool	FBto0000318	FBrf0223769		TOOL DATA from: FBal0298270
+FBti0168697_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298270
+FBti0168698_cas	carries_tool	FBto0000349	FBrf0223769		TOOL DATA from: FBal0298268
+FBti0168698_cas	tagged_with	FBto0000077	FBrf0223769		TOOL DATA from: FBal0298268
+FBti0168698_cas	tagged_with	FBto0000213	FBrf0223769		TOOL DATA from: FBal0298268
+FBti0168700_cas	encodes_tool	FBto0000135	FBrf0226680		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168700_cas	tool_uses	promoter trap	FBrf0226680		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168704_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0302679
+FBti0168704_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0302682
+FBti0168705_cas	encodes_tool	FBto0000135	FBrf0227415		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168705_cas	tool_uses	promoter trap	FBrf0227415		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168705_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0302672
+FBti0168705_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0302678
+FBti0168706_cas	encodes_tool	FBto0000031	FBrf0227415		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168706_cas	tool_uses	promoter trap	FBrf0227415		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168706_cas	carries_tool	FBto0000349	FBrf0227415		TOOL DATA from: FBal0304368
+FBti0168708_cas	encodes_tool	FBto0000135	FBrf0214254		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168708_cas	tool_uses	promoter trap	FBrf0214254		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168710_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182427
+FBti0168711_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182425
+FBti0168712_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182424
+FBti0168713_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182426
+FBti0168714_cas	carries_tool	FBto0000318	FBrf0167805		TOOL DATA from: FBal0182423
+FBti0168715_cas				FTA: unable to add tool information from FBal0277644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168716_cas				FTA: unable to add tool information from FBal0277643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168717_cas	carries_tool	FBto0000349	FBrf0218141		TOOL DATA from: FBal0277645
+FBti0168717_cas	tagged_with	FBto0000077	FBrf0218141		TOOL DATA from: FBal0277645
+FBti0168718_cas	carries_tool	FBto0000349	FBrf0218141		TOOL DATA from: FBal0277646
+FBti0168718_cas	tagged_with	FBto0000077	FBrf0218141		TOOL DATA from: FBal0277646
+FBti0168720_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280511
+FBti0168720_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280511
+FBti0168721_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280508
+FBti0168721_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280508
+FBti0168722_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280506
+FBti0168722_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280506
+FBti0168723_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280507
+FBti0168723_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280507
+FBti0168724_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280505
+FBti0168724_cas	carries_tool	FBto0000356	FBrf0219767		TOOL DATA from: FBal0280505
+FBti0168725_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280512
+FBti0168725_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280512
+FBti0168726_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280513
+FBti0168726_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280513
+FBti0168727_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280510
+FBti0168727_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280510
+FBti0168728_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280509
+FBti0168728_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280509
+FBti0168729_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280516
+FBti0168729_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280516
+FBti0168730_cas	carries_tool	FBto0000319	FBrf0219767		TOOL DATA from: FBal0280517
+FBti0168730_cas	tagged_with	FBto0000031	FBrf0219767		TOOL DATA from: FBal0280517
+FBti0168731_cas	encodes_tool	FBto0000135	FBrf0213020		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168731_cas	tool_uses	promoter trap	FBrf0213020		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168732_cas	carries_tool	FBto0000349	FBrf0225809		TOOL DATA from: FBal0298308
+FBti0168736_cas	carries_tool	FBto0000349	FBrf0217965		TOOL DATA from: FBal0268277
+FBti0168736_cas	carries_tool	FBto0000356	FBrf0217965		TOOL DATA from: FBal0268277
+FBti0168736_cas	carries_tool	FBto0000349	FBrf0217965		TOOL DATA from: FBal0268280
+FBti0168736_cas	carries_tool	FBto0000356	FBrf0217965		TOOL DATA from: FBal0268280
+FBti0168738_cas	carries_tool	FBto0000349	FBrf0217965		TOOL DATA from: FBal0268278
+FBti0168738_cas	carries_tool	FBto0000356	FBrf0217965		TOOL DATA from: FBal0268278
+FBti0168739_cas	encodes_tool	FBto0000308	FBrf0211884		TOOL DATA from: FBtp0099203, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168739_cas	tool_uses	promoter trap	FBrf0211884		TOOL DATA from: FBtp0099203, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168742_cas	tagged_with	FBto0000027	FBrf0222325		TOOL DATA from: FBal0288693
+FBti0168743_cas	encodes_tool	FBto0000135	FBrf0222578		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168743_cas	tool_uses	promoter trap	FBrf0222578		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168743_cas	carries_tool	FBto0000349	FBrf0222578		TOOL DATA from: FBal0290287
+FBti0168743_cas	carries_tool	FBto0000349	FBrf0222578		TOOL DATA from: FBal0290291
+FBti0168744_cas	carries_tool	FBto0000349	FBrf0201071		TOOL DATA from: FBal0240504
+FBti0168745_cas	carries_tool	FBto0000349	FBrf0201071		TOOL DATA from: FBal0240509
+FBti0168746_cas	encodes_tool	FBto0000135	FBrf0223563		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168746_cas	tool_uses	promoter trap	FBrf0223563		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168749_cas	tagged_with	FBto0000077	FBrf0200445		TOOL DATA from: FBal0242694
+FBti0168750_cas				FTA: unable to add tool information from FBal0219059 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168751_cas	encodes_tool	FBto0000135	FBrf0209074		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168751_cas	tool_uses	promoter trap	FBrf0209074		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168752_cas	carries_tool	FBto0000349	FBrf0225717		TOOL DATA from: FBal0297886
+FBti0168753_cas	carries_tool	FBto0000349	FBrf0227399		TOOL DATA from: FBal0257044
+FBti0168755_cas	carries_tool	FBto0000318	FBrf0218347		TOOL DATA from: FBal0269902
+FBti0168757_cas	carries_tool	FBto0000349	FBrf0212221		TOOL DATA from: FBal0260619
+FBti0168761_cas	carries_tool	FBto0000318	FBrf0211655		TOOL DATA from: FBal0175408
+FBti0168762_cas	carries_tool	FBto0000318	FBrf0211655		TOOL DATA from: FBal0175409
+FBti0168763_cas	encodes_tool	FBto0000135	FBrf0219398		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168763_cas	tool_uses	promoter trap	FBrf0219398		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168764_cas	encodes_tool	FBto0000135	FBrf0219398		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168764_cas	tool_uses	promoter trap	FBrf0219398		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168765_cas				FTA: unable to add tool information from FBal0283278 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168766_cas	carries_tool	FBto0000319	FBrf0219398		TOOL DATA from: FBal0283280
+FBti0168766_cas	carries_tool	FBto0000356	FBrf0219398		TOOL DATA from: FBal0283280
+FBti0168773_cas				FTA: unable to add tool information from FBal0283248 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0168778_cas	carries_tool	FBto0000349	FBrf0218054		TOOL DATA from: FBal0270281
+FBti0168780_cas	carries_tool	FBto0000318	FBrf0205458		TOOL DATA from: FBal0304370
+FBti0168780_cas	carries_tool	FBto0000904	FBrf0205458		TOOL DATA from: FBal0304370
+FBti0168787_cas	carries_tool	FBto0000318	FBrf0167414		TOOL DATA from: FBal0304377
+FBti0168788_cas	carries_tool	FBto0000318	FBrf0160936		TOOL DATA from: FBal0304378
+FBti0168789_cas	carries_tool	FBto0000318	FBrf0160936		TOOL DATA from: FBal0304379
+FBti0168790_cas	carries_tool	FBto0000318	FBrf0160936		TOOL DATA from: FBal0304380
+FBti0168791_cas	carries_tool	FBto0000318	FBrf0160936		TOOL DATA from: FBal0304381
+FBti0168792_cas	carries_tool	FBto0000318	FBrf0198770		TOOL DATA from: FBal0304382
+FBti0168793_cas	carries_tool	FBto0000318	FBrf0159299		TOOL DATA from: FBal0304383
+FBti0168794_cas	carries_tool	FBto0000318	FBrf0205189		TOOL DATA from: FBal0304384
+FBti0168796_cas	carries_tool	FBto0000318	FBrf0179131		TOOL DATA from: FBal0304386
+FBti0168796_cas	carries_tool	FBto0000904	FBrf0179131		TOOL DATA from: FBal0304386
+FBti0168834_cas	encodes_tool	FBto0000135	FBrf0205376		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168834_cas	tool_uses	promoter trap	FBrf0205376		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168920_cas	encodes_tool	FBto0000027	FBrf0228332		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0168920_cas	tool_uses	promoter trap	FBrf0228332		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0169380_cas				FTA: unable to add tool information from FBal0291053 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0178258_cas	carries_tool	FBto0000349	FBrf0208945		TOOL DATA from: FBal0247973
+FBti0178258_cas	carries_tool	FBto0000356	FBrf0208945		TOOL DATA from: FBal0247973
+FBti0178263_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314192
+FBti0178263_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314192
+FBti0178264_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314193
+FBti0178264_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314193
+FBti0178265_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314194
+FBti0178265_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314194
+FBti0178266_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314195
+FBti0178266_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314195
+FBti0178267_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314196
+FBti0178267_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314196
+FBti0178268_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314197
+FBti0178268_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314197
+FBti0178269_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314198
+FBti0178269_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314198
+FBti0178270_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314199
+FBti0178270_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314199
+FBti0178271_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314200
+FBti0178271_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314200
+FBti0178272_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314201
+FBti0178272_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314201
+FBti0178273_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314202
+FBti0178273_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314202
+FBti0178274_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314203
+FBti0178274_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314203
+FBti0178275_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314204
+FBti0178275_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314204
+FBti0178276_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314205
+FBti0178276_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314205
+FBti0178277_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314206
+FBti0178277_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314206
+FBti0178278_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314207
+FBti0178278_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314207
+FBti0178279_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314208
+FBti0178279_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314208
+FBti0178280_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314209
+FBti0178280_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314209
+FBti0178281_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314210
+FBti0178281_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314210
+FBti0178282_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314211
+FBti0178282_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314211
+FBti0178283_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314212
+FBti0178283_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314212
+FBti0178284_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314213
+FBti0178284_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314213
+FBti0178285_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314214
+FBti0178285_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314214
+FBti0178286_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314215
+FBti0178286_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314215
+FBti0178287_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314216
+FBti0178287_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314216
+FBti0178288_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314217
+FBti0178288_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314217
+FBti0178289_cas	tagged_with	FBto0000030	FBrf0228313		TOOL DATA from: FBal0314218
+FBti0178289_cas	tagged_with	FBto0000079	FBrf0228313		TOOL DATA from: FBal0314218
+FBti0180187_cas				FTA: unable to add tool information from FBal0316238 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0180251_cas	carries_tool	FBto0000349	FBrf0229366		TOOL DATA from: FBal0316501
+FBti0180251_cas	carries_tool	FBto0000356	FBrf0229366		TOOL DATA from: FBal0316501
+FBti0180381_cas				FTA: unable to add tool information from FBal0267202 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0180395_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304937
+FBti0180396_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304936
+FBti0180397_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304938
+FBti0180398_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304939
+FBti0180399_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304940
+FBti0180401_cas	carries_tool	FBto0000318	FBrf0228676		TOOL DATA from: FBal0304944
+FBti0180401_cas	carries_tool	FBto0000349	FBrf0228676		TOOL DATA from: FBal0304944
+FBti0180401_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304944
+FBti0180403_cas	carries_tool	FBto0000318	FBrf0228676		TOOL DATA from: FBal0304942
+FBti0180403_cas	carries_tool	FBto0000349	FBrf0228676		TOOL DATA from: FBal0304942
+FBti0180531_cas				FTA: unable to add tool information from FBal0317120 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0180533_cas	carries_tool	FBto0000356	FBrf0229921		TOOL DATA from: FBal0317128
+FBti0180537_cas	carries_tool	FBto0000318	FBrf0229921		TOOL DATA from: FBal0317151
+FBti0180537_cas	carries_tool	FBto0000349	FBrf0229921		TOOL DATA from: FBal0317151
+FBti0180537_cas	carries_tool	FBto0000356	FBrf0229921		TOOL DATA from: FBal0317151
+FBti0181543_cas	encodes_tool	FBto0000135	FBrf0228530		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0181543_cas	tool_uses	promoter trap	FBrf0228530		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0181768_cas	carries_tool	FBto0000349	FBrf0227817		TOOL DATA from: FBal0318359
+FBti0181769_cas	carries_tool	FBto0000349	FBrf0227817		TOOL DATA from: FBal0318360
+FBti0181770_cas	carries_tool	FBto0000349	FBrf0227817		TOOL DATA from: FBal0318361
+FBti0181772_cas	carries_tool	FBto0000349	FBrf0229617		TOOL DATA from: FBal0318382
+FBti0181787_cas	carries_tool	FBto0000349	FBrf0221975		TOOL DATA from: FBal0318439
+FBti0181793_cas	carries_tool	FBto0000318	FBrf0228676		TOOL DATA from: FBal0304943
+FBti0181793_cas	carries_tool	FBto0000349	FBrf0228676		TOOL DATA from: FBal0304943
+FBti0181793_cas	carries_tool	FBto0000356	FBrf0228676		TOOL DATA from: FBal0304943
+FBti0181810_cas	tagged_with	FBto0000121	FBrf0230786		TOOL DATA from: FBal0318490
+FBti0181813_cas	tagged_with	FBto0000031	FBrf0227332		TOOL DATA from: FBal0318505
+FBti0181883_cas	carries_tool	FBto0000349	FBrf0230589		TOOL DATA from: FBal0318727
+FBti0181883_cas	carries_tool	FBto0000356	FBrf0230589		TOOL DATA from: FBal0318727
+FBti0181884_cas	carries_tool	FBto0000349	FBrf0230589		TOOL DATA from: FBal0318728
+FBti0181884_cas	carries_tool	FBto0000356	FBrf0230589		TOOL DATA from: FBal0318728
+FBti0181885_cas	carries_tool	FBto0000349	FBrf0230589		TOOL DATA from: FBal0318730
+FBti0181885_cas	tagged_with	FBto0000076	FBrf0230589		TOOL DATA from: FBal0318730
+FBti0181887_cas				FTA: unable to add tool information from FBal0318747 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0181896_cas				FTA: unable to add tool information from FBal0318789 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0181897_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0181897_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0182057_cas	carries_tool	FBto0000318	FBrf0194622		TOOL DATA from: FBal0219236
+FBti0182101_cas	carries_tool	FBto0000349	FBrf0222842		TOOL DATA from: FBal0319123
+FBti0182131_cas	tagged_with	FBto0000031	FBrf0231866		TOOL DATA from: FBal0319206
+FBti0182150_cas	carries_tool	FBto0000349	FBrf0229285		TOOL DATA from: FBal0319257
+FBti0182157_cas	carries_tool	FBto0000349	FBrf0232113		TOOL DATA from: FBal0319276
+FBti0182157_cas	tagged_with	FBto0000093	FBrf0232113		TOOL DATA from: FBal0319276
+FBti0182249_cas	tagged_with	FBto0000031	FBrf0232306		TOOL DATA from: FBal0319445
+FBti0182250_cas	tagged_with	FBto0000118	FBrf0232306		TOOL DATA from: FBal0319452
+FBti0182581_cas	tagged_with	FBto0000027	FBrf0232493		TOOL DATA from: FBal0319665
+FBti0182663_cas	carries_tool	FBto0000349	FBrf0232358		TOOL DATA from: FBal0319858
+FBti0182663_cas	carries_tool	FBto0000356	FBrf0232358		TOOL DATA from: FBal0319858
+FBti0182701_cas	encodes_tool	FBto0000063	FBrf0232045		TOOL DATA from: FBtp0112818, used single pub_curie from FBti->FBtp producedby f_r
+FBti0182701_cas	tool_uses	promoter trap	FBrf0232045		TOOL DATA from: FBtp0112818, used single pub_curie from FBti->FBtp producedby f_r
+FBti0182701_cas	carries_tool	FBto0000349	FBrf0232045		TOOL DATA from: FBal0320004
+FBti0182712_cas	encodes_tool	FBto0000135	FBrf0227361		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0182712_cas	tool_uses	promoter trap	FBrf0227361		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0182713_cas	encodes_tool	FBto0000135	FBrf0227361		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0182713_cas	tool_uses	promoter trap	FBrf0227361		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0183176_cas	encodes_tool	FBto0000135	FBrf0232779		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0183176_cas	tool_uses	promoter trap	FBrf0232779		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0183608_cas	encodes_tool	FBto0000135	FBrf0233039		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0183608_cas	tool_uses	promoter trap	FBrf0233039		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0184517_cas	carries_tool	FBto0000318	FBrf0233338		TOOL DATA from: FBal0322593
+FBti0184517_cas	carries_tool	FBto0000356	FBrf0233338		TOOL DATA from: FBal0322593
+FBti0184518_cas	carries_tool	FBto0000318	FBrf0233338		TOOL DATA from: FBal0322594
+FBti0184518_cas	carries_tool	FBto0000356	FBrf0233338		TOOL DATA from: FBal0322594
+FBti0184519_cas				FTA: unable to add tool information from FBal0322596 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184520_cas				FTA: unable to add tool information from FBal0322597 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184522_cas				FTA: unable to add tool information from FBal0322599 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184523_cas				FTA: unable to add tool information from FBal0322600 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184524_cas				FTA: unable to add tool information from FBal0322601 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184525_cas				FTA: unable to add tool information from FBal0322602 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184526_cas				FTA: unable to add tool information from FBal0322603 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184527_cas				FTA: unable to add tool information from FBal0322604 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184528_cas				FTA: unable to add tool information from FBal0322605 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184529_cas				FTA: unable to add tool information from FBal0322606 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184530_cas				FTA: unable to add tool information from FBal0322607 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184531_cas				FTA: unable to add tool information from FBal0322608 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184532_cas				FTA: unable to add tool information from FBal0322609 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184533_cas				FTA: unable to add tool information from FBal0322610 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184534_cas				FTA: unable to add tool information from FBal0322611 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184535_cas				FTA: unable to add tool information from FBal0322612 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184536_cas				FTA: unable to add tool information from FBal0322613 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184537_cas				FTA: unable to add tool information from FBal0322614 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184538_cas				FTA: unable to add tool information from FBal0322615 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184539_cas				FTA: unable to add tool information from FBal0322616 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184540_cas				FTA: unable to add tool information from FBal0322617 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184541_cas				FTA: unable to add tool information from FBal0322618 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184542_cas				FTA: unable to add tool information from FBal0322619 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184543_cas				FTA: unable to add tool information from FBal0322620 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184544_cas				FTA: unable to add tool information from FBal0322621 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184545_cas				FTA: unable to add tool information from FBal0322622 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184546_cas				FTA: unable to add tool information from FBal0322623 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184547_cas				FTA: unable to add tool information from FBal0322624 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184548_cas				FTA: unable to add tool information from FBal0322625 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184549_cas				FTA: unable to add tool information from FBal0322626 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184550_cas				FTA: unable to add tool information from FBal0322627 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184551_cas				FTA: unable to add tool information from FBal0322628 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184552_cas				FTA: unable to add tool information from FBal0322629 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184553_cas				FTA: unable to add tool information from FBal0322630 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184554_cas				FTA: unable to add tool information from FBal0322631 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184555_cas				FTA: unable to add tool information from FBal0322632 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184556_cas				FTA: unable to add tool information from FBal0322633 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184557_cas				FTA: unable to add tool information from FBal0322634 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184558_cas				FTA: unable to add tool information from FBal0322635 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184559_cas				FTA: unable to add tool information from FBal0322636 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184560_cas				FTA: unable to add tool information from FBal0322637 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184561_cas				FTA: unable to add tool information from FBal0322638 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184562_cas				FTA: unable to add tool information from FBal0322639 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184563_cas				FTA: unable to add tool information from FBal0322640 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184564_cas				FTA: unable to add tool information from FBal0322641 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184565_cas				FTA: unable to add tool information from FBal0322642 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184566_cas				FTA: unable to add tool information from FBal0322643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184567_cas				FTA: unable to add tool information from FBal0322644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184568_cas				FTA: unable to add tool information from FBal0322645 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184569_cas				FTA: unable to add tool information from FBal0322646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184570_cas				FTA: unable to add tool information from FBal0322647 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184571_cas				FTA: unable to add tool information from FBal0322648 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184572_cas				FTA: unable to add tool information from FBal0322649 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184574_cas				FTA: unable to add tool information from FBal0322651 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184575_cas				FTA: unable to add tool information from FBal0322652 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184576_cas				FTA: unable to add tool information from FBal0322653 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184577_cas				FTA: unable to add tool information from FBal0322654 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184578_cas				FTA: unable to add tool information from FBal0322655 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184581_cas	encodes_tool	FBto0000027	FBrf0233338		TOOL DATA from: FBal0322658
+FBti0184582_cas				FTA: unable to add tool information from FBal0322659 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184583_cas				FTA: unable to add tool information from FBal0322660 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184585_cas				FTA: unable to add tool information from FBal0322662 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184587_cas				FTA: unable to add tool information from FBal0322664 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184588_cas				FTA: unable to add tool information from FBal0322665 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184589_cas				FTA: unable to add tool information from FBal0322666 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184590_cas				FTA: unable to add tool information from FBal0322667 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184591_cas				FTA: unable to add tool information from FBal0322668 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184592_cas				FTA: unable to add tool information from FBal0322669 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184594_cas	carries_tool	FBto0000318	FBrf0233338		TOOL DATA from: FBal0322671
+FBti0184594_cas	carries_tool	FBto0000356	FBrf0233338		TOOL DATA from: FBal0322671
+FBti0184595_cas				FTA: unable to add tool information from FBal0322672 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184596_cas				FTA: unable to add tool information from FBal0322673 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184597_cas				FTA: unable to add tool information from FBal0322674 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184598_cas				FTA: unable to add tool information from FBal0322675 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184599_cas				FTA: unable to add tool information from FBal0322676 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184600_cas				FTA: unable to add tool information from FBal0322677 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184601_cas				FTA: unable to add tool information from FBal0322678 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184602_cas				FTA: unable to add tool information from FBal0322679 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184603_cas				FTA: unable to add tool information from FBal0322680 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184604_cas				FTA: unable to add tool information from FBal0322681 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184605_cas				FTA: unable to add tool information from FBal0322682 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184606_cas				FTA: unable to add tool information from FBal0322683 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184607_cas				FTA: unable to add tool information from FBal0322684 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184608_cas				FTA: unable to add tool information from FBal0322685 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184609_cas				FTA: unable to add tool information from FBal0322686 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184610_cas				FTA: unable to add tool information from FBal0322687 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184611_cas				FTA: unable to add tool information from FBal0322688 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184612_cas				FTA: unable to add tool information from FBal0322689 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184613_cas				FTA: unable to add tool information from FBal0322690 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184614_cas				FTA: unable to add tool information from FBal0322691 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184615_cas				FTA: unable to add tool information from FBal0322692 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184616_cas				FTA: unable to add tool information from FBal0322693 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184617_cas				FTA: unable to add tool information from FBal0322694 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184618_cas				FTA: unable to add tool information from FBal0322695 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184619_cas				FTA: unable to add tool information from FBal0322696 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184620_cas				FTA: unable to add tool information from FBal0322697 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184621_cas				FTA: unable to add tool information from FBal0322698 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184622_cas				FTA: unable to add tool information from FBal0322699 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184623_cas				FTA: unable to add tool information from FBal0322700 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0184630_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322738
+FBti0184630_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322738
+FBti0184631_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322741
+FBti0184631_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322741
+FBti0184632_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322745
+FBti0184632_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322745
+FBti0184633_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322746
+FBti0184633_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322746
+FBti0184634_cas	tagged_with	FBto0000093	FBrf0233126		TOOL DATA from: FBal0322747
+FBti0184634_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322747
+FBti0184635_cas	tagged_with	FBto0000077	FBrf0233126		TOOL DATA from: FBal0322748
+FBti0184635_cas	tagged_with	FBto0000290	FBrf0233126		TOOL DATA from: FBal0322748
+FBti0184655_cas	tagged_with	FBto0000102	FBrf0232696		TOOL DATA from: FBal0322765
+FBti0184967_cas	tagged_with	FBto0000079	FBrf0233328		TOOL DATA from: FBal0322954
+FBti0184969_cas	encodes_tool	FBto0000135	FBrf0233460		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0184969_cas	tool_uses	promoter trap	FBrf0233460		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185073_cas				FTA: unable to add tool information from FBal0323134 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185074_cas	carries_tool	FBto0000349	FBrf0227831		TOOL DATA from: FBal0323135
+FBti0185075_cas	carries_tool	FBto0000318	FBrf0227831		TOOL DATA from: FBal0323136
+FBti0185077_cas	encodes_tool	FBto0000135	FBrf0232112		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185077_cas	tool_uses	promoter trap	FBrf0232112		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185118_cas				FTA: unable to add tool information from FBal0323340 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185119_cas	carries_tool	FBto0000349	FBrf0232350		TOOL DATA from: FBal0323341
+FBti0185120_cas				FTA: unable to add tool information from FBal0323342 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185121_cas				FTA: unable to add tool information from FBal0323343 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185122_cas				FTA: unable to add tool information from FBal0323344 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185281_cas	encodes_tool	FBto0000135	FBrf0233642		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185281_cas	tool_uses	promoter trap	FBrf0233642		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185282_cas	encodes_tool	FBto0000135	FBrf0233642		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185282_cas	tool_uses	promoter trap	FBrf0233642		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185284_cas	encodes_tool	FBto0000135	FBrf0233642		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185284_cas	tool_uses	promoter trap	FBrf0233642		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185285_cas	encodes_tool	FBto0000155	FBrf0105495		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185285_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0185296_cas	tagged_with	FBto0000063	FBrf0230069		TOOL DATA from: FBal0323559
+FBti0185297_cas				FTA: unable to add tool information from FBal0323560 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185298_cas				FTA: unable to add tool information from FBal0323561 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185299_cas				FTA: unable to add tool information from FBal0323562 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185300_cas				FTA: unable to add tool information from FBal0323563 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0185691_cas	carries_tool	FBto0000318	FBrf0230209		TOOL DATA from: FBal0324293
+FBti0185691_cas	carries_tool	FBto0000349	FBrf0230209		TOOL DATA from: FBal0324293
+FBti0185692_cas	carries_tool	FBto0000318	FBrf0230209		TOOL DATA from: FBal0324294
+FBti0185692_cas	carries_tool	FBto0000349	FBrf0230209		TOOL DATA from: FBal0324294
+FBti0186070_cas	tagged_with	FBto0000027	FBrf0233964		TOOL DATA from: FBal0324692
+FBti0186071_cas	tagged_with	FBto0000027	FBrf0233964		TOOL DATA from: FBal0324693
+FBti0186072_cas	tagged_with	FBto0000027	FBrf0233964		TOOL DATA from: FBal0324694
+FBti0186126_cas	carries_tool	FBto0000349	FBrf0215219		TOOL DATA from: FBal0324807
+FBti0186126_cas	carries_tool	FBto0000358	FBrf0215219		TOOL DATA from: FBal0324807
+FBti0186127_cas	carries_tool	FBto0000349	FBrf0215219		TOOL DATA from: FBal0324808
+FBti0186127_cas	carries_tool	FBto0000358	FBrf0215219		TOOL DATA from: FBal0324808
+FBti0186128_cas	carries_tool	FBto0000349	FBrf0215219		TOOL DATA from: FBal0324809
+FBti0186128_cas	carries_tool	FBto0000356	FBrf0215219		TOOL DATA from: FBal0324809
+FBti0186129_cas	carries_tool	FBto0000349	FBrf0215219		TOOL DATA from: FBal0324810
+FBti0186139_cas	encodes_tool	FBto0000135	FBrf0210738		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186139_cas	tool_uses	promoter trap	FBrf0210738		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186161_cas	tagged_with	FBto0000027	FBrf0230384		TOOL DATA from: FBal0324929
+FBti0186162_cas	tagged_with	FBto0000076	FBrf0230384		TOOL DATA from: FBal0324930
+FBti0186163_cas	tagged_with	FBto0000076	FBrf0230384		TOOL DATA from: FBal0324931
+FBti0186164_cas	tagged_with	FBto0000027	FBrf0230384		TOOL DATA from: FBal0324932
+FBti0186198_cas	encodes_tool	FBto0000135	FBrf0234470		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186198_cas	tool_uses	promoter trap	FBrf0234470		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186204_cas	carries_tool	FBto0000349	FBrf0234054		TOOL DATA from: FBal0325082
+FBti0186204_cas	carries_tool	FBto0000356	FBrf0234054		TOOL DATA from: FBal0325082
+FBti0186205_cas	carries_tool	FBto0000349	FBrf0234054		TOOL DATA from: FBal0325083
+FBti0186205_cas	carries_tool	FBto0000356	FBrf0234054		TOOL DATA from: FBal0325083
+FBti0186210_cas	encodes_tool	FBto0000118	FBrf0234010		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186210_cas	tool_uses	promoter trap	FBrf0234010		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186210_cas	tagged_with	FBto0000118	FBrf0234010		TOOL DATA from: FBal0325092
+FBti0186250_cas	tagged_with	FBto0000076	FBrf0234262		TOOL DATA from: FBal0325187
+FBti0186468_cas	tagged_with	FBto0000031	FBrf0234377		TOOL DATA from: FBal0325423
+FBti0186469_cas	tagged_with	FBto0000077	FBrf0234377		TOOL DATA from: FBal0325424
+FBti0186500_cas	encodes_tool	FBto0000118	FBrf0234489		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186500_cas	tool_uses	promoter trap	FBrf0234489		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186500_cas	tagged_with	FBto0000118	FBrf0234489		TOOL DATA from: FBal0325517
+FBti0186503_cas	tagged_with	FBto0000118	FBrf0234661		TOOL DATA from: FBal0325533
+FBti0186504_cas	tagged_with	FBto0000335	FBrf0234661		TOOL DATA from: FBal0325536
+FBti0186505_cas	carries_tool	FBto0000349	FBrf0234661		TOOL DATA from: FBal0325537
+FBti0186505_cas	tool_uses	enhancer trap	FBrf0234661		TOOL DATA from: FBal0325537
+FBti0186505_cas	carries_tool	FBto0000349	FBrf0234661		TOOL DATA from: FBal0325538
+FBti0186505_cas	encodes_tool	FBto0000027	FBrf0234661		TOOL DATA from: FBal0325538
+FBti0186505_cas	tool_uses	enhancer trap	FBrf0234661		TOOL DATA from: FBal0325538
+FBti0186509_cas				FTA: unable to add tool information from FBal0325572 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0186510_cas	carries_tool	FBto0000349	FBrf0234669		TOOL DATA from: FBal0325573
+FBti0186510_cas	carries_tool	FBto0000906	FBrf0234669		TOOL DATA from: FBal0325573
+FBti0186511_cas	carries_tool	FBto0000349	FBrf0234669		TOOL DATA from: FBal0325574
+FBti0186511_cas	carries_tool	FBto0000906	FBrf0234669		TOOL DATA from: FBal0325574
+FBti0186514_cas	carries_tool	FBto0000349	FBrf0234758		TOOL DATA from: FBal0325576
+FBti0186514_cas	carries_tool	FBto0000356	FBrf0234758		TOOL DATA from: FBal0325576
+FBti0186515_cas	carries_tool	FBto0000349	FBrf0234758		TOOL DATA from: FBal0325577
+FBti0186515_cas	carries_tool	FBto0000356	FBrf0234758		TOOL DATA from: FBal0325577
+FBti0186540_cas				FTA: unable to add tool information from FBal0325646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0186555_cas	encodes_tool	FBto0000135	FBrf0235037		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186555_cas	tool_uses	promoter trap	FBrf0235037		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186555_cas				FTA: unable to add tool information from FBal0290246 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0186559_cas	encodes_tool	FBto0000118	FBrf0231009		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186559_cas	tool_uses	promoter trap	FBrf0231009		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186559_cas				FTA: unable to add tool information from FBal0325667 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0186561_cas	carries_tool	FBto0000356	FBrf0233649		TOOL DATA from: FBal0325675
+FBti0186571_cas	tagged_with	FBto0000102	FBrf0232854		TOOL DATA from: FBal0325770
+FBti0186572_cas	encodes_tool	FBto0000146	FBrf0234085		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186572_cas	tool_uses	promoter trap	FBrf0234085		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0186857_cas	tagged_with	FBto0000076	FBrf0234011		TOOL DATA from: FBal0326180
+FBti0186857_cas	tagged_with	FBto0000118	FBrf0234011		TOOL DATA from: FBal0326180
+FBti0186933_cas	tagged_with	FBto0000076	FBrf0235527		TOOL DATA from: FBal0326318
+FBti0186933_cas	tagged_with	FBto0000102	FBrf0235527		TOOL DATA from: FBal0326318
+FBti0186934_cas	tagged_with	FBto0000102	FBrf0235527		TOOL DATA from: FBal0326320
+FBti0186935_cas	carries_tool	FBto0000349	FBrf0235210		TOOL DATA from: FBal0326334
+FBti0186936_cas	carries_tool	FBto0000349	FBrf0235210		TOOL DATA from: FBal0326335
+FBti0186936_cas	tagged_with	FBto0000050	FBrf0235210		TOOL DATA from: FBal0326335
+FBti0186937_cas	carries_tool	FBto0000349	FBrf0235210		TOOL DATA from: FBal0326338
+FBti0186937_cas	tagged_with	FBto0000126	FBrf0235210		TOOL DATA from: FBal0326338
+FBti0187205_cas	tagged_with	FBto0000079	FBrf0231243		TOOL DATA from: FBal0326557
+FBti0187205_cas	tagged_with	FBto0000104	FBrf0231243		TOOL DATA from: FBal0326557
+FBti0187206_cas	carries_tool	FBto0000349	FBrf0235936		TOOL DATA from: FBal0326563
+FBti0187206_cas	tagged_with	FBto0000126	FBrf0235936		TOOL DATA from: FBal0326563
+FBti0187207_cas	carries_tool	FBto0000349	FBrf0235936		TOOL DATA from: FBal0326564
+FBti0187208_cas	carries_tool	FBto0000349	FBrf0235936		TOOL DATA from: FBal0326565
+FBti0187208_cas	tagged_with	FBto0000050	FBrf0235936		TOOL DATA from: FBal0326565
+FBti0187209_cas	carries_tool	FBto0000349	FBrf0235590		TOOL DATA from: FBal0323541
+FBti0187210_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326569
+FBti0187210_cas	carries_tool	FBto0000356	FBrf0229826		TOOL DATA from: FBal0326569
+FBti0187211_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326570
+FBti0187211_cas	carries_tool	FBto0000356	FBrf0229826		TOOL DATA from: FBal0326570
+FBti0187212_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326571
+FBti0187213_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326572
+FBti0187214_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326573
+FBti0187215_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326574
+FBti0187216_cas	carries_tool	FBto0000349	FBrf0229826		TOOL DATA from: FBal0326575
+FBti0187230_cas	tagged_with	FBto0000027	FBrf0231133		TOOL DATA from: FBal0326609
+FBti0187233_cas	tagged_with	FBto0000031	FBrf0230799		TOOL DATA from: FBal0326612
+FBti0187234_cas	carries_tool	FBto0000349	FBrf0235055		TOOL DATA from: FBal0326664
+FBti0187234_cas	tagged_with	FBto0000031	FBrf0235055		TOOL DATA from: FBal0326664
+FBti0187235_cas				FTA: unable to add tool information from FBal0326665 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0187236_cas				FTA: unable to add tool information from FBal0326684 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0187237_cas	tagged_with	FBto0000031	FBrf0230432		TOOL DATA from: FBal0326685
+FBti0187240_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0187240_cas	tool_uses	gene trap	FBrf0105495		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0187287_cas				FTA: unable to add tool information from FBal0326705 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0187298_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326723
+FBti0187298_cas	carries_tool	FBto0000356	FBrf0235648		TOOL DATA from: FBal0326723
+FBti0187299_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326724
+FBti0187299_cas	carries_tool	FBto0000356	FBrf0235648		TOOL DATA from: FBal0326724
+FBti0187300_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326725
+FBti0187301_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326726
+FBti0187302_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326727
+FBti0187303_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326728
+FBti0187304_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326729
+FBti0187305_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326730
+FBti0187306_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326731
+FBti0187307_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326732
+FBti0187307_cas	tagged_with	FBto0000118	FBrf0235648		TOOL DATA from: FBal0326732
+FBti0187308_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326733
+FBti0187308_cas	tagged_with	FBto0000118	FBrf0235648		TOOL DATA from: FBal0326733
+FBti0187309_cas	carries_tool	FBto0000349	FBrf0235648		TOOL DATA from: FBal0326734
+FBti0187309_cas	tagged_with	FBto0000118	FBrf0235648		TOOL DATA from: FBal0326734
+FBti0187310_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326741
+FBti0187311_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326742
+FBti0187312_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326743
+FBti0187313_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326744
+FBti0187314_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326745
+FBti0187315_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326746
+FBti0187316_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326747
+FBti0187317_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326748
+FBti0187318_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326749
+FBti0187319_cas	carries_tool	FBto0000349	FBrf0233673		TOOL DATA from: FBal0326750
+FBti0187320_cas	has_reg_region	FBto0000180	FBrf0235396		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0187320_cas	tool_uses	misexpression element	FBrf0235396		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0187320_cas	carries_tool	FBto0000349	FBrf0235396		TOOL DATA from: FBal0326765
+FBti0187321_cas	carries_tool	FBto0000349	FBrf0235396		TOOL DATA from: FBal0326766
+FBti0187332_cas				FTA: unable to add tool information from FBal0326958 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0187333_cas	encodes_tool	FBto0000135	FBrf0235434		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0187333_cas	tool_uses	promoter trap	FBrf0235434		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0187365_cas	carries_tool	FBto0000318	FBrf0235353		TOOL DATA from: FBal0327010
+FBti0187365_cas	tagged_with	FBto0000077	FBrf0235353		TOOL DATA from: FBal0327010
+FBti0187369_cas	encodes_tool	FBto0000135	FBrf0235764		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0187369_cas	tool_uses	promoter trap	FBrf0235764		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0187374_cas	tagged_with	FBto0000009	FBrf0233082		TOOL DATA from: FBal0327048
+FBti0187375_cas	tagged_with	FBto0000009	FBrf0233082		TOOL DATA from: FBal0327049
+FBti0187376_cas	tagged_with	FBto0000009	FBrf0233082		TOOL DATA from: FBal0327050
+FBti0187401_cas	tagged_with	FBto0000027	FBrf0235933		TOOL DATA from: FBal0327217
+FBti0187478_cas	tagged_with	FBto0000079	FBrf0210059		TOOL DATA from: FBal0242713
+FBti0187483_cas	carries_tool	FBto0000349	FBrf0223774		TOOL DATA from: FBal0327577
+FBti0187483_cas	tagged_with	FBto0000093	FBrf0223774		TOOL DATA from: FBal0327577
+FBti0187484_cas	carries_tool	FBto0000349	FBrf0223774		TOOL DATA from: FBal0327578
+FBti0187484_cas	tagged_with	FBto0000093	FBrf0223774		TOOL DATA from: FBal0327578
+FBti0187492_cas	carries_tool	FBto0000349	FBrf0235096		TOOL DATA from: FBal0327603
+FBti0187492_cas	tagged_with	FBto0000027	FBrf0235096		TOOL DATA from: FBal0327603
+FBti0187492_cas	tagged_with	FBto0000307	FBrf0235096		TOOL DATA from: FBal0327603
+FBti0187606_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0187606_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0194879_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335391
+FBti0194879_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335391
+FBti0194879_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335391
+FBti0194880_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335394
+FBti0194880_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335394
+FBti0194880_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335394
+FBti0194881_cas				FTA: unable to add tool information from FBal0335395 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194882_cas				FTA: unable to add tool information from FBal0335397 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194884_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335400
+FBti0194884_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335400
+FBti0194884_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335400
+FBti0194885_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335402
+FBti0194885_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335402
+FBti0194885_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335402
+FBti0194886_cas				FTA: unable to add tool information from FBal0335403 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194887_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335405
+FBti0194887_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335405
+FBti0194887_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335405
+FBti0194888_cas				FTA: unable to add tool information from FBal0335406 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194889_cas				FTA: unable to add tool information from FBal0335407 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194890_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335408
+FBti0194890_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335408
+FBti0194890_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335408
+FBti0194891_cas				FTA: unable to add tool information from FBal0335409 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194892_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335410
+FBti0194892_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335410
+FBti0194892_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335410
+FBti0194893_cas				FTA: unable to add tool information from FBal0335412 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194894_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335414
+FBti0194894_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335414
+FBti0194894_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335414
+FBti0194895_cas				FTA: unable to add tool information from FBal0335415 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194896_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335417
+FBti0194896_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335417
+FBti0194896_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335417
+FBti0194897_cas				FTA: unable to add tool information from FBal0335418 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0194898_cas	carries_tool	FBto0000349	FBrf0236101		TOOL DATA from: FBal0335420
+FBti0194898_cas	tagged_with	FBto0000077	FBrf0236101		TOOL DATA from: FBal0335420
+FBti0194898_cas	tagged_with	FBto0000083	FBrf0236101		TOOL DATA from: FBal0335420
+FBti0195115_cas				FTA: unable to add tool information from FBal0335646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195143_cas				FTA: unable to add tool information from FBal0335708 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195148_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335733
+FBti0195148_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335737
+FBti0195148_cas	tagged_with	FBto0000076	FBrf0236011		TOOL DATA from: FBal0335737
+FBti0195149_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335734
+FBti0195149_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335738
+FBti0195149_cas	tagged_with	FBto0000076	FBrf0236011		TOOL DATA from: FBal0335738
+FBti0195150_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335735
+FBti0195150_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335739
+FBti0195150_cas	tagged_with	FBto0000076	FBrf0236011		TOOL DATA from: FBal0335739
+FBti0195151_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335736
+FBti0195151_cas	carries_tool	FBto0000349	FBrf0236011		TOOL DATA from: FBal0335740
+FBti0195151_cas	tagged_with	FBto0000076	FBrf0236011		TOOL DATA from: FBal0335740
+FBti0195509_cas	encodes_tool	FBto0000118	FBrf0105495		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0195509_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0195509_cas	carries_tool	FBto0000349	FBrf0236381		TOOL DATA from: FBal0336285
+FBti0195509_cas	carries_tool	FBto0000349	FBrf0236381		TOOL DATA from: FBal0338392
+FBti0195675_cas				FTA: unable to add tool information from FBal0336599 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195677_cas	carries_tool	FBto0000349	FBrf0228397		TOOL DATA from: FBal0336602
+FBti0195677_cas	carries_tool	FBto0000356	FBrf0228397		TOOL DATA from: FBal0336602
+FBti0195678_cas	encodes_tool	FBto0000140	FBrf0105495		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0195678_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0195689_cas				FTA: unable to add tool information from FBal0336630 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195700_cas	tagged_with	FBto0000048	FBrf0236304		TOOL DATA from: FBal0336671
+FBti0195703_cas	tagged_with	FBto0000093	FBrf0236304		TOOL DATA from: FBal0336674
+FBti0195704_cas	tagged_with	FBto0000077	FBrf0236304		TOOL DATA from: FBal0336675
+FBti0195705_cas	tagged_with	FBto0000048	FBrf0236304		TOOL DATA from: FBal0336676
+FBti0195706_cas	tagged_with	FBto0000048	FBrf0236304		TOOL DATA from: FBal0336677
+FBti0195739_cas	tagged_with	FBto0000031	FBrf0237362		TOOL DATA from: FBal0336721
+FBti0195937_cas	carries_tool	FBto0000349	FBrf0237099		TOOL DATA from: FBal0336933
+FBti0195938_cas	carries_tool	FBto0000349	FBrf0237099		TOOL DATA from: FBal0325865
+FBti0195939_cas	encodes_tool	FBto0000135	FBrf0237308		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0195939_cas	tool_uses	promoter trap	FBrf0237308		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0195939_cas	carries_tool	FBto0000349	FBrf0237308		TOOL DATA from: FBal0336935
+FBti0195939_cas	carries_tool	FBto0000349	FBrf0237308		TOOL DATA from: FBal0336938
+FBti0195940_cas	carries_tool	FBto0000349	FBrf0237308		TOOL DATA from: FBal0336936
+FBti0195950_cas				FTA: unable to add tool information from FBal0305166 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0195951_cas	carries_tool	FBto0000349	FBrf0221715		TOOL DATA from: FBal0305165
+FBti0195951_cas	carries_tool	FBto0000356	FBrf0221715		TOOL DATA from: FBal0305165
+FBti0195955_cas	carries_tool	FBto0000356	FBrf0229921		TOOL DATA from: FBal0317152
+FBti0195959_cas	carries_tool	FBto0000349	FBrf0205704		TOOL DATA from: FBal0264687
+FBti0196133_cas	tagged_with	FBto0000076	FBrf0237868		TOOL DATA from: FBal0337130
+FBti0196134_cas	tagged_with	FBto0000093	FBrf0237868		TOOL DATA from: FBal0337131
+FBti0196135_cas	tagged_with	FBto0000076	FBrf0237869		TOOL DATA from: FBal0337132
+FBti0196565_cas	tagged_with	FBto0000093	FBrf0237716		TOOL DATA from: FBal0337832
+FBti0196566_cas				FTA: unable to add tool information from FBal0337839 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0196567_cas	carries_tool	FBto0000349	FBrf0237630		TOOL DATA from: FBal0337847
+FBti0196567_cas	tagged_with	FBto0000063	FBrf0237630		TOOL DATA from: FBal0337847
+FBti0196568_cas	carries_tool	FBto0000349	FBrf0237630		TOOL DATA from: FBal0337848
+FBti0196568_cas	tagged_with	FBto0000118	FBrf0237630		TOOL DATA from: FBal0337848
+FBti0196569_cas	carries_tool	FBto0000349	FBrf0237630		TOOL DATA from: FBal0337849
+FBti0196569_cas	tagged_with	FBto0000118	FBrf0237630		TOOL DATA from: FBal0337849
+FBti0196589_cas	carries_tool	FBto0000349	FBrf0237104		TOOL DATA from: FBal0337891
+FBti0196590_cas	carries_tool	FBto0000349	FBrf0237104		TOOL DATA from: FBal0337892
+FBti0196634_cas	tagged_with	FBto0000027	FBrf0236131		TOOL DATA from: FBal0337945
+FBti0196641_cas	tagged_with	FBto0000031	FBrf0235878		TOOL DATA from: FBal0337951
+FBti0196646_cas	encodes_tool	FBto0000155	FBrf0105495		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0196646_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0196658_cas	carries_tool	FBto0000349	FBrf0237501		TOOL DATA from: FBal0338001
+FBti0196659_cas	tagged_with	FBto0000063	FBrf0237501		TOOL DATA from: FBal0338002
+FBti0196693_cas				FTA: unable to add tool information from FBal0338099 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0197170_cas				FTA: unable to add tool information from FBal0338153 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0197292_cas	carries_tool	FBto0000349	FBrf0232176		TOOL DATA from: FBal0338155
+FBti0197292_cas	tagged_with	FBto0000102	FBrf0232176		TOOL DATA from: FBal0338155
+FBti0197293_cas	carries_tool	FBto0000349	FBrf0232176		TOOL DATA from: FBal0338156
+FBti0197293_cas	tagged_with	FBto0000102	FBrf0232176		TOOL DATA from: FBal0338156
+FBti0199344_cas	tagged_with	FBto0000027	FBrf0238107		TOOL DATA from: FBal0340475
+FBti0199344_cas	tagged_with	FBto0000087	FBrf0238107		TOOL DATA from: FBal0340475
+FBti0199344_cas	tagged_with	FBto0000299	FBrf0238107		TOOL DATA from: FBal0340475
+FBti0199345_cas	tagged_with	FBto0000027	FBrf0238107		TOOL DATA from: FBal0340479
+FBti0199345_cas	tagged_with	FBto0000087	FBrf0238107		TOOL DATA from: FBal0340479
+FBti0199345_cas	tagged_with	FBto0000299	FBrf0238107		TOOL DATA from: FBal0340479
+FBti0199346_cas	tagged_with	FBto0000027	FBrf0238107		TOOL DATA from: FBal0340494
+FBti0199346_cas	tagged_with	FBto0000087	FBrf0238107		TOOL DATA from: FBal0340494
+FBti0199346_cas	tagged_with	FBto0000299	FBrf0238107		TOOL DATA from: FBal0340494
+FBti0199347_cas	tagged_with	FBto0000027	FBrf0238107		TOOL DATA from: FBal0340496
+FBti0199347_cas	tagged_with	FBto0000087	FBrf0238107		TOOL DATA from: FBal0340496
+FBti0199347_cas	tagged_with	FBto0000299	FBrf0238107		TOOL DATA from: FBal0340496
+FBti0199495_cas	carries_tool	FBto0000356	FBrf0239544		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0199495_cas	tool_uses	docking element	FBrf0239544		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0199496_cas	encodes_tool	FBto0000063	FBrf0239545		TOOL DATA from: FBtp0112818, used single pub_curie from FBti->FBtp producedby f_r
+FBti0199496_cas	tool_uses	promoter trap	FBrf0239545		TOOL DATA from: FBtp0112818, used single pub_curie from FBti->FBtp producedby f_r
+FBti0199500_cas	encodes_tool	FBto0000135	FBrf0238268		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0199500_cas	tool_uses	promoter trap	FBrf0238268		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0199536_cas	encodes_tool	FBto0000135	FBrf0237201		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0199536_cas	tool_uses	promoter trap	FBrf0237201		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0199536_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0340857
+FBti0199536_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0340858
+FBti0199537_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0340859
+FBti0199537_cas	tagged_with	FBto0000031	FBrf0239978		TOOL DATA from: FBal0340859
+FBti0199701_cas	tagged_with	FBto0000076	FBrf0238411		TOOL DATA from: FBal0341184
+FBti0200064_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341589
+FBti0200065_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341590
+FBti0200066_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341591
+FBti0200067_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341592
+FBti0200069_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341594
+FBti0200075_cas	tagged_with	FBto0000076	FBrf0239826		TOOL DATA from: FBal0341600
+FBti0200077_cas	tagged_with	FBto0000076	FBrf0239826		TOOL DATA from: FBal0341602
+FBti0200079_cas	tagged_with	FBto0000027	FBrf0239826		TOOL DATA from: FBal0341604
+FBti0200124_cas				FTA: unable to add tool information from FBal0341667 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0200149_cas	tagged_with	FBto0000027	FBrf0238077		TOOL DATA from: FBal0341720
+FBti0200436_cas	carries_tool	FBto0000349	FBrf0168001		TOOL DATA from: FBal0151319
+FBti0200437_cas	carries_tool	FBto0000349	FBrf0168001		TOOL DATA from: FBal0151318
+FBti0200438_cas	carries_tool	FBto0000349	FBrf0168001		TOOL DATA from: FBal0151317
+FBti0200439_cas	carries_tool	FBto0000349	FBrf0168001		TOOL DATA from: FBal0151316
+FBti0200474_cas	carries_tool	FBto0000349	FBrf0195007		TOOL DATA from: FBal0193352
+FBti0200475_cas	carries_tool	FBto0000349	FBrf0195007		TOOL DATA from: FBal0193354
+FBti0200476_cas	carries_tool	FBto0000349	FBrf0195007		TOOL DATA from: FBal0193353
+FBti0200485_cas	carries_tool	FBto0000349	FBrf0205704		TOOL DATA from: FBal0264685
+FBti0200494_cas	tagged_with	FBto0000093	FBrf0239943		TOOL DATA from: FBal0342156
+FBti0201288_cas	tagged_with	FBto0000063	FBrf0239562		TOOL DATA from: FBal0343279
+FBti0201289_cas	tagged_with	FBto0000099	FBrf0239562		TOOL DATA from: FBal0343281
+FBti0201290_cas	tagged_with	FBto0000063	FBrf0239562		TOOL DATA from: FBal0343282
+FBti0201291_cas	encodes_tool	FBto0000135	FBrf0238699		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201291_cas	tool_uses	promoter trap	FBrf0238699		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201293_cas	tagged_with	FBto0000027	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201293_cas	tagged_with	FBto0000076	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201293_cas	tagged_with	FBto0000088	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201293_cas	tagged_with	FBto0000287	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201293_cas	tagged_with	FBto0000341	FBrf0238699		TOOL DATA from: FBal0343288
+FBti0201400_cas	tagged_with	FBto0000027	FBrf0239362		TOOL DATA from: FBal0343422
+FBti0201401_cas	tagged_with	FBto0000031	FBrf0238947		TOOL DATA from: FBal0343435
+FBti0201402_cas	tagged_with	FBto0000031	FBrf0238947		TOOL DATA from: FBal0343436
+FBti0201403_cas	tagged_with	FBto0000031	FBrf0238947		TOOL DATA from: FBal0343437
+FBti0201418_cas	tagged_with	FBto0000079	FBrf0238295		TOOL DATA from: FBal0343477
+FBti0201419_cas	encodes_tool	FBto0000118	FBrf0238110		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201419_cas	tool_uses	promoter trap	FBrf0238110		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201419_cas	carries_tool	FBto0000349	FBrf0238110		TOOL DATA from: FBal0343484
+FBti0201423_cas	tagged_with	FBto0000118	FBrf0238554		TOOL DATA from: FBal0343494
+FBti0201424_cas	tagged_with	FBto0000031	FBrf0238554		TOOL DATA from: FBal0343495
+FBti0201616_cas				FTA: unable to add tool information from FBal0343772 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0201617_cas				FTA: unable to add tool information from FBal0343773 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0201620_cas	encodes_tool	FBto0000135	FBrf0240518		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201620_cas	tool_uses	promoter trap	FBrf0240518		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201620_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0343779
+FBti0201620_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0343780
+FBti0201620_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0343780
+FBti0201624_cas	encodes_tool	FBto0000155	FBrf0229653		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201624_cas	tool_uses	promoter trap	FBrf0229653		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201625_cas	tagged_with	FBto0000118	FBrf0233664		TOOL DATA from: FBal0343784
+FBti0201627_cas	encodes_tool	FBto0000135	FBrf0240321		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201627_cas	tool_uses	promoter trap	FBrf0240321		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201675_cas	carries_tool	FBto0000349	FBrf0235164		TOOL DATA from: FBal0343834
+FBti0201676_cas	encodes_tool	FBto0000155	FBrf0233288		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201676_cas	tool_uses	promoter trap	FBrf0233288		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201762_cas	tagged_with	FBto0000093	FBrf0240113		TOOL DATA from: FBal0343993
+FBti0201817_cas	encodes_tool	FBto0000146	FBrf0232698		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201817_cas	tool_uses	promoter trap	FBrf0232698		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0201834_cas	tagged_with	FBto0000031	FBrf0238979		TOOL DATA from: FBal0344142
+FBti0201835_cas	carries_tool	FBto0000349	FBrf0238979		TOOL DATA from: FBal0344143
+FBti0201835_cas	tagged_with	FBto0000375	FBrf0238979		TOOL DATA from: FBal0344143
+FBti0201847_cas				FTA: unable to add tool information from FBal0344213 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0201848_cas	tagged_with	FBto0000027	FBrf0239135		TOOL DATA from: FBal0344225
+FBti0201849_cas	tagged_with	FBto0000027	FBrf0239006		TOOL DATA from: FBal0344227
+FBti0201850_cas	tagged_with	FBto0000027	FBrf0239006		TOOL DATA from: FBal0344228
+FBti0202051_cas	tagged_with	FBto0000079	FBrf0238006		TOOL DATA from: FBal0344449
+FBti0202058_cas	tagged_with	FBto0000375	FBrf0238867		TOOL DATA from: FBal0344479
+FBti0202074_cas	tagged_with	FBto0000027	FBrf0219618		TOOL DATA from: FBal0344517
+FBti0202076_cas				FTA: unable to add tool information from FBal0344556 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202095_cas				FTA: unable to add tool information from FBal0344599 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202096_cas	tagged_with	FBto0000118	FBrf0238804		TOOL DATA from: FBal0344600
+FBti0202099_cas	tagged_with	FBto0000063	FBrf0240552		TOOL DATA from: FBal0344640
+FBti0202100_cas	tagged_with	FBto0000076	FBrf0240552		TOOL DATA from: FBal0344641
+FBti0202102_cas				FTA: unable to add tool information from FBal0344650 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202113_cas	tagged_with	FBto0000070	FBrf0239381		TOOL DATA from: FBal0344708
+FBti0202114_cas	tagged_with	FBto0000070	FBrf0239381		TOOL DATA from: FBal0344709
+FBti0202123_cas	tagged_with	FBto0000070	FBrf0239381		TOOL DATA from: FBal0344718
+FBti0202141_cas	encodes_tool	FBto0000135	FBrf0237214		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202141_cas	tool_uses	promoter trap	FBrf0237214		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202206_cas	carries_tool	FBto0000349	FBrf0235475		TOOL DATA from: FBal0344892
+FBti0202206_cas	tagged_with	FBto0000063	FBrf0235475		TOOL DATA from: FBal0344892
+FBti0202207_cas	carries_tool	FBto0000349	FBrf0235475		TOOL DATA from: FBal0344893
+FBti0202207_cas	tagged_with	FBto0000063	FBrf0235475		TOOL DATA from: FBal0344893
+FBti0202224_cas	encodes_tool	FBto0000143	FBrf0240803		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202224_cas	tool_uses	promoter trap	FBrf0240803		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202224_cas	carries_tool	FBto0000349	FBrf0240803		TOOL DATA from: FBal0344966
+FBti0202224_cas	carries_tool	FBto0000349	FBrf0240803		TOOL DATA from: FBal0344970
+FBti0202225_cas	encodes_tool	FBto0000143	FBrf0240803		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202225_cas	tool_uses	promoter trap	FBrf0240803		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202225_cas	carries_tool	FBto0000349	FBrf0240803		TOOL DATA from: FBal0344967
+FBti0202225_cas	carries_tool	FBto0000349	FBrf0240803		TOOL DATA from: FBal0344968
+FBti0202231_cas				FTA: unable to add tool information from FBal0345003 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202232_cas				FTA: unable to add tool information from FBal0345004 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202236_cas	tagged_with	FBto0000063	FBrf0240615		TOOL DATA from: FBal0345011
+FBti0202237_cas	tagged_with	FBto0000118	FBrf0240615		TOOL DATA from: FBal0345014
+FBti0202241_cas				FTA: unable to add tool information from FBal0345026 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202242_cas	carries_tool	FBto0000349	FBrf0237568		TOOL DATA from: FBal0345027
+FBti0202243_cas	carries_tool	FBto0000349	FBrf0237568		TOOL DATA from: FBal0345028
+FBti0202243_cas	tagged_with	FBto0000031	FBrf0237568		TOOL DATA from: FBal0345028
+FBti0202244_cas				FTA: unable to add tool information from FBal0345029 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202245_cas				FTA: unable to add tool information from FBal0345030 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202246_cas				FTA: unable to add tool information from FBal0345031 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202247_cas	carries_tool	FBto0000349	FBrf0237568		TOOL DATA from: FBal0345032
+FBti0202248_cas				FTA: unable to add tool information from FBal0345033 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202249_cas				FTA: unable to add tool information from FBal0345034 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202251_cas	carries_tool	FBto0000356	FBrf0240135		TOOL DATA from: FBal0345042
+FBti0202267_cas	encodes_tool	FBto0000118	FBrf0238358		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202267_cas	tool_uses	promoter trap	FBrf0238358		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202267_cas	carries_tool	FBto0000320	FBrf0238358		TOOL DATA from: FBal0345092
+FBti0202267_cas	carries_tool	FBto0000349	FBrf0238358		TOOL DATA from: FBal0345092
+FBti0202267_cas	carries_tool	FBto0000356	FBrf0238358		TOOL DATA from: FBal0345092
+FBti0202267_cas	carries_tool	FBto0000320	FBrf0238358		TOOL DATA from: FBal0345094
+FBti0202267_cas	carries_tool	FBto0000349	FBrf0238358		TOOL DATA from: FBal0345094
+FBti0202267_cas	carries_tool	FBto0000356	FBrf0238358		TOOL DATA from: FBal0345094
+FBti0202267_cas	tagged_with	FBto0000205	FBrf0238358		TOOL DATA from: FBal0345094
+FBti0202270_cas	encodes_tool	FBto0000031	FBrf0240566		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202270_cas	tool_uses	promoter trap	FBrf0240566		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202270_cas	carries_tool	FBto0000349	FBrf0240566		TOOL DATA from: FBal0345145
+FBti0202270_cas	carries_tool	FBto0000356	FBrf0240566		TOOL DATA from: FBal0345145
+FBti0202270_cas	carries_tool	FBto0000349	FBrf0240566		TOOL DATA from: FBal0345148
+FBti0202270_cas	carries_tool	FBto0000356	FBrf0240566		TOOL DATA from: FBal0345148
+FBti0202271_cas	encodes_tool	FBto0000118	FBrf0240566		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202271_cas	tool_uses	promoter trap	FBrf0240566		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202272_cas	carries_tool	FBto0000349	FBrf0240422		TOOL DATA from: FBal0345149
+FBti0202273_cas	carries_tool	FBto0000349	FBrf0240422		TOOL DATA from: FBal0345150
+FBti0202273_cas	tagged_with	FBto0000031	FBrf0240422		TOOL DATA from: FBal0345150
+FBti0202276_cas	tagged_with	FBto0000093	FBrf0238737		TOOL DATA from: FBal0345155
+FBti0202277_cas	tagged_with	FBto0000093	FBrf0238737		TOOL DATA from: FBal0345156
+FBti0202278_cas				FTA: unable to add tool information from FBal0345159 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202588_cas				FTA: unable to add tool information from FBal0345503 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202599_cas	tagged_with	FBto0000031	FBrf0241227		TOOL DATA from: FBal0345526
+FBti0202625_cas	carries_tool	FBto0000349	FBrf0241173		TOOL DATA from: FBal0345565
+FBti0202626_cas	carries_tool	FBto0000349	FBrf0241173		TOOL DATA from: FBal0345568
+FBti0202626_cas	carries_tool	FBto0000356	FBrf0241173		TOOL DATA from: FBal0345568
+FBti0202627_cas	carries_tool	FBto0000349	FBrf0241173		TOOL DATA from: FBal0345569
+FBti0202627_cas	tagged_with	FBto0000118	FBrf0241173		TOOL DATA from: FBal0345569
+FBti0202629_cas	tagged_with	FBto0000027	FBrf0240126		TOOL DATA from: FBal0345598
+FBti0202649_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345672
+FBti0202649_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345672
+FBti0202649_cas	carries_tool	FBto0000356	FBrf0229738		TOOL DATA from: FBal0345672
+FBti0202650_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345673
+FBti0202650_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345673
+FBti0202651_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345674
+FBti0202651_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345674
+FBti0202652_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345675
+FBti0202652_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345675
+FBti0202653_cas	carries_tool	FBto0000318	FBrf0229738		TOOL DATA from: FBal0345676
+FBti0202653_cas	carries_tool	FBto0000349	FBrf0229738		TOOL DATA from: FBal0345676
+FBti0202938_cas				FTA: unable to add tool information from FBal0346048 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202946_cas				FTA: unable to add tool information from FBal0346063 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202947_cas				FTA: unable to add tool information from FBal0346064 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0202948_cas	encodes_tool	FBto0000135	FBrf0241362		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202948_cas	tool_uses	promoter trap	FBrf0241362		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202972_cas	carries_tool	FBto0000356	FBrf0226270		TOOL DATA from: FBal0346121
+FBti0202974_cas	encodes_tool	FBto0000135	FBrf0226270		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202974_cas	tool_uses	promoter trap	FBrf0226270		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202976_cas	encodes_tool	FBto0000135	FBrf0226270		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202976_cas	tool_uses	promoter trap	FBrf0226270		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202979_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346130
+FBti0202979_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346130
+FBti0202980_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346131
+FBti0202980_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346131
+FBti0202981_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346132
+FBti0202981_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346132
+FBti0202982_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346133
+FBti0202982_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346133
+FBti0202983_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346134
+FBti0202983_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346134
+FBti0202984_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346135
+FBti0202984_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346135
+FBti0202985_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346136
+FBti0202985_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346136
+FBti0202986_cas	carries_tool	FBto0000318	FBrf0236132		TOOL DATA from: FBal0346137
+FBti0202986_cas	carries_tool	FBto0000349	FBrf0236132		TOOL DATA from: FBal0346137
+FBti0202987_cas	encodes_tool	FBto0000118	FBrf0241414		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202987_cas	tool_uses	promoter trap	FBrf0241414		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0202987_cas				FTA: unable to add tool information from FBal0346145 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203001_cas	carries_tool	FBto0000318	FBrf0241011		TOOL DATA from: FBal0346216
+FBti0203001_cas	carries_tool	FBto0000349	FBrf0241011		TOOL DATA from: FBal0346216
+FBti0203015_cas				FTA: unable to add tool information from FBal0346245 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203021_cas	encodes_tool	FBto0000031	FBrf0241271		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203021_cas	tool_uses	promoter trap	FBrf0241271		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203026_cas				FTA: unable to add tool information from FBal0346268 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203027_cas	carries_tool	FBto0000349	FBrf0241193		TOOL DATA from: FBal0346271
+FBti0203027_cas	carries_tool	FBto0000356	FBrf0241193		TOOL DATA from: FBal0346271
+FBti0203031_cas				FTA: unable to add tool information from FBal0346301 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203032_cas				FTA: unable to add tool information from FBal0346304 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203033_cas	carries_tool	FBto0000349	FBrf0241758		TOOL DATA from: FBal0346308
+FBti0203034_cas	carries_tool	FBto0000349	FBrf0231596		TOOL DATA from: FBal0346317
+FBti0203034_cas	tagged_with	FBto0000027	FBrf0231596		TOOL DATA from: FBal0346317
+FBti0203073_cas	encodes_tool	FBto0000031	FBrf0237912		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203073_cas	tool_uses	promoter trap	FBrf0237912		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203297_cas				FTA: unable to add tool information from FBal0346658 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203303_cas	tagged_with	FBto0000031	FBrf0236602		TOOL DATA from: FBal0346674
+FBti0203331_cas	encodes_tool	FBto0000135	FBrf0237278		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203331_cas	tool_uses	promoter trap	FBrf0237278		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203343_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346789
+FBti0203343_cas	tagged_with	FBto0000077	FBrf0241707		TOOL DATA from: FBal0346789
+FBti0203344_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346790
+FBti0203345_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346791
+FBti0203345_cas	tagged_with	FBto0000031	FBrf0241707		TOOL DATA from: FBal0346791
+FBti0203346_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346792
+FBti0203347_cas	carries_tool	FBto0000326	FBrf0241707		TOOL DATA from: FBal0346793
+FBti0203347_cas	tagged_with	FBto0000118	FBrf0241707		TOOL DATA from: FBal0346793
+FBti0203348_cas	carries_tool	FBto0000318	FBrf0241707		TOOL DATA from: FBal0346794
+FBti0203348_cas	carries_tool	FBto0000345	FBrf0241707		TOOL DATA from: FBal0346794
+FBti0203349_cas	carries_tool	FBto0000318	FBrf0241707		TOOL DATA from: FBal0346795
+FBti0203349_cas	carries_tool	FBto0000345	FBrf0241707		TOOL DATA from: FBal0346795
+FBti0203349_cas	tagged_with	FBto0000077	FBrf0241707		TOOL DATA from: FBal0346795
+FBti0203350_cas	carries_tool	FBto0000318	FBrf0241707		TOOL DATA from: FBal0346796
+FBti0203350_cas	carries_tool	FBto0000345	FBrf0241707		TOOL DATA from: FBal0346796
+FBti0203351_cas	carries_tool	FBto0000318	FBrf0241707		TOOL DATA from: FBal0346797
+FBti0203351_cas	carries_tool	FBto0000345	FBrf0241707		TOOL DATA from: FBal0346797
+FBti0203351_cas	tagged_with	FBto0000076	FBrf0241707		TOOL DATA from: FBal0346797
+FBti0203370_cas	encodes_tool	FBto0000118	FBrf0241288		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203370_cas	tool_uses	promoter trap	FBrf0241288		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203370_cas	carries_tool	FBto0000320	FBrf0241288		TOOL DATA from: FBal0346822
+FBti0203370_cas	carries_tool	FBto0000349	FBrf0241288		TOOL DATA from: FBal0346822
+FBti0203370_cas	carries_tool	FBto0000356	FBrf0241288		TOOL DATA from: FBal0346822
+FBti0203370_cas	carries_tool	FBto0000320	FBrf0241288		TOOL DATA from: FBal0346823
+FBti0203370_cas	carries_tool	FBto0000349	FBrf0241288		TOOL DATA from: FBal0346823
+FBti0203370_cas	carries_tool	FBto0000356	FBrf0241288		TOOL DATA from: FBal0346823
+FBti0203370_cas	tagged_with	FBto0000205	FBrf0241288		TOOL DATA from: FBal0346823
+FBti0203385_cas	encodes_tool	FBto0000155	FBrf0241449		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203385_cas	tool_uses	promoter trap	FBrf0241449		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203386_cas				FTA: unable to add tool information from FBal0346866 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203387_cas	tagged_with	FBto0000063	FBrf0241405		TOOL DATA from: FBal0346867
+FBti0203394_cas	carries_tool	FBto0000349	FBrf0241753		TOOL DATA from: FBal0346876
+FBti0203395_cas				FTA: unable to add tool information from FBal0346877 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203396_cas				FTA: unable to add tool information from FBal0346880 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203397_cas	carries_tool	FBto0000349	FBrf0241739		TOOL DATA from: FBal0346881
+FBti0203397_cas	carries_tool	FBto0000356	FBrf0241739		TOOL DATA from: FBal0346881
+FBti0203414_cas				FTA: unable to add tool information from FBal0302673 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203415_cas	encodes_tool	FBto0000118	FBrf0240994		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203415_cas	tool_uses	promoter trap	FBrf0240994		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203416_cas	carries_tool	FBto0000349	FBrf0241819		TOOL DATA from: FBal0346908
+FBti0203416_cas	carries_tool	FBto0000356	FBrf0241819		TOOL DATA from: FBal0346908
+FBti0203417_cas	carries_tool	FBto0000349	FBrf0241819		TOOL DATA from: FBal0346909
+FBti0203417_cas	carries_tool	FBto0000356	FBrf0241819		TOOL DATA from: FBal0346909
+FBti0203418_cas	carries_tool	FBto0000349	FBrf0241819		TOOL DATA from: FBal0346910
+FBti0203418_cas	carries_tool	FBto0000356	FBrf0241819		TOOL DATA from: FBal0346910
+FBti0203420_cas	encodes_tool	FBto0000143	FBrf0241661		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203420_cas	tool_uses	promoter trap	FBrf0241661		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203420_cas	carries_tool	FBto0000349	FBrf0241661		TOOL DATA from: FBal0346914
+FBti0203420_cas	carries_tool	FBto0000349	FBrf0241661		TOOL DATA from: FBal0346916
+FBti0203421_cas	encodes_tool	FBto0000143	FBrf0241661		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203421_cas	tool_uses	promoter trap	FBrf0241661		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203421_cas	carries_tool	FBto0000349	FBrf0241661		TOOL DATA from: FBal0346917
+FBti0203421_cas	carries_tool	FBto0000349	FBrf0241661		TOOL DATA from: FBal0346919
+FBti0203646_cas	tagged_with	FBto0000014	FBrf0241249		TOOL DATA from: FBal0347211
+FBti0203850_cas	tagged_with	FBto0000031	FBrf0241857		TOOL DATA from: FBal0347457
+FBti0203851_cas	tagged_with	FBto0000031	FBrf0241857		TOOL DATA from: FBal0347459
+FBti0203864_cas	carries_tool	FBto0000349	FBrf0241779		TOOL DATA from: FBal0347472
+FBti0203864_cas	tagged_with	FBto0000031	FBrf0241779		TOOL DATA from: FBal0347472
+FBti0203866_cas				FTA: unable to add tool information from FBal0347482 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0203867_cas	carries_tool	FBto0000349	FBrf0241769		TOOL DATA from: FBal0347483
+FBti0203912_cas	tagged_with	FBto0000063	FBrf0241908		TOOL DATA from: FBal0347551
+FBti0203913_cas	tagged_with	FBto0000063	FBrf0241908		TOOL DATA from: FBal0347553
+FBti0203914_cas	tagged_with	FBto0000522	FBrf0241908		TOOL DATA from: FBal0347554
+FBti0203915_cas	tagged_with	FBto0000027	FBrf0241908		TOOL DATA from: FBal0347555
+FBti0203916_cas	tagged_with	FBto0000077	FBrf0241858		TOOL DATA from: FBal0347557
+FBti0203917_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347558
+FBti0203918_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347559
+FBti0203919_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347560
+FBti0203920_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347561
+FBti0203921_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347562
+FBti0203922_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347563
+FBti0203923_cas	tagged_with	FBto0000076	FBrf0241858		TOOL DATA from: FBal0347564
+FBti0203986_cas	encodes_tool	FBto0000135	FBrf0240720		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0203986_cas	tool_uses	promoter trap	FBrf0240720		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204000_cas	tagged_with	FBto0000063	FBrf0241918		TOOL DATA from: FBal0348179
+FBti0204001_cas	tagged_with	FBto0000099	FBrf0241918		TOOL DATA from: FBal0348180
+FBti0204004_cas	tagged_with	FBto0000027	FBrf0241149		TOOL DATA from: FBal0348186
+FBti0204006_cas	carries_tool	FBto0000318	FBrf0240826		TOOL DATA from: FBal0348204
+FBti0204006_cas	tagged_with	FBto0000027	FBrf0240826		TOOL DATA from: FBal0348204
+FBti0204675_cas	encodes_tool	FBto0000135	FBrf0230098		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204675_cas	tool_uses	promoter trap	FBrf0230098		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204675_cas	carries_tool	FBto0000320	FBrf0230098		TOOL DATA from: FBal0349045
+FBti0204675_cas	carries_tool	FBto0000349	FBrf0230098		TOOL DATA from: FBal0349045
+FBti0204675_cas	carries_tool	FBto0000320	FBrf0230098		TOOL DATA from: FBal0349047
+FBti0204675_cas	carries_tool	FBto0000349	FBrf0230098		TOOL DATA from: FBal0349047
+FBti0204676_cas	encodes_tool	FBto0000118	FBrf0230098		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204676_cas	tool_uses	promoter trap	FBrf0230098		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204676_cas	carries_tool	FBto0000320	FBrf0230098		TOOL DATA from: FBal0349046
+FBti0204676_cas	carries_tool	FBto0000349	FBrf0230098		TOOL DATA from: FBal0349046
+FBti0204676_cas	carries_tool	FBto0000356	FBrf0230098		TOOL DATA from: FBal0349046
+FBti0204692_cas	tagged_with	FBto0000031	FBrf0239995		TOOL DATA from: FBal0349082
+FBti0204720_cas	encodes_tool	FBto0000135	FBrf0234424		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204720_cas	tool_uses	promoter trap	FBrf0234424		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204740_cas	encodes_tool	FBto0000135	FBrf0240322		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204740_cas	tool_uses	promoter trap	FBrf0240322		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204741_cas	encodes_tool	FBto0000135	FBrf0240322		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204741_cas	tool_uses	promoter trap	FBrf0240322		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204742_cas	encodes_tool	FBto0000308	FBrf0240322		TOOL DATA from: FBtp0099203, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204742_cas	tool_uses	promoter trap	FBrf0240322		TOOL DATA from: FBtp0099203, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204762_cas	encodes_tool	FBto0000118	FBrf0239741		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204762_cas	tool_uses	promoter trap	FBrf0239741		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204762_cas	carries_tool	FBto0000320	FBrf0239741		TOOL DATA from: FBal0349248
+FBti0204762_cas	carries_tool	FBto0000349	FBrf0239741		TOOL DATA from: FBal0349248
+FBti0204762_cas	carries_tool	FBto0000356	FBrf0239741		TOOL DATA from: FBal0349248
+FBti0204766_cas	encodes_tool	FBto0000027	FBrf0240603		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204766_cas	tool_uses	promoter trap	FBrf0240603		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204767_cas	tagged_with	FBto0000077	FBrf0240603		TOOL DATA from: FBal0349269
+FBti0204799_cas	carries_tool	FBto0000349	FBrf0242560		TOOL DATA from: FBal0349321
+FBti0204800_cas	carries_tool	FBto0000349	FBrf0242560		TOOL DATA from: FBal0349322
+FBti0204801_cas	carries_tool	FBto0000349	FBrf0242560		TOOL DATA from: FBal0349323
+FBti0204802_cas				FTA: unable to add tool information from FBal0408254 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0204803_cas				FTA: unable to add tool information from FBal0349325 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0204805_cas	tagged_with	FBto0000076	FBrf0241107		TOOL DATA from: FBal0349331
+FBti0204805_cas	tagged_with	FBto0000126	FBrf0241107		TOOL DATA from: FBal0349331
+FBti0204806_cas	tagged_with	FBto0000044	FBrf0241107		TOOL DATA from: FBal0349332
+FBti0204806_cas	tagged_with	FBto0000076	FBrf0241107		TOOL DATA from: FBal0349332
+FBti0204807_cas	tagged_with	FBto0000044	FBrf0241107		TOOL DATA from: FBal0349333
+FBti0204807_cas	tagged_with	FBto0000076	FBrf0241107		TOOL DATA from: FBal0349333
+FBti0204971_cas	carries_tool	FBto0000318	FBrf0241626		TOOL DATA from: FBal0349509
+FBti0204974_cas	encodes_tool	FBto0000308	FBrf0105495		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204974_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204974_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349527
+FBti0204974_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0367427
+FBti0204975_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204975_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204975_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349526
+FBti0204975_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349544
+FBti0204976_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204976_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204976_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349537
+FBti0204976_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349545
+FBti0204977_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204977_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204977_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349522
+FBti0204977_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349539
+FBti0204978_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204978_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204978_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349529
+FBti0204978_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349540
+FBti0204979_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204979_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204979_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349533
+FBti0204979_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349541
+FBti0204980_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204980_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204980_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349536
+FBti0204980_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349542
+FBti0204981_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204981_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204981_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349538
+FBti0204981_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349543
+FBti0204982_cas	encodes_tool	FBto0000158	FBrf0105495		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204982_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0204982_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349530
+FBti0204982_cas	carries_tool	FBto0000349	FBrf0242301		TOOL DATA from: FBal0349546
+FBti0205017_cas				FTA: unable to add tool information from FBal0349586 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0205017_cas				FTA: unable to add tool information from FBal0349588 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0205257_cas	tagged_with	FBto0000027	FBrf0240858		TOOL DATA from: FBal0349885
+FBti0205257_cas	tagged_with	FBto0000307	FBrf0240858		TOOL DATA from: FBal0349885
+FBti0205258_cas	carries_tool	FBto0000349	FBrf0242466		TOOL DATA from: FBal0349888
+FBti0205259_cas	carries_tool	FBto0000349	FBrf0242466		TOOL DATA from: FBal0349889
+FBti0205260_cas	carries_tool	FBto0000349	FBrf0242466		TOOL DATA from: FBal0349890
+FBti0205550_cas	encodes_tool	FBto0000146	FBrf0242251		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0205550_cas	tool_uses	promoter trap	FBrf0242251		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0205580_cas				FTA: unable to add tool information from FBal0350400 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0206387_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351249
+FBti0206388_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351250
+FBti0206389_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351251
+FBti0206390_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351252
+FBti0206391_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351253
+FBti0206392_cas	tagged_with	FBto0000077	FBrf0242345		TOOL DATA from: FBal0351254
+FBti0206392_cas	tagged_with	FBto0000118	FBrf0242345		TOOL DATA from: FBal0351254
+FBti0206393_cas	tagged_with	FBto0000077	FBrf0242345		TOOL DATA from: FBal0351255
+FBti0206393_cas	tagged_with	FBto0000542	FBrf0242345		TOOL DATA from: FBal0351255
+FBti0206394_cas	tagged_with	FBto0000077	FBrf0242345		TOOL DATA from: FBal0351256
+FBti0206394_cas	tagged_with	FBto0000121	FBrf0242345		TOOL DATA from: FBal0351256
+FBti0206395_cas	tagged_with	FBto0000044	FBrf0242345		TOOL DATA from: FBal0351257
+FBti0206396_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351258
+FBti0206397_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351259
+FBti0206398_cas	tagged_with	FBto0000027	FBrf0242345		TOOL DATA from: FBal0351260
+FBti0206398_cas	tagged_with	FBto0000077	FBrf0242345		TOOL DATA from: FBal0351260
+FBti0206406_cas	tagged_with	FBto0000063	FBrf0242229		TOOL DATA from: FBal0351300
+FBti0206406_cas	tagged_with	FBto0000077	FBrf0242229		TOOL DATA from: FBal0351300
+FBti0206407_cas	tagged_with	FBto0000063	FBrf0242229		TOOL DATA from: FBal0351301
+FBti0206407_cas	tagged_with	FBto0000077	FBrf0242229		TOOL DATA from: FBal0351301
+FBti0206411_cas	carries_tool	FBto0000349	FBrf0241998		TOOL DATA from: FBal0351316
+FBti0206411_cas	carries_tool	FBto0000356	FBrf0241998		TOOL DATA from: FBal0351316
+FBti0206415_cas	carries_tool	FBto0000356	FBrf0241023		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0206415_cas	tool_uses	docking element	FBrf0241023		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0206624_cas				FTA: unable to add tool information from FBal0351594 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0206631_cas				FTA: unable to add tool information from FBal0351610 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0206669_cas	encodes_tool	FBto0000135	FBrf0242072		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0206669_cas	tool_uses	promoter trap	FBrf0242072		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0206669_cas	carries_tool	FBto0000349	FBrf0242072		TOOL DATA from: FBal0351665
+FBti0206669_cas	carries_tool	FBto0000349	FBrf0242072		TOOL DATA from: FBal0351676
+FBti0206685_cas	carries_tool	FBto0000349	FBrf0242991		TOOL DATA from: FBal0351692
+FBti0206685_cas	carries_tool	FBto0000356	FBrf0242991		TOOL DATA from: FBal0351692
+FBti0206708_cas	tagged_with	FBto0000079	FBrf0242779		TOOL DATA from: FBal0351805
+FBti0206720_cas	carries_tool	FBto0000349	FBrf0241968		TOOL DATA from: FBal0351833
+FBti0206720_cas	carries_tool	FBto0000356	FBrf0241968		TOOL DATA from: FBal0351833
+FBti0206720_cas	carries_tool	FBto0000906	FBrf0241968		TOOL DATA from: FBal0351833
+FBti0206721_cas	tagged_with	FBto0000077	FBrf0241968		TOOL DATA from: FBal0351834
+FBti0206755_cas	tagged_with	FBto0000076	FBrf0242616		TOOL DATA from: FBal0351878
+FBti0206756_cas	tagged_with	FBto0000076	FBrf0242616		TOOL DATA from: FBal0351879
+FBti0206965_cas	tagged_with	FBto0000027	FBrf0242498		TOOL DATA from: FBal0352225
+FBti0206966_cas	tagged_with	FBto0000099	FBrf0242498		TOOL DATA from: FBal0352226
+FBti0206967_cas	carries_tool	FBto0000349	FBrf0237330		TOOL DATA from: FBal0352227
+FBti0206967_cas	tagged_with	FBto0000027	FBrf0237330		TOOL DATA from: FBal0352227
+FBti0206968_cas	carries_tool	FBto0000349	FBrf0237330		TOOL DATA from: FBal0352229
+FBti0206968_cas	tagged_with	FBto0000027	FBrf0237330		TOOL DATA from: FBal0352229
+FBti0206969_cas	carries_tool	FBto0000349	FBrf0237330		TOOL DATA from: FBal0352233
+FBti0206969_cas	tagged_with	FBto0000027	FBrf0237330		TOOL DATA from: FBal0352233
+FBti0206977_cas	carries_tool	FBto0000349	FBrf0242623		TOOL DATA from: FBal0352238
+FBti0206977_cas	tagged_with	FBto0000102	FBrf0242623		TOOL DATA from: FBal0352238
+FBti0206978_cas	carries_tool	FBto0000349	FBrf0242623		TOOL DATA from: FBal0352242
+FBti0206978_cas	tagged_with	FBto0000098	FBrf0242623		TOOL DATA from: FBal0352242
+FBti0207003_cas	encodes_tool	FBto0000135	FBrf0243068		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207003_cas	tool_uses	promoter trap	FBrf0243068		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207007_cas	carries_tool	FBto0000356	FBrf0243030		TOOL DATA from: FBal0352281
+FBti0207008_cas	tagged_with	FBto0000031	FBrf0243030		TOOL DATA from: FBal0352282
+FBti0207009_cas	carries_tool	FBto0000356	FBrf0243030		TOOL DATA from: FBal0352285
+FBti0207010_cas	tagged_with	FBto0000118	FBrf0243030		TOOL DATA from: FBal0352286
+FBti0207144_cas	carries_tool	FBto0000349	FBrf0243221		TOOL DATA from: FBal0352434
+FBti0207144_cas	carries_tool	FBto0000356	FBrf0243221		TOOL DATA from: FBal0352434
+FBti0207145_cas	tagged_with	FBto0000076	FBrf0243221		TOOL DATA from: FBal0352435
+FBti0207145_cas	tagged_with	FBto0000126	FBrf0243221		TOOL DATA from: FBal0352435
+FBti0207146_cas	carries_tool	FBto0000318	FBrf0243221		TOOL DATA from: FBal0352436
+FBti0207146_cas	tagged_with	FBto0000076	FBrf0243221		TOOL DATA from: FBal0352436
+FBti0207146_cas	tagged_with	FBto0000126	FBrf0243221		TOOL DATA from: FBal0352436
+FBti0207147_cas	carries_tool	FBto0000318	FBrf0243221		TOOL DATA from: FBal0352437
+FBti0207524_cas	tagged_with	FBto0000031	FBrf0243126		TOOL DATA from: FBal0353029
+FBti0207524_cas	tagged_with	FBto0000076	FBrf0243126		TOOL DATA from: FBal0353029
+FBti0207524_cas	tagged_with	FBto0000093	FBrf0243126		TOOL DATA from: FBal0353029
+FBti0207525_cas	tagged_with	FBto0000031	FBrf0243126		TOOL DATA from: FBal0353030
+FBti0207525_cas	tagged_with	FBto0000076	FBrf0243126		TOOL DATA from: FBal0353030
+FBti0207525_cas	tagged_with	FBto0000093	FBrf0243126		TOOL DATA from: FBal0353030
+FBti0207526_cas	tagged_with	FBto0000077	FBrf0243126		TOOL DATA from: FBal0353038
+FBti0207526_cas	tagged_with	FBto0000079	FBrf0243126		TOOL DATA from: FBal0353038
+FBti0207526_cas	tagged_with	FBto0000121	FBrf0243126		TOOL DATA from: FBal0353038
+FBti0207527_cas	tagged_with	FBto0000031	FBrf0243126		TOOL DATA from: FBal0353047
+FBti0207527_cas	tagged_with	FBto0000076	FBrf0243126		TOOL DATA from: FBal0353047
+FBti0207527_cas	tagged_with	FBto0000093	FBrf0243126		TOOL DATA from: FBal0353047
+FBti0207548_cas	encodes_tool	FBto0000155	FBrf0243395		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207548_cas	tool_uses	promoter trap	FBrf0243395		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207549_cas	encodes_tool	FBto0000155	FBrf0243395		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207549_cas	tool_uses	promoter trap	FBrf0243395		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207551_cas	tagged_with	FBto0000027	FBrf0243353		TOOL DATA from: FBal0353057
+FBti0207552_cas	tagged_with	FBto0000077	FBrf0243353		TOOL DATA from: FBal0353058
+FBti0207554_cas				FTA: unable to add tool information from FBal0353069 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0207555_cas	carries_tool	FBto0000349	FBrf0243149		TOOL DATA from: FBal0353070
+FBti0207556_cas	tagged_with	FBto0000031	FBrf0243169		TOOL DATA from: FBal0353071
+FBti0207559_cas	encodes_tool	FBto0000143	FBrf0242908		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207559_cas	tool_uses	promoter trap	FBrf0242908		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207559_cas				FTA: unable to add tool information from FBal0353075 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0207560_cas	encodes_tool	FBto0000143	FBrf0242908		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207560_cas	tool_uses	promoter trap	FBrf0242908		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0207560_cas				FTA: unable to add tool information from FBal0353077 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0207607_cas				FTA: unable to add tool information from FBal0353149 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0207638_cas	tagged_with	FBto0000031	FBrf0243113		TOOL DATA from: FBal0353201
+FBti0207640_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353218
+FBti0207641_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353219
+FBti0207642_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353220
+FBti0207643_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353221
+FBti0207644_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353222
+FBti0207645_cas	carries_tool	FBto0000349	FBrf0243123		TOOL DATA from: FBal0353223
+FBti0207699_cas	tagged_with	FBto0000077	FBrf0243279		TOOL DATA from: FBal0353302
+FBti0207703_cas	carries_tool	FBto0000349	FBrf0242749		TOOL DATA from: FBal0353304
+FBti0207704_cas	carries_tool	FBto0000349	FBrf0243536		TOOL DATA from: FBal0353319
+FBti0207708_cas	tagged_with	FBto0000031	FBrf0242585		TOOL DATA from: FBal0353343
+FBti0207709_cas	tagged_with	FBto0000076	FBrf0243130		TOOL DATA from: FBal0353346
+FBti0207709_cas	tagged_with	FBto0000077	FBrf0243130		TOOL DATA from: FBal0353346
+FBti0207897_cas	tagged_with	FBto0000077	FBrf0242899		TOOL DATA from: FBal0353540
+FBti0207902_cas	tagged_with	FBto0000582	FBrf0242057		TOOL DATA from: FBal0353551
+FBti0207912_cas	tagged_with	FBto0000118	FBrf0243742		TOOL DATA from: FBal0353580
+FBti0209576_cas	tagged_with	FBto0000031	FBrf0222281		TOOL DATA from: FBal0287834
+FBti0209587_cas	carries_tool	FBto0000349	FBrf0236234		TOOL DATA from: FBal0355290
+FBti0209587_cas	tagged_with	FBto0000063	FBrf0236234		TOOL DATA from: FBal0355290
+FBti0209588_cas	carries_tool	FBto0000349	FBrf0236234		TOOL DATA from: FBal0355291
+FBti0209588_cas	tagged_with	FBto0000334	FBrf0236234		TOOL DATA from: FBal0355291
+FBti0209624_cas				FTA: unable to add tool information from FBal0355350 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209625_cas				FTA: unable to add tool information from FBal0355351 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209626_cas				FTA: unable to add tool information from FBal0355352 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209627_cas				FTA: unable to add tool information from FBal0355353 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209628_cas				FTA: unable to add tool information from FBal0355354 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209629_cas				FTA: unable to add tool information from FBal0355355 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209630_cas				FTA: unable to add tool information from FBal0355356 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209631_cas				FTA: unable to add tool information from FBal0355357 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209632_cas				FTA: unable to add tool information from FBal0355358 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209633_cas				FTA: unable to add tool information from FBal0355359 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209634_cas				FTA: unable to add tool information from FBal0355360 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209635_cas				FTA: unable to add tool information from FBal0355361 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209636_cas				FTA: unable to add tool information from FBal0355362 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209637_cas				FTA: unable to add tool information from FBal0355363 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209638_cas				FTA: unable to add tool information from FBal0355364 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209639_cas				FTA: unable to add tool information from FBal0355365 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209640_cas				FTA: unable to add tool information from FBal0355366 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209641_cas				FTA: unable to add tool information from FBal0355367 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209642_cas				FTA: unable to add tool information from FBal0355368 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209643_cas				FTA: unable to add tool information from FBal0355369 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209644_cas				FTA: unable to add tool information from FBal0355370 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209645_cas				FTA: unable to add tool information from FBal0355371 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209646_cas				FTA: unable to add tool information from FBal0355372 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209647_cas				FTA: unable to add tool information from FBal0355373 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209648_cas				FTA: unable to add tool information from FBal0355374 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209649_cas				FTA: unable to add tool information from FBal0355375 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209650_cas				FTA: unable to add tool information from FBal0355376 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209651_cas				FTA: unable to add tool information from FBal0355377 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209652_cas				FTA: unable to add tool information from FBal0355378 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209653_cas				FTA: unable to add tool information from FBal0355379 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209654_cas				FTA: unable to add tool information from FBal0355380 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209655_cas				FTA: unable to add tool information from FBal0355381 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209656_cas				FTA: unable to add tool information from FBal0355382 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209657_cas				FTA: unable to add tool information from FBal0355383 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209658_cas				FTA: unable to add tool information from FBal0355384 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209659_cas				FTA: unable to add tool information from FBal0355385 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209660_cas				FTA: unable to add tool information from FBal0355386 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209661_cas				FTA: unable to add tool information from FBal0355387 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209662_cas				FTA: unable to add tool information from FBal0355388 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209663_cas				FTA: unable to add tool information from FBal0355389 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209664_cas				FTA: unable to add tool information from FBal0355390 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209665_cas				FTA: unable to add tool information from FBal0355391 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209666_cas				FTA: unable to add tool information from FBal0355392 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209667_cas				FTA: unable to add tool information from FBal0355393 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209668_cas				FTA: unable to add tool information from FBal0355394 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209669_cas				FTA: unable to add tool information from FBal0355395 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209670_cas				FTA: unable to add tool information from FBal0355396 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209671_cas				FTA: unable to add tool information from FBal0355397 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209672_cas				FTA: unable to add tool information from FBal0355398 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209673_cas				FTA: unable to add tool information from FBal0355399 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209674_cas				FTA: unable to add tool information from FBal0355400 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209675_cas				FTA: unable to add tool information from FBal0355401 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209676_cas				FTA: unable to add tool information from FBal0355402 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209677_cas				FTA: unable to add tool information from FBal0355403 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209678_cas				FTA: unable to add tool information from FBal0355404 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209679_cas				FTA: unable to add tool information from FBal0355405 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209680_cas				FTA: unable to add tool information from FBal0355406 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209681_cas				FTA: unable to add tool information from FBal0355407 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209682_cas				FTA: unable to add tool information from FBal0355408 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209683_cas				FTA: unable to add tool information from FBal0355409 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209684_cas				FTA: unable to add tool information from FBal0355410 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209685_cas				FTA: unable to add tool information from FBal0355411 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209686_cas				FTA: unable to add tool information from FBal0355412 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209687_cas				FTA: unable to add tool information from FBal0355413 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209688_cas				FTA: unable to add tool information from FBal0355414 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209689_cas				FTA: unable to add tool information from FBal0355415 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209690_cas				FTA: unable to add tool information from FBal0355416 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209691_cas				FTA: unable to add tool information from FBal0355417 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209692_cas				FTA: unable to add tool information from FBal0355418 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209693_cas				FTA: unable to add tool information from FBal0355419 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209694_cas				FTA: unable to add tool information from FBal0355420 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209695_cas				FTA: unable to add tool information from FBal0355421 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209696_cas				FTA: unable to add tool information from FBal0355422 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209697_cas				FTA: unable to add tool information from FBal0355423 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209698_cas				FTA: unable to add tool information from FBal0355424 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209699_cas				FTA: unable to add tool information from FBal0355425 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209700_cas				FTA: unable to add tool information from FBal0355426 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209701_cas				FTA: unable to add tool information from FBal0355427 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209702_cas				FTA: unable to add tool information from FBal0355428 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209703_cas				FTA: unable to add tool information from FBal0355429 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209704_cas				FTA: unable to add tool information from FBal0355430 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209705_cas				FTA: unable to add tool information from FBal0355431 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209706_cas				FTA: unable to add tool information from FBal0355432 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209707_cas				FTA: unable to add tool information from FBal0355433 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209708_cas				FTA: unable to add tool information from FBal0355435 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209709_cas				FTA: unable to add tool information from FBal0355436 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209710_cas				FTA: unable to add tool information from FBal0355437 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209711_cas				FTA: unable to add tool information from FBal0355438 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209712_cas				FTA: unable to add tool information from FBal0355439 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209713_cas				FTA: unable to add tool information from FBal0355440 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209714_cas				FTA: unable to add tool information from FBal0355441 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209715_cas				FTA: unable to add tool information from FBal0355442 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209716_cas				FTA: unable to add tool information from FBal0355443 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209717_cas				FTA: unable to add tool information from FBal0355444 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209718_cas				FTA: unable to add tool information from FBal0355445 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209719_cas				FTA: unable to add tool information from FBal0355446 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209720_cas				FTA: unable to add tool information from FBal0355447 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209721_cas				FTA: unable to add tool information from FBal0355448 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209722_cas				FTA: unable to add tool information from FBal0355449 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209723_cas				FTA: unable to add tool information from FBal0355450 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209724_cas				FTA: unable to add tool information from FBal0355451 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209725_cas				FTA: unable to add tool information from FBal0355452 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209726_cas				FTA: unable to add tool information from FBal0355453 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209727_cas				FTA: unable to add tool information from FBal0355454 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209728_cas				FTA: unable to add tool information from FBal0355455 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209729_cas				FTA: unable to add tool information from FBal0355456 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209730_cas				FTA: unable to add tool information from FBal0355457 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209731_cas				FTA: unable to add tool information from FBal0355458 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209732_cas				FTA: unable to add tool information from FBal0355459 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209733_cas				FTA: unable to add tool information from FBal0355460 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209734_cas				FTA: unable to add tool information from FBal0355461 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209735_cas				FTA: unable to add tool information from FBal0355462 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209736_cas				FTA: unable to add tool information from FBal0355463 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209737_cas				FTA: unable to add tool information from FBal0355464 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209738_cas				FTA: unable to add tool information from FBal0355465 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209739_cas				FTA: unable to add tool information from FBal0355466 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209740_cas				FTA: unable to add tool information from FBal0355467 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209741_cas				FTA: unable to add tool information from FBal0355468 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209742_cas				FTA: unable to add tool information from FBal0355469 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209743_cas				FTA: unable to add tool information from FBal0355470 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209744_cas				FTA: unable to add tool information from FBal0355471 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209745_cas				FTA: unable to add tool information from FBal0355472 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209746_cas				FTA: unable to add tool information from FBal0355473 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209747_cas				FTA: unable to add tool information from FBal0355474 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209748_cas				FTA: unable to add tool information from FBal0355475 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209749_cas				FTA: unable to add tool information from FBal0355476 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209750_cas				FTA: unable to add tool information from FBal0355477 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209751_cas				FTA: unable to add tool information from FBal0355478 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209752_cas				FTA: unable to add tool information from FBal0355479 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209753_cas				FTA: unable to add tool information from FBal0355480 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209754_cas				FTA: unable to add tool information from FBal0355481 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209755_cas				FTA: unable to add tool information from FBal0355482 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209756_cas				FTA: unable to add tool information from FBal0355483 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209757_cas				FTA: unable to add tool information from FBal0355484 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209758_cas				FTA: unable to add tool information from FBal0355485 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209759_cas				FTA: unable to add tool information from FBal0355486 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209760_cas				FTA: unable to add tool information from FBal0355487 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209761_cas				FTA: unable to add tool information from FBal0355488 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209762_cas				FTA: unable to add tool information from FBal0355489 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209763_cas				FTA: unable to add tool information from FBal0355490 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209764_cas				FTA: unable to add tool information from FBal0355491 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209765_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355434
+FBti0209765_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355434
+FBti0209765_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355492
+FBti0209765_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355492
+FBti0209766_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355493
+FBti0209766_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355493
+FBti0209767_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355495
+FBti0209767_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355495
+FBti0209767_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355496
+FBti0209767_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355496
+FBti0209768_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355497
+FBti0209768_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355497
+FBti0209768_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355498
+FBti0209768_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355498
+FBti0209769_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355499
+FBti0209769_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355499
+FBti0209769_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355500
+FBti0209769_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355500
+FBti0209770_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355501
+FBti0209770_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355501
+FBti0209770_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355502
+FBti0209770_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355502
+FBti0209770_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355503
+FBti0209770_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355503
+FBti0209771_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355504
+FBti0209771_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355504
+FBti0209771_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355505
+FBti0209771_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355505
+FBti0209772_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355507
+FBti0209772_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355507
+FBti0209772_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355508
+FBti0209772_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355508
+FBti0209773_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355509
+FBti0209773_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355509
+FBti0209773_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355510
+FBti0209773_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355510
+FBti0209774_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355511
+FBti0209774_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355511
+FBti0209774_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355512
+FBti0209774_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355512
+FBti0209775_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355513
+FBti0209775_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355513
+FBti0209775_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355514
+FBti0209775_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355514
+FBti0209775_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355515
+FBti0209775_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355515
+FBti0209776_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355506
+FBti0209776_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355506
+FBti0209776_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355516
+FBti0209776_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355516
+FBti0209777_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355517
+FBti0209777_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355517
+FBti0209777_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355518
+FBti0209777_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355518
+FBti0209778_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355519
+FBti0209778_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355519
+FBti0209778_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355520
+FBti0209778_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355520
+FBti0209779_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355521
+FBti0209779_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355521
+FBti0209779_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355522
+FBti0209779_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355522
+FBti0209780_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355523
+FBti0209780_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355523
+FBti0209780_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355524
+FBti0209780_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355524
+FBti0209781_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355525
+FBti0209781_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355525
+FBti0209781_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355526
+FBti0209781_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355526
+FBti0209782_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355527
+FBti0209782_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355527
+FBti0209782_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355528
+FBti0209782_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355528
+FBti0209783_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355529
+FBti0209783_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355529
+FBti0209783_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355530
+FBti0209783_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355530
+FBti0209784_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355531
+FBti0209784_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355531
+FBti0209784_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355532
+FBti0209784_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355532
+FBti0209784_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355533
+FBti0209784_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355533
+FBti0209785_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355534
+FBti0209785_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355534
+FBti0209785_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355535
+FBti0209785_cas	carries_tool	FBto0000356	FBrf0243924		TOOL DATA from: FBal0355535
+FBti0209788_cas				FTA: unable to add tool information from FBal0355581 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209790_cas				FTA: unable to add tool information from FBal0355588 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0209800_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209800_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209801_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209801_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209801_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355630
+FBti0209801_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355630
+FBti0209801_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355961
+FBti0209802_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209802_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209802_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355631
+FBti0209802_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355631
+FBti0209802_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355855
+FBti0209803_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209803_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209803_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355632
+FBti0209803_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355632
+FBti0209803_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355962
+FBti0209804_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209804_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209804_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355633
+FBti0209804_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355633
+FBti0209804_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355856
+FBti0209805_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209805_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209805_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355634
+FBti0209805_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355634
+FBti0209805_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355963
+FBti0209806_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209806_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209806_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355635
+FBti0209806_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355635
+FBti0209806_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355857
+FBti0209807_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209807_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209807_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355636
+FBti0209807_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355636
+FBti0209807_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355964
+FBti0209808_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209808_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209808_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355637
+FBti0209808_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355637
+FBti0209808_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355858
+FBti0209809_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209809_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209809_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355638
+FBti0209809_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355638
+FBti0209809_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355965
+FBti0209810_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209810_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209810_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355639
+FBti0209810_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355639
+FBti0209810_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355859
+FBti0209811_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209811_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209811_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355640
+FBti0209811_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355640
+FBti0209811_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355966
+FBti0209812_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209812_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209812_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355641
+FBti0209812_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355641
+FBti0209812_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355860
+FBti0209813_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209813_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209813_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355642
+FBti0209813_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355642
+FBti0209813_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355967
+FBti0209814_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209814_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209814_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355643
+FBti0209814_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355643
+FBti0209814_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355861
+FBti0209815_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209815_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209815_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355644
+FBti0209815_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355644
+FBti0209815_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355956
+FBti0209816_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209816_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209816_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355645
+FBti0209816_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355645
+FBti0209816_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355862
+FBti0209817_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209817_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209817_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355646
+FBti0209817_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355646
+FBti0209817_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355968
+FBti0209818_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209818_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209818_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355647
+FBti0209818_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355647
+FBti0209818_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355969
+FBti0209819_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209819_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209819_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355648
+FBti0209819_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355648
+FBti0209819_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355970
+FBti0209820_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209820_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209820_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355649
+FBti0209820_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355649
+FBti0209820_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355971
+FBti0209821_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209821_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209821_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355650
+FBti0209821_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355650
+FBti0209821_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355863
+FBti0209822_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209822_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209822_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355651
+FBti0209822_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355651
+FBti0209822_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355864
+FBti0209823_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209823_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209823_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355652
+FBti0209823_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355652
+FBti0209823_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355972
+FBti0209824_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209824_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209824_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355653
+FBti0209824_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355653
+FBti0209824_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355865
+FBti0209825_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209825_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209825_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355654
+FBti0209825_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355654
+FBti0209825_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355973
+FBti0209826_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209826_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209826_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355655
+FBti0209826_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355655
+FBti0209826_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355866
+FBti0209827_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209827_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209827_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355656
+FBti0209827_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355656
+FBti0209827_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355974
+FBti0209828_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209828_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209828_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355657
+FBti0209828_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355657
+FBti0209828_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355867
+FBti0209829_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209829_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209829_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355658
+FBti0209829_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355658
+FBti0209829_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355975
+FBti0209830_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209830_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209830_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355659
+FBti0209830_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355659
+FBti0209830_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355976
+FBti0209831_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209831_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209831_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355660
+FBti0209831_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355660
+FBti0209831_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355868
+FBti0209832_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209832_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209832_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355661
+FBti0209832_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355661
+FBti0209832_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355869
+FBti0209833_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209833_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209833_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355662
+FBti0209833_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355662
+FBti0209833_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355977
+FBti0209834_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209834_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209834_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355663
+FBti0209834_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355663
+FBti0209834_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355870
+FBti0209835_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209835_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209835_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355664
+FBti0209835_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355664
+FBti0209835_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355978
+FBti0209836_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209836_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209836_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355665
+FBti0209836_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355665
+FBti0209836_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355979
+FBti0209837_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209837_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209837_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355666
+FBti0209837_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355666
+FBti0209837_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355871
+FBti0209838_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209838_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209838_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355667
+FBti0209838_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355667
+FBti0209838_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355980
+FBti0209839_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209839_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209839_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355668
+FBti0209839_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355668
+FBti0209839_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355872
+FBti0209840_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209840_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209840_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355669
+FBti0209840_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355669
+FBti0209840_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355981
+FBti0209841_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209841_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209841_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355670
+FBti0209841_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355670
+FBti0209841_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355873
+FBti0209842_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209842_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209842_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355671
+FBti0209842_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355671
+FBti0209842_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355874
+FBti0209843_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209843_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209843_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355672
+FBti0209843_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355672
+FBti0209843_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355982
+FBti0209844_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209844_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209844_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355673
+FBti0209844_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355673
+FBti0209844_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355875
+FBti0209845_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209845_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209845_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355674
+FBti0209845_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355674
+FBti0209845_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355983
+FBti0209846_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209846_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209846_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355675
+FBti0209846_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355675
+FBti0209846_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355876
+FBti0209847_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209847_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209847_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355676
+FBti0209847_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355676
+FBti0209847_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355984
+FBti0209848_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209848_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209848_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355677
+FBti0209848_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355677
+FBti0209848_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355877
+FBti0209849_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209849_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209849_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355678
+FBti0209849_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355678
+FBti0209849_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355985
+FBti0209850_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209850_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209850_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355679
+FBti0209850_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355679
+FBti0209850_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355878
+FBti0209851_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209851_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209851_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355680
+FBti0209851_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355680
+FBti0209851_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355986
+FBti0209852_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209852_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209852_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355681
+FBti0209852_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355681
+FBti0209852_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355879
+FBti0209853_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209853_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209853_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355682
+FBti0209853_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355682
+FBti0209853_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355880
+FBti0209854_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209854_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209854_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355683
+FBti0209854_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355683
+FBti0209854_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355987
+FBti0209855_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209855_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209855_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355684
+FBti0209855_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355684
+FBti0209855_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355988
+FBti0209856_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209856_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209856_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355685
+FBti0209856_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355685
+FBti0209856_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355989
+FBti0209857_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209857_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209857_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355686
+FBti0209857_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355686
+FBti0209857_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355881
+FBti0209858_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209858_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209858_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355687
+FBti0209858_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355687
+FBti0209858_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355990
+FBti0209859_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209859_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209859_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355688
+FBti0209859_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355688
+FBti0209859_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355882
+FBti0209860_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209860_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209860_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355689
+FBti0209860_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355689
+FBti0209860_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355991
+FBti0209861_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209861_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209861_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355690
+FBti0209861_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355690
+FBti0209861_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355992
+FBti0209862_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209862_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209862_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355691
+FBti0209862_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355691
+FBti0209862_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355883
+FBti0209863_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209863_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209863_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355692
+FBti0209863_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355692
+FBti0209863_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355993
+FBti0209864_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209864_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209864_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355693
+FBti0209864_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355693
+FBti0209864_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355994
+FBti0209865_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209865_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209865_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355694
+FBti0209865_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355694
+FBti0209865_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355884
+FBti0209866_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209866_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209866_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355695
+FBti0209866_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355695
+FBti0209866_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355995
+FBti0209867_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209867_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209867_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355696
+FBti0209867_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355696
+FBti0209867_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355885
+FBti0209868_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209868_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209868_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355697
+FBti0209868_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355697
+FBti0209868_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355996
+FBti0209869_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209869_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209869_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355698
+FBti0209869_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355698
+FBti0209869_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355997
+FBti0209870_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209870_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209870_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355699
+FBti0209870_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355699
+FBti0209870_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355998
+FBti0209871_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209871_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209871_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355700
+FBti0209871_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355700
+FBti0209871_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355886
+FBti0209872_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209872_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209872_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355701
+FBti0209872_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355701
+FBti0209872_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355999
+FBti0209873_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209873_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209873_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355702
+FBti0209873_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355702
+FBti0209873_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355887
+FBti0209874_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209874_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209874_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355703
+FBti0209874_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355703
+FBti0209874_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355957
+FBti0209875_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209875_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209875_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355704
+FBti0209875_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355704
+FBti0209875_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355958
+FBti0209876_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209876_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209876_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355705
+FBti0209876_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355705
+FBti0209876_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355888
+FBti0209877_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209877_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209877_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0355706
+FBti0209877_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0355706
+FBti0209877_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0355954
+FBti0209877_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0355954
+FBti0209880_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209880_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209880_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0355709
+FBti0209880_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0355709
+FBti0209880_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0355955
+FBti0209880_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0355955
+FBti0209881_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209881_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209881_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355710
+FBti0209881_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355710
+FBti0209881_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356000
+FBti0209882_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209882_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209882_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355711
+FBti0209882_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355711
+FBti0209882_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355889
+FBti0209883_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209883_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209883_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355712
+FBti0209883_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355712
+FBti0209883_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356001
+FBti0209884_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209884_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209885_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209885_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209885_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355714
+FBti0209885_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355714
+FBti0209885_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356002
+FBti0209886_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209886_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209886_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355715
+FBti0209886_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355715
+FBti0209886_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355890
+FBti0209887_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209887_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209887_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355716
+FBti0209887_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355716
+FBti0209887_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355891
+FBti0209888_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209888_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209888_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355717
+FBti0209888_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355717
+FBti0209888_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356003
+FBti0209889_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209889_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209889_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355718
+FBti0209889_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355718
+FBti0209889_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356004
+FBti0209890_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209890_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209890_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355719
+FBti0209890_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355719
+FBti0209890_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355892
+FBti0209891_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209891_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209891_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355720
+FBti0209891_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355720
+FBti0209891_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356005
+FBti0209892_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209892_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209892_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355721
+FBti0209892_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355721
+FBti0209892_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355893
+FBti0209893_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209893_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209893_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355722
+FBti0209893_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355722
+FBti0209893_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356006
+FBti0209894_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209894_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209894_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355723
+FBti0209894_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355723
+FBti0209894_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355894
+FBti0209895_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209895_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209895_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355724
+FBti0209895_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355724
+FBti0209895_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356007
+FBti0209896_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209896_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209896_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355725
+FBti0209896_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355725
+FBti0209896_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356008
+FBti0209897_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209897_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209897_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355726
+FBti0209897_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355726
+FBti0209897_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355895
+FBti0209898_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209898_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209898_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355727
+FBti0209898_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355727
+FBti0209898_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356009
+FBti0209899_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209899_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209899_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355728
+FBti0209899_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355728
+FBti0209899_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355896
+FBti0209900_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209900_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209900_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355729
+FBti0209900_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355729
+FBti0209900_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355897
+FBti0209901_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209901_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209901_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355730
+FBti0209901_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355730
+FBti0209901_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356010
+FBti0209902_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209902_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209902_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355731
+FBti0209902_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355731
+FBti0209902_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356011
+FBti0209903_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209903_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209903_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355732
+FBti0209903_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355732
+FBti0209903_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355898
+FBti0209904_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209904_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209904_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355733
+FBti0209904_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355733
+FBti0209904_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355899
+FBti0209905_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209905_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209905_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355734
+FBti0209905_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355734
+FBti0209905_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356012
+FBti0209906_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209906_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209906_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355735
+FBti0209906_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355735
+FBti0209906_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355900
+FBti0209907_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209907_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209907_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355736
+FBti0209907_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355736
+FBti0209907_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356013
+FBti0209908_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209908_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209908_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355737
+FBti0209908_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355737
+FBti0209908_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356014
+FBti0209909_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209909_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209909_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355738
+FBti0209909_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355738
+FBti0209909_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356015
+FBti0209910_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209910_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209910_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355739
+FBti0209910_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355739
+FBti0209910_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356016
+FBti0209911_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209911_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209911_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355740
+FBti0209911_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355740
+FBti0209911_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356017
+FBti0209912_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209912_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209912_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355741
+FBti0209912_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355741
+FBti0209912_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356018
+FBti0209913_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209913_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209913_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355742
+FBti0209913_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355742
+FBti0209913_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356019
+FBti0209914_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209914_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209914_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355743
+FBti0209914_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355743
+FBti0209914_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355901
+FBti0209915_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209915_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209915_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355744
+FBti0209915_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355744
+FBti0209915_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356020
+FBti0209916_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209916_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209916_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355745
+FBti0209916_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355745
+FBti0209916_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355902
+FBti0209917_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209917_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209917_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355746
+FBti0209917_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355746
+FBti0209917_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356021
+FBti0209918_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209918_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209918_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355747
+FBti0209918_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355747
+FBti0209918_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355903
+FBti0209919_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209919_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209919_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355748
+FBti0209919_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355748
+FBti0209919_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356022
+FBti0209920_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209920_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209920_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355749
+FBti0209920_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355749
+FBti0209920_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355904
+FBti0209921_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209921_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209921_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355750
+FBti0209921_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355750
+FBti0209921_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356023
+FBti0209922_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209922_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209922_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355751
+FBti0209922_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355751
+FBti0209922_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355905
+FBti0209923_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209923_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209923_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355752
+FBti0209923_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355752
+FBti0209923_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356024
+FBti0209924_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209924_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209924_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355753
+FBti0209924_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355753
+FBti0209924_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355906
+FBti0209925_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209925_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209925_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355754
+FBti0209925_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355754
+FBti0209925_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356025
+FBti0209926_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209926_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209926_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355755
+FBti0209926_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355755
+FBti0209926_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355907
+FBti0209927_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209927_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209927_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355756
+FBti0209927_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355756
+FBti0209927_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356026
+FBti0209928_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209928_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209928_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355757
+FBti0209928_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355757
+FBti0209928_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355908
+FBti0209929_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209929_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209929_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355758
+FBti0209929_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355758
+FBti0209929_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356027
+FBti0209930_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209930_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209930_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355759
+FBti0209930_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355759
+FBti0209930_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355909
+FBti0209931_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209931_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209931_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355760
+FBti0209931_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355760
+FBti0209931_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356028
+FBti0209932_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209932_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209932_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355761
+FBti0209932_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355761
+FBti0209932_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355910
+FBti0209933_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209933_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209933_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355762
+FBti0209933_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355762
+FBti0209933_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356029
+FBti0209934_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209934_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209934_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355763
+FBti0209934_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355763
+FBti0209934_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356030
+FBti0209935_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209935_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209935_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355764
+FBti0209935_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355764
+FBti0209935_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355911
+FBti0209936_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209936_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209936_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355765
+FBti0209936_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355765
+FBti0209936_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356031
+FBti0209937_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209937_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209937_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355766
+FBti0209937_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355766
+FBti0209937_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355912
+FBti0209938_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209938_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209938_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355767
+FBti0209938_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355767
+FBti0209938_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356032
+FBti0209939_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209939_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209939_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355769
+FBti0209939_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355769
+FBti0209939_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356033
+FBti0209940_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209940_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209940_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355770
+FBti0209940_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355770
+FBti0209940_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355913
+FBti0209941_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209941_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209941_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355771
+FBti0209941_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355771
+FBti0209941_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356034
+FBti0209942_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209942_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209942_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355772
+FBti0209942_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355772
+FBti0209942_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356035
+FBti0209943_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209943_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209943_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355773
+FBti0209943_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355773
+FBti0209943_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356036
+FBti0209944_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209944_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209944_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355774
+FBti0209944_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355774
+FBti0209944_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355914
+FBti0209945_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209945_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209945_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355775
+FBti0209945_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355775
+FBti0209945_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355915
+FBti0209946_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209946_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209946_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355776
+FBti0209946_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355776
+FBti0209946_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356037
+FBti0209947_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209947_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209947_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355777
+FBti0209947_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355777
+FBti0209947_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356038
+FBti0209948_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209948_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209948_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355778
+FBti0209948_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355778
+FBti0209948_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355916
+FBti0209949_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209949_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209949_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355779
+FBti0209949_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355779
+FBti0209949_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356039
+FBti0209950_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209950_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209950_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355780
+FBti0209950_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355780
+FBti0209950_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355917
+FBti0209951_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209951_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209951_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355781
+FBti0209951_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355781
+FBti0209951_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356040
+FBti0209952_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209952_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209952_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355782
+FBti0209952_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355782
+FBti0209952_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356041
+FBti0209953_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209953_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209953_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355783
+FBti0209953_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355783
+FBti0209953_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356042
+FBti0209954_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209954_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209954_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355784
+FBti0209954_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355784
+FBti0209954_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355918
+FBti0209955_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209955_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209955_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355785
+FBti0209955_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355785
+FBti0209955_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356043
+FBti0209956_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209956_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209956_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355786
+FBti0209956_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355786
+FBti0209956_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356044
+FBti0209957_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209957_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209957_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355787
+FBti0209957_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355787
+FBti0209957_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355919
+FBti0209958_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209958_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209958_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355788
+FBti0209958_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355788
+FBti0209958_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356045
+FBti0209959_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209959_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209959_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355789
+FBti0209959_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355789
+FBti0209959_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355920
+FBti0209960_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209960_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209960_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355790
+FBti0209960_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355790
+FBti0209960_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355959
+FBti0209961_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209961_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209961_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355791
+FBti0209961_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355791
+FBti0209961_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355921
+FBti0209962_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209962_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209962_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355792
+FBti0209962_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355792
+FBti0209962_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355922
+FBti0209963_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209963_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209963_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355793
+FBti0209963_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355793
+FBti0209963_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356046
+FBti0209964_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209964_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209964_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355794
+FBti0209964_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355794
+FBti0209964_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355923
+FBti0209965_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209965_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209965_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355795
+FBti0209965_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355795
+FBti0209965_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356047
+FBti0209966_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209966_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209966_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355796
+FBti0209966_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355796
+FBti0209966_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356048
+FBti0209967_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209967_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209967_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355797
+FBti0209967_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355797
+FBti0209967_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355924
+FBti0209968_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209968_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209968_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355798
+FBti0209968_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355798
+FBti0209968_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356049
+FBti0209969_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209969_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209969_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355799
+FBti0209969_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355799
+FBti0209969_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355925
+FBti0209970_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209970_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209970_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355800
+FBti0209970_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355800
+FBti0209970_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355926
+FBti0209971_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209971_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209971_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355801
+FBti0209971_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355801
+FBti0209971_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356050
+FBti0209972_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209972_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209972_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355802
+FBti0209972_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355802
+FBti0209972_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355927
+FBti0209973_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209973_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209973_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355803
+FBti0209973_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355803
+FBti0209973_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356051
+FBti0209974_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209974_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209974_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355804
+FBti0209974_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355804
+FBti0209974_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355928
+FBti0209975_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209975_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209975_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355805
+FBti0209975_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355805
+FBti0209975_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356052
+FBti0209976_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209976_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209976_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355806
+FBti0209976_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355806
+FBti0209976_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355929
+FBti0209977_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209977_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209977_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355807
+FBti0209977_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355807
+FBti0209977_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356053
+FBti0209978_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209978_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209978_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355808
+FBti0209978_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355808
+FBti0209978_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355930
+FBti0209979_cas	encodes_tool	FBto0000308	FBrf0243924		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209979_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209979_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355809
+FBti0209979_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355809
+FBti0209979_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356079
+FBti0209980_cas	encodes_tool	FBto0000166	FBrf0243924		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209980_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209980_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355810
+FBti0209980_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356077
+FBti0209981_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209981_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209981_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355811
+FBti0209981_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355811
+FBti0209981_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356054
+FBti0209982_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209982_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209982_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355812
+FBti0209982_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355812
+FBti0209982_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355931
+FBti0209983_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209983_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209983_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355813
+FBti0209983_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355813
+FBti0209983_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356055
+FBti0209984_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209984_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209984_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355814
+FBti0209984_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355814
+FBti0209984_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356056
+FBti0209985_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209985_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209985_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355815
+FBti0209985_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355815
+FBti0209985_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355932
+FBti0209986_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209986_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209986_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355816
+FBti0209986_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355816
+FBti0209986_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356057
+FBti0209987_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209987_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209987_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355817
+FBti0209987_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355817
+FBti0209987_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356058
+FBti0209988_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209988_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209988_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355818
+FBti0209988_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355818
+FBti0209988_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356059
+FBti0209989_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209989_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209989_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355819
+FBti0209989_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355819
+FBti0209989_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355933
+FBti0209990_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209990_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209990_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355820
+FBti0209990_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355820
+FBti0209990_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356060
+FBti0209991_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209991_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209991_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355821
+FBti0209991_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355821
+FBti0209991_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356061
+FBti0209992_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209992_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209992_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355822
+FBti0209992_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355822
+FBti0209992_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355934
+FBti0209993_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209993_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209993_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355823
+FBti0209993_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355823
+FBti0209993_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356062
+FBti0209994_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209994_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209994_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355824
+FBti0209994_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355824
+FBti0209994_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355935
+FBti0209995_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209995_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209995_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355825
+FBti0209995_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355825
+FBti0209995_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355936
+FBti0209996_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209996_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209996_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355826
+FBti0209996_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355826
+FBti0209996_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356063
+FBti0209997_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209997_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209997_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355827
+FBti0209997_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355827
+FBti0209997_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355937
+FBti0209998_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209998_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209998_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355828
+FBti0209998_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355828
+FBti0209998_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356064
+FBti0209999_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209999_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0209999_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355829
+FBti0209999_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355829
+FBti0209999_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355938
+FBti0210000_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210000_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210000_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355830
+FBti0210000_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355830
+FBti0210000_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356065
+FBti0210001_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210001_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210001_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355831
+FBti0210001_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355831
+FBti0210001_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355939
+FBti0210002_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210002_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210002_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355832
+FBti0210002_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355832
+FBti0210002_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356066
+FBti0210003_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210003_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210003_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355833
+FBti0210003_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355833
+FBti0210003_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355940
+FBti0210004_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210004_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210004_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355834
+FBti0210004_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355834
+FBti0210004_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356067
+FBti0210005_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210005_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210005_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355835
+FBti0210005_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355835
+FBti0210005_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356068
+FBti0210006_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210006_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210006_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355836
+FBti0210006_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355836
+FBti0210006_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355941
+FBti0210007_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210007_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210007_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355837
+FBti0210007_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355837
+FBti0210007_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356069
+FBti0210008_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210008_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210008_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355838
+FBti0210008_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355838
+FBti0210008_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355942
+FBti0210009_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210009_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210009_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355839
+FBti0210009_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355839
+FBti0210009_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355943
+FBti0210010_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210010_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210010_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355840
+FBti0210010_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355840
+FBti0210010_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356070
+FBti0210011_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210011_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210011_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355841
+FBti0210011_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355841
+FBti0210011_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355944
+FBti0210012_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210012_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210012_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355842
+FBti0210012_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355842
+FBti0210012_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356071
+FBti0210013_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210013_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210013_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355843
+FBti0210013_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355843
+FBti0210013_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355945
+FBti0210014_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210014_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210014_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355844
+FBti0210014_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355844
+FBti0210014_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356072
+FBti0210015_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210015_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210015_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355845
+FBti0210015_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355845
+FBti0210015_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355946
+FBti0210016_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210016_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210016_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355846
+FBti0210016_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355846
+FBti0210016_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356073
+FBti0210017_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210017_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210017_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355847
+FBti0210017_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355847
+FBti0210017_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355947
+FBti0210018_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210018_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210018_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355848
+FBti0210018_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355848
+FBti0210018_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356074
+FBti0210019_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210019_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210019_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355849
+FBti0210019_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355849
+FBti0210019_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355948
+FBti0210020_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210020_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210020_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355850
+FBti0210020_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355850
+FBti0210020_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355949
+FBti0210021_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210021_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210021_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355851
+FBti0210021_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355851
+FBti0210021_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355960
+FBti0210022_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210022_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210022_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355852
+FBti0210022_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355852
+FBti0210022_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356075
+FBti0210023_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210023_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210023_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355853
+FBti0210023_cas	tagged_with	FBto0000079	FBrf0243924		TOOL DATA from: FBal0355853
+FBti0210023_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356076
+FBti0210024_cas	encodes_tool	FBto0000155	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210024_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210024_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355854
+FBti0210024_cas	tagged_with	FBto0000093	FBrf0243924		TOOL DATA from: FBal0355854
+FBti0210024_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0355950
+FBti0210025_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210025_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210026_cas	encodes_tool	FBto0000166	FBrf0243924		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210026_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210026_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356078
+FBti0210026_cas	carries_tool	FBto0000349	FBrf0243924		TOOL DATA from: FBal0356080
+FBti0210033_cas	carries_tool	FBto0000318	FBrf0243881		TOOL DATA from: FBal0356089
+FBti0210033_cas	tagged_with	FBto0000027	FBrf0243881		TOOL DATA from: FBal0356089
+FBti0210035_cas				FTA: unable to add tool information from FBal0356105 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210036_cas	carries_tool	FBto0000349	FBrf0243754		TOOL DATA from: FBal0356106
+FBti0210036_cas	carries_tool	FBto0000356	FBrf0243754		TOOL DATA from: FBal0356106
+FBti0210038_cas	tagged_with	FBto0000076	FBrf0242308		TOOL DATA from: FBal0356129
+FBti0210039_cas	carries_tool	FBto0000349	FBrf0243775		TOOL DATA from: FBal0356141
+FBti0210039_cas	tagged_with	FBto0000028	FBrf0243775		TOOL DATA from: FBal0356141
+FBti0210040_cas	tagged_with	FBto0000031	FBrf0243162		TOOL DATA from: FBal0356168
+FBti0210040_cas	tagged_with	FBto0000076	FBrf0243162		TOOL DATA from: FBal0356168
+FBti0210040_cas	tagged_with	FBto0000093	FBrf0243162		TOOL DATA from: FBal0356168
+FBti0210041_cas	tagged_with	FBto0000031	FBrf0243162		TOOL DATA from: FBal0356173
+FBti0210041_cas	tagged_with	FBto0000076	FBrf0243162		TOOL DATA from: FBal0356173
+FBti0210041_cas	tagged_with	FBto0000093	FBrf0243162		TOOL DATA from: FBal0356173
+FBti0210052_cas				FTA: unable to add tool information from FBal0356212 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210053_cas	carries_tool	FBto0000349	FBrf0240702		TOOL DATA from: FBal0356230
+FBti0210054_cas				FTA: unable to add tool information from FBal0356231 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210055_cas				FTA: unable to add tool information from FBal0356232 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210061_cas	tagged_with	FBto0000093	FBrf0243748		TOOL DATA from: FBal0356243
+FBti0210061_cas	tagged_with	FBto0000589	FBrf0243748		TOOL DATA from: FBal0356243
+FBti0210062_cas	tagged_with	FBto0000093	FBrf0243748		TOOL DATA from: FBal0356244
+FBti0210062_cas	tagged_with	FBto0000589	FBrf0243748		TOOL DATA from: FBal0356244
+FBti0210063_cas	tagged_with	FBto0000093	FBrf0243748		TOOL DATA from: FBal0356245
+FBti0210063_cas	tagged_with	FBto0000589	FBrf0243748		TOOL DATA from: FBal0356245
+FBti0210065_cas	tagged_with	FBto0000166	FBrf0243173		TOOL DATA from: FBal0356253
+FBti0210096_cas	carries_tool	FBto0000349	FBrf0244173		TOOL DATA from: FBal0356314
+FBti0210096_cas	tagged_with	FBto0000027	FBrf0244173		TOOL DATA from: FBal0356314
+FBti0210097_cas	carries_tool	FBto0000349	FBrf0244175		TOOL DATA from: FBal0356320
+FBti0210097_cas	tagged_with	FBto0000126	FBrf0244175		TOOL DATA from: FBal0356320
+FBti0210098_cas	carries_tool	FBto0000349	FBrf0244175		TOOL DATA from: FBal0356321
+FBti0210098_cas	tagged_with	FBto0000126	FBrf0244175		TOOL DATA from: FBal0356321
+FBti0210099_cas	carries_tool	FBto0000349	FBrf0244175		TOOL DATA from: FBal0356322
+FBti0210099_cas	tagged_with	FBto0000031	FBrf0244175		TOOL DATA from: FBal0356322
+FBti0210099_cas	tagged_with	FBto0000077	FBrf0244175		TOOL DATA from: FBal0356322
+FBti0210213_cas	carries_tool	FBto0000356	FBrf0243785		TOOL DATA from: FBal0356483
+FBti0210214_cas	carries_tool	FBto0000356	FBrf0243785		TOOL DATA from: FBal0356484
+FBti0210236_cas	has_reg_region	FBto0000180	FBrf0244320		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210236_cas	tool_uses	misexpression element	FBrf0244320		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210237_cas	tagged_with	FBto0000077	FBrf0244320		TOOL DATA from: FBal0356523
+FBti0210238_cas	tagged_with	FBto0000031	FBrf0244320		TOOL DATA from: FBal0356524
+FBti0210241_cas	tagged_with	FBto0000077	FBrf0244320		TOOL DATA from: FBal0356527
+FBti0210242_cas	tagged_with	FBto0000031	FBrf0244320		TOOL DATA from: FBal0356528
+FBti0210542_cas	encodes_tool	FBto0000135	FBrf0236990		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210542_cas	tool_uses	promoter trap	FBrf0236990		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210543_cas	encodes_tool	FBto0000135	FBrf0236990		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210543_cas	tool_uses	promoter trap	FBrf0236990		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210544_cas	encodes_tool	FBto0000135	FBrf0236990		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210544_cas	tool_uses	promoter trap	FBrf0236990		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210545_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0357038
+FBti0210546_cas	encodes_tool	FBto0000153	FBrf0236990		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210546_cas	tool_uses	promoter trap	FBrf0236990		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210547_cas	encodes_tool	FBto0000135	FBrf0236990		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210547_cas	tool_uses	promoter trap	FBrf0236990		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210548_cas	encodes_tool	FBto0000135	FBrf0236990		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210548_cas	tool_uses	promoter trap	FBrf0236990		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210548_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0357044
+FBti0210548_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0357044
+FBti0210548_cas	carries_tool	FBto0000349	FBrf0236990		TOOL DATA from: FBal0357047
+FBti0210548_cas	carries_tool	FBto0000356	FBrf0236990		TOOL DATA from: FBal0357047
+FBti0210551_cas				FTA: unable to add tool information from FBal0357051 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210553_cas				FTA: unable to add tool information from FBal0357073 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210584_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210584_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210585_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210585_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210586_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210586_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210587_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210587_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210588_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210588_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210589_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210589_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210590_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210590_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210591_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210591_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210592_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210592_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210593_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210593_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210594_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210594_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210595_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210595_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210596_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210596_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210597_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210597_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210598_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210598_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210599_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210599_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210600_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210600_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210601_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210601_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210602_cas	encodes_tool	FBto0000135	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210602_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210603_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210603_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210604_cas	encodes_tool	FBto0000153	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210604_cas	tool_uses	promoter trap	FBrf0243924		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210609_cas	encodes_tool	FBto0000135	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210609_cas	tool_uses	promoter trap	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210610_cas	encodes_tool	FBto0000135	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210610_cas	tool_uses	promoter trap	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210611_cas	encodes_tool	FBto0000135	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210611_cas	tool_uses	promoter trap	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210612_cas	encodes_tool	FBto0000135	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210612_cas	tool_uses	promoter trap	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210613_cas	encodes_tool	FBto0000135	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210613_cas	tool_uses	promoter trap	FBrf0244536		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210614_cas	tagged_with	FBto0000027	FBrf0243879		TOOL DATA from: FBal0357203
+FBti0210632_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357261
+FBti0210632_cas	tagged_with	FBto0000063	FBrf0241737		TOOL DATA from: FBal0357261
+FBti0210633_cas	encodes_tool	FBto0000308	FBrf0241737		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210633_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210633_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357262
+FBti0210633_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357262
+FBti0210633_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357303
+FBti0210634_cas	encodes_tool	FBto0000166	FBrf0241737		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210634_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210634_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357263
+FBti0210634_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357307
+FBti0210635_cas	encodes_tool	FBto0000135	FBrf0241737		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210635_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210635_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357265
+FBti0210635_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0357265
+FBti0210635_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357298
+FBti0210635_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0357298
+FBti0210636_cas	encodes_tool	FBto0000135	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210636_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210636_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357266
+FBti0210636_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357266
+FBti0210636_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357302
+FBti0210637_cas	encodes_tool	FBto0000135	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210637_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210637_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357267
+FBti0210637_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357267
+FBti0210637_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357299
+FBti0210637_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357299
+FBti0210638_cas	encodes_tool	FBto0000308	FBrf0241737		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210638_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210638_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357268
+FBti0210638_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357268
+FBti0210638_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357304
+FBti0210639_cas	encodes_tool	FBto0000166	FBrf0241737		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210639_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210639_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357269
+FBti0210639_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357308
+FBti0210640_cas	encodes_tool	FBto0000135	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210640_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210640_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357271
+FBti0210640_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357271
+FBti0210640_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357301
+FBti0210641_cas	encodes_tool	FBto0000308	FBrf0241737		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210641_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210641_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357272
+FBti0210641_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357272
+FBti0210641_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357305
+FBti0210642_cas	encodes_tool	FBto0000166	FBrf0241737		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210642_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210642_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357273
+FBti0210642_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357309
+FBti0210643_cas	encodes_tool	FBto0000308	FBrf0241737		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210643_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210643_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357274
+FBti0210643_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357274
+FBti0210643_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357306
+FBti0210644_cas	encodes_tool	FBto0000135	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210644_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210644_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357275
+FBti0210644_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357275
+FBti0210644_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357295
+FBti0210644_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357295
+FBti0210645_cas	encodes_tool	FBto0000135	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210645_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210645_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357276
+FBti0210645_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357276
+FBti0210645_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357296
+FBti0210645_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357296
+FBti0210646_cas	encodes_tool	FBto0000135	FBrf0241737		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210646_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210646_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357277
+FBti0210646_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0357277
+FBti0210646_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357297
+FBti0210646_cas	carries_tool	FBto0000356	FBrf0241737		TOOL DATA from: FBal0357297
+FBti0210647_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357278
+FBti0210647_cas	tagged_with	FBto0000063	FBrf0241737		TOOL DATA from: FBal0357278
+FBti0210648_cas				FTA: unable to add tool information from FBal0357279 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210649_cas				FTA: unable to add tool information from FBal0357280 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210650_cas				FTA: unable to add tool information from FBal0357281 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210651_cas				FTA: unable to add tool information from FBal0357282 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210652_cas				FTA: unable to add tool information from FBal0357283 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210653_cas				FTA: unable to add tool information from FBal0357284 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210654_cas				FTA: unable to add tool information from FBal0357285 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210655_cas				FTA: unable to add tool information from FBal0357286 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210656_cas				FTA: unable to add tool information from FBal0357287 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210657_cas				FTA: unable to add tool information from FBal0357288 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210658_cas				FTA: unable to add tool information from FBal0357289 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210659_cas				FTA: unable to add tool information from FBal0357290 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210660_cas				FTA: unable to add tool information from FBal0357291 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210661_cas				FTA: unable to add tool information from FBal0357292 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210662_cas				FTA: unable to add tool information from FBal0357293 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210663_cas				FTA: unable to add tool information from FBal0357294 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0210664_cas	encodes_tool	FBto0000135	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210664_cas	tool_uses	promoter trap	FBrf0241737		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0210664_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357300
+FBti0210664_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357300
+FBti0210664_cas	carries_tool	FBto0000349	FBrf0241737		TOOL DATA from: FBal0357310
+FBti0210664_cas	tagged_with	FBto0000079	FBrf0241737		TOOL DATA from: FBal0357310
+FBti0210780_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358022
+FBti0210780_cas	carries_tool	FBto0000356	FBrf0243398		TOOL DATA from: FBal0358022
+FBti0210781_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358023
+FBti0210782_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358024
+FBti0210783_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358025
+FBti0210784_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358026
+FBti0210785_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358027
+FBti0210786_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358028
+FBti0210787_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358029
+FBti0210788_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358030
+FBti0210789_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358031
+FBti0210790_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358032
+FBti0210791_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358033
+FBti0210792_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358034
+FBti0210793_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358035
+FBti0210794_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358036
+FBti0210795_cas	carries_tool	FBto0000349	FBrf0243398		TOOL DATA from: FBal0358037
+FBti0211003_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358297
+FBti0211004_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358299
+FBti0211005_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358300
+FBti0211006_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358302
+FBti0211007_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358304
+FBti0211008_cas	carries_tool	FBto0000349	FBrf0244487		TOOL DATA from: FBal0358305
+FBti0211017_cas	encodes_tool	FBto0000135	FBrf0244507		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211017_cas	tool_uses	promoter trap	FBrf0244507		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211017_cas	carries_tool	FBto0000349	FBrf0244507		TOOL DATA from: FBal0358315
+FBti0211017_cas	carries_tool	FBto0000349	FBrf0244507		TOOL DATA from: FBal0358329
+FBti0211037_cas				FTA: unable to add tool information from FBal0358346 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211040_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358351
+FBti0211040_cas	carries_tool	FBto0000356	FBrf0239358		TOOL DATA from: FBal0358351
+FBti0211041_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358352
+FBti0211042_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358353
+FBti0211042_cas	tagged_with	FBto0000077	FBrf0239358		TOOL DATA from: FBal0358353
+FBti0211043_cas	tagged_with	FBto0000077	FBrf0239358		TOOL DATA from: FBal0358354
+FBti0211044_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358355
+FBti0211044_cas	carries_tool	FBto0000356	FBrf0239358		TOOL DATA from: FBal0358355
+FBti0211045_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358356
+FBti0211045_cas	tagged_with	FBto0000031	FBrf0239358		TOOL DATA from: FBal0358356
+FBti0211046_cas	carries_tool	FBto0000349	FBrf0239358		TOOL DATA from: FBal0358358
+FBti0211046_cas	tagged_with	FBto0000031	FBrf0239358		TOOL DATA from: FBal0358358
+FBti0211048_cas	carries_tool	FBto0000356	FBrf0242094		TOOL DATA from: FBal0358360
+FBti0211049_cas	carries_tool	FBto0000356	FBrf0242094		TOOL DATA from: FBal0358361
+FBti0211049_cas	carries_tool	FBto0000356	FBrf0242094		TOOL DATA from: FBal0358372
+FBti0211050_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358362
+FBti0211050_cas	tool_uses	mechanical force sensor	FBrf0242094		TOOL DATA from: FBal0358362
+FBti0211051_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358363
+FBti0211051_cas	tool_uses	mechanical force sensor	FBrf0242094		TOOL DATA from: FBal0358363
+FBti0211052_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358364
+FBti0211052_cas	tool_uses	mechanical force sensor	FBrf0242094		TOOL DATA from: FBal0358364
+FBti0211053_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358365
+FBti0211054_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358366
+FBti0211055_cas	tool_uses	fluorescent protein	FBrf0242094		TOOL DATA from: FBal0358367
+FBti0211056_cas	tagged_with	FBto0000105	FBrf0242094		TOOL DATA from: FBal0358368
+FBti0211057_cas	tagged_with	FBto0000118	FBrf0242094		TOOL DATA from: FBal0358369
+FBti0211058_cas	tagged_with	FBto0000105	FBrf0242094		TOOL DATA from: FBal0358370
+FBti0211059_cas	tagged_with	FBto0000118	FBrf0242094		TOOL DATA from: FBal0358371
+FBti0211086_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358420
+FBti0211086_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358425
+FBti0211087_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358421
+FBti0211087_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358426
+FBti0211088_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358422
+FBti0211088_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358427
+FBti0211089_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358423
+FBti0211089_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358428
+FBti0211090_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358424
+FBti0211090_cas	carries_tool	FBto0000349	FBrf0236541		TOOL DATA from: FBal0358429
+FBti0211092_cas	encodes_tool	FBto0000155	FBrf0230875		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211092_cas	tool_uses	promoter trap	FBrf0230875		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211093_cas	encodes_tool	FBto0000155	FBrf0230875		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211093_cas	tool_uses	promoter trap	FBrf0230875		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211112_cas	carries_tool	FBto0000318	FBrf0243031		TOOL DATA from: FBal0358484
+FBti0211112_cas	carries_tool	FBto0000349	FBrf0243031		TOOL DATA from: FBal0358484
+FBti0211112_cas	tagged_with	FBto0000031	FBrf0243031		TOOL DATA from: FBal0358484
+FBti0211113_cas	encodes_tool	FBto0000308	FBrf0243031		TOOL DATA from: FBtp0099203, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211113_cas	tool_uses	promoter trap	FBrf0243031		TOOL DATA from: FBtp0099203, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211113_cas	has_reg_region	FBgn0001235	FBrf0243031		TOOL DATA from: FBal0358482
+FBti0211114_cas	carries_tool	FBto0000318	FBrf0243031		TOOL DATA from: FBal0358483
+FBti0211114_cas	carries_tool	FBto0000349	FBrf0243031		TOOL DATA from: FBal0358483
+FBti0211115_cas	tagged_with	FBto0000031	FBrf0242987		TOOL DATA from: FBal0358491
+FBti0211116_cas	tagged_with	FBto0000093	FBrf0242987		TOOL DATA from: FBal0358492
+FBti0211125_cas	has_reg_region	FBto0000180	FBrf0244085		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211125_cas	tool_uses	misexpression element	FBrf0244085		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211125_cas	carries_tool	FBto0000349	FBrf0244085		TOOL DATA from: FBal0358515
+FBti0211127_cas	carries_tool	FBto0000349	FBrf0243083		TOOL DATA from: FBal0358521
+FBti0211127_cas	carries_tool	FBto0000356	FBrf0243083		TOOL DATA from: FBal0358521
+FBti0211128_cas	carries_tool	FBto0000349	FBrf0243083		TOOL DATA from: FBal0358522
+FBti0211129_cas	carries_tool	FBto0000349	FBrf0243083		TOOL DATA from: FBal0358523
+FBti0211130_cas	carries_tool	FBto0000349	FBrf0243083		TOOL DATA from: FBal0358524
+FBti0211172_cas	carries_tool	FBto0000349	FBrf0244557		TOOL DATA from: FBal0358600
+FBti0211172_cas	carries_tool	FBto0000356	FBrf0244557		TOOL DATA from: FBal0358600
+FBti0211172_cas	carries_tool	FBto0000375	FBrf0244557		TOOL DATA from: FBal0358600
+FBti0211174_cas	encodes_tool	FBto0000146	FBrf0237473		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211174_cas	tool_uses	promoter trap	FBrf0237473		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211175_cas	encodes_tool	FBto0000166	FBrf0237473		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211175_cas	tool_uses	promoter trap	FBrf0237473		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211176_cas	encodes_tool	FBto0000157	FBrf0237473		TOOL DATA from: FBtp0141342, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211176_cas	tool_uses	promoter trap	FBrf0237473		TOOL DATA from: FBtp0141342, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211181_cas				FTA: unable to add tool information from FBal0358641 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211182_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358642
+FBti0211182_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358642
+FBti0211183_cas				FTA: unable to add tool information from FBal0358643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211184_cas				FTA: unable to add tool information from FBal0358644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211185_cas				FTA: unable to add tool information from FBal0358645 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211186_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358646
+FBti0211186_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358646
+FBti0211187_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358647
+FBti0211187_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358647
+FBti0211188_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358648
+FBti0211188_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358648
+FBti0211189_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358649
+FBti0211189_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358649
+FBti0211190_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358650
+FBti0211190_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358650
+FBti0211191_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358651
+FBti0211191_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358651
+FBti0211192_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358652
+FBti0211192_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358652
+FBti0211193_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358653
+FBti0211193_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358653
+FBti0211194_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358654
+FBti0211194_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358654
+FBti0211195_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358655
+FBti0211195_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358655
+FBti0211196_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358656
+FBti0211196_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358656
+FBti0211197_cas	carries_tool	FBto0000349	FBrf0235092		TOOL DATA from: FBal0358657
+FBti0211197_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0358657
+FBti0211205_cas	encodes_tool	FBto0000118	FBrf0244531		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211205_cas	tool_uses	promoter trap	FBrf0244531		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211205_cas	carries_tool	FBto0000320	FBrf0244531		TOOL DATA from: FBal0358699
+FBti0211205_cas	carries_tool	FBto0000349	FBrf0244531		TOOL DATA from: FBal0358699
+FBti0211205_cas	carries_tool	FBto0000356	FBrf0244531		TOOL DATA from: FBal0358699
+FBti0211211_cas	tagged_with	FBto0000027	FBrf0244258		TOOL DATA from: FBal0358713
+FBti0211212_cas	tagged_with	FBto0000027	FBrf0244258		TOOL DATA from: FBal0358719
+FBti0211222_cas	carries_tool	FBto0000318	FBrf0244620		TOOL DATA from: FBal0358724
+FBti0211222_cas	carries_tool	FBto0000349	FBrf0244620		TOOL DATA from: FBal0358724
+FBti0211222_cas	tagged_with	FBto0000093	FBrf0244620		TOOL DATA from: FBal0358724
+FBti0211223_cas	carries_tool	FBto0000318	FBrf0244620		TOOL DATA from: FBal0358725
+FBti0211223_cas	tagged_with	FBto0000076	FBrf0244620		TOOL DATA from: FBal0358725
+FBti0211224_cas	encodes_tool	FBto0000135	FBrf0244526		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211224_cas	tool_uses	promoter trap	FBrf0244526		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211224_cas	carries_tool	FBto0000349	FBrf0244526		TOOL DATA from: FBal0358729
+FBti0211224_cas	carries_tool	FBto0000349	FBrf0244526		TOOL DATA from: FBal0358730
+FBti0211241_cas	encodes_tool	FBto0000621	FBrf0243140		TOOL DATA from: FBtp0141328, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211241_cas	tool_uses	promoter trap	FBrf0243140		TOOL DATA from: FBtp0141328, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211250_cas	tagged_with	FBto0000076	FBrf0244753		TOOL DATA from: FBal0358829
+FBti0211276_cas	carries_tool	FBto0000318	FBrf0244760		TOOL DATA from: FBal0358914
+FBti0211276_cas	tagged_with	FBto0000079	FBrf0244760		TOOL DATA from: FBal0358914
+FBti0211277_cas	carries_tool	FBto0000326	FBrf0244760		TOOL DATA from: FBal0358915
+FBti0211277_cas	tagged_with	FBto0000079	FBrf0244760		TOOL DATA from: FBal0358915
+FBti0211278_cas	carries_tool	FBto0000318	FBrf0244760		TOOL DATA from: FBal0358916
+FBti0211278_cas	tagged_with	FBto0000081	FBrf0244760		TOOL DATA from: FBal0358916
+FBti0211279_cas	carries_tool	FBto0000326	FBrf0244760		TOOL DATA from: FBal0358917
+FBti0211279_cas	tagged_with	FBto0000081	FBrf0244760		TOOL DATA from: FBal0358917
+FBti0211280_cas	carries_tool	FBto0000318	FBrf0244760		TOOL DATA from: FBal0358918
+FBti0211280_cas	tagged_with	FBto0000079	FBrf0244760		TOOL DATA from: FBal0358918
+FBti0211281_cas	carries_tool	FBto0000326	FBrf0244760		TOOL DATA from: FBal0358919
+FBti0211281_cas	tagged_with	FBto0000079	FBrf0244760		TOOL DATA from: FBal0358919
+FBti0211282_cas	carries_tool	FBto0000318	FBrf0244760		TOOL DATA from: FBal0358920
+FBti0211282_cas	tagged_with	FBto0000081	FBrf0244760		TOOL DATA from: FBal0358920
+FBti0211283_cas	carries_tool	FBto0000326	FBrf0244760		TOOL DATA from: FBal0358921
+FBti0211283_cas	tagged_with	FBto0000081	FBrf0244760		TOOL DATA from: FBal0358921
+FBti0211290_cas	tagged_with	FBto0000079	FBrf0244809		TOOL DATA from: FBal0358927
+FBti0211290_cas	tagged_with	FBto0000093	FBrf0244809		TOOL DATA from: FBal0358927
+FBti0211290_cas	tagged_with	FBto0000403	FBrf0244809		TOOL DATA from: FBal0358927
+FBti0211291_cas	tagged_with	FBto0000079	FBrf0244809		TOOL DATA from: FBal0358928
+FBti0211291_cas	tagged_with	FBto0000093	FBrf0244809		TOOL DATA from: FBal0358928
+FBti0211291_cas	tagged_with	FBto0000403	FBrf0244809		TOOL DATA from: FBal0358928
+FBti0211296_cas	tagged_with	FBto0000335	FBrf0243150		TOOL DATA from: FBal0358944
+FBti0211300_cas	tagged_with	FBto0000623	FBrf0239119		TOOL DATA from: FBal0358953
+FBti0211301_cas	tagged_with	FBto0000622	FBrf0239119		TOOL DATA from: FBal0358955
+FBti0211313_cas	tagged_with	FBto0000126	FBrf0244839		TOOL DATA from: FBal0358978
+FBti0211314_cas	tagged_with	FBto0000126	FBrf0244839		TOOL DATA from: FBal0358979
+FBti0211325_cas	tagged_with	FBto0000633	FBrf0243137		TOOL DATA from: FBal0359012
+FBti0211378_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211378_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211378_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359119
+FBti0211378_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359119
+FBti0211378_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359119
+FBti0211378_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359210
+FBti0211378_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359210
+FBti0211378_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359210
+FBti0211379_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211379_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211379_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359120
+FBti0211379_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359120
+FBti0211379_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359120
+FBti0211379_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359211
+FBti0211379_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359211
+FBti0211379_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359211
+FBti0211380_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211380_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211380_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359121
+FBti0211380_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359121
+FBti0211380_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359121
+FBti0211380_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359212
+FBti0211380_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359212
+FBti0211380_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359212
+FBti0211381_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211381_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211381_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359122
+FBti0211381_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359122
+FBti0211381_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359122
+FBti0211381_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359213
+FBti0211381_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359213
+FBti0211381_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359213
+FBti0211382_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211382_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211382_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359123
+FBti0211382_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359123
+FBti0211382_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359123
+FBti0211382_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359214
+FBti0211382_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359214
+FBti0211382_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359214
+FBti0211383_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211383_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211383_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359124
+FBti0211383_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359124
+FBti0211383_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359124
+FBti0211383_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359215
+FBti0211383_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359215
+FBti0211383_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359215
+FBti0211384_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211384_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211384_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359125
+FBti0211384_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359125
+FBti0211384_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359125
+FBti0211384_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359216
+FBti0211384_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359216
+FBti0211384_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359216
+FBti0211385_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211385_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211385_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359126
+FBti0211385_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359126
+FBti0211385_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359126
+FBti0211385_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359217
+FBti0211385_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359217
+FBti0211385_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359217
+FBti0211386_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211386_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211386_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359127
+FBti0211386_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359127
+FBti0211386_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359127
+FBti0211386_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359218
+FBti0211386_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359218
+FBti0211386_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359218
+FBti0211387_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211387_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211387_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359128
+FBti0211387_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359128
+FBti0211387_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359128
+FBti0211387_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359219
+FBti0211387_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359219
+FBti0211387_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359219
+FBti0211388_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211388_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211388_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359129
+FBti0211388_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359129
+FBti0211388_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359129
+FBti0211388_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359220
+FBti0211388_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359220
+FBti0211388_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359220
+FBti0211389_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211389_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211389_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359130
+FBti0211389_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359130
+FBti0211389_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359130
+FBti0211389_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359221
+FBti0211389_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359221
+FBti0211389_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359221
+FBti0211390_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211390_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211390_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359131
+FBti0211390_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359131
+FBti0211390_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359131
+FBti0211390_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359222
+FBti0211390_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359222
+FBti0211390_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359222
+FBti0211391_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211391_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211391_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359132
+FBti0211391_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359132
+FBti0211391_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359132
+FBti0211391_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359223
+FBti0211391_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359223
+FBti0211391_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359223
+FBti0211392_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211392_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211392_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359133
+FBti0211392_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359133
+FBti0211392_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359133
+FBti0211392_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359224
+FBti0211392_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359224
+FBti0211392_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359224
+FBti0211393_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211393_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211393_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359134
+FBti0211393_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359134
+FBti0211393_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359134
+FBti0211393_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359225
+FBti0211393_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359225
+FBti0211393_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359225
+FBti0211394_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211394_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211394_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359135
+FBti0211394_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359135
+FBti0211394_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359135
+FBti0211394_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359226
+FBti0211394_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359226
+FBti0211394_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359226
+FBti0211395_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211395_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211395_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359136
+FBti0211395_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359136
+FBti0211395_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359136
+FBti0211395_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359227
+FBti0211395_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359227
+FBti0211395_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359227
+FBti0211396_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211396_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211396_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359137
+FBti0211396_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359137
+FBti0211396_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359137
+FBti0211396_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359259
+FBti0211396_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359259
+FBti0211396_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359259
+FBti0211397_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359138
+FBti0211397_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359138
+FBti0211397_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359138
+FBti0211398_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211398_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211398_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359139
+FBti0211398_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359139
+FBti0211398_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359139
+FBti0211398_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359228
+FBti0211398_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359228
+FBti0211398_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359228
+FBti0211399_cas	encodes_tool	FBto0000158	FBrf0244475		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211399_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211399_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359140
+FBti0211399_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359140
+FBti0211399_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359291
+FBti0211399_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359291
+FBti0211400_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359141
+FBti0211400_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359141
+FBti0211400_cas	tagged_with	FBto0000070	FBrf0244475		TOOL DATA from: FBal0359141
+FBti0211401_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211401_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211401_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359142
+FBti0211401_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359142
+FBti0211401_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359142
+FBti0211401_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359229
+FBti0211401_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359229
+FBti0211401_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359229
+FBti0211402_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359143
+FBti0211402_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359143
+FBti0211402_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359143
+FBti0211403_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211403_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211403_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359144
+FBti0211403_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359144
+FBti0211403_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359144
+FBti0211403_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359230
+FBti0211403_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359230
+FBti0211403_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359230
+FBti0211404_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359145
+FBti0211404_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359145
+FBti0211404_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359145
+FBti0211405_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359146
+FBti0211405_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359146
+FBti0211405_cas	tagged_with	FBto0000070	FBrf0244475		TOOL DATA from: FBal0359146
+FBti0211406_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211406_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211406_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359147
+FBti0211406_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359147
+FBti0211406_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359147
+FBti0211406_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359231
+FBti0211406_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359231
+FBti0211406_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359231
+FBti0211407_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211407_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211407_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359148
+FBti0211407_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359148
+FBti0211407_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359148
+FBti0211407_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359232
+FBti0211407_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359232
+FBti0211407_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359232
+FBti0211408_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211408_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211408_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359149
+FBti0211408_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359149
+FBti0211408_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359149
+FBti0211408_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359233
+FBti0211408_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359233
+FBti0211408_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359233
+FBti0211409_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211409_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211409_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359150
+FBti0211409_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359150
+FBti0211409_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359150
+FBti0211409_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359234
+FBti0211409_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359234
+FBti0211409_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359234
+FBti0211410_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211410_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211410_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359151
+FBti0211410_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359151
+FBti0211410_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359151
+FBti0211410_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359235
+FBti0211410_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359235
+FBti0211410_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359235
+FBti0211411_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211411_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211411_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359152
+FBti0211411_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359152
+FBti0211411_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359152
+FBti0211411_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359236
+FBti0211411_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359236
+FBti0211411_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359236
+FBti0211412_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211412_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211412_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359153
+FBti0211412_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359153
+FBti0211412_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359153
+FBti0211412_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359237
+FBti0211412_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359237
+FBti0211412_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359237
+FBti0211413_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211413_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211413_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359154
+FBti0211413_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359154
+FBti0211413_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359154
+FBti0211413_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359238
+FBti0211413_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359238
+FBti0211413_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359238
+FBti0211414_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211414_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211414_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359155
+FBti0211414_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359155
+FBti0211414_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359155
+FBti0211414_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359239
+FBti0211414_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359239
+FBti0211414_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359239
+FBti0211415_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211415_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211415_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359156
+FBti0211415_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359156
+FBti0211415_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359156
+FBti0211415_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359240
+FBti0211415_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359240
+FBti0211415_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359240
+FBti0211416_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211416_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211416_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359157
+FBti0211416_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359157
+FBti0211416_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359157
+FBti0211416_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359241
+FBti0211416_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359241
+FBti0211416_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359241
+FBti0211417_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211417_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211417_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359158
+FBti0211417_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359158
+FBti0211417_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359158
+FBti0211417_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359242
+FBti0211417_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359242
+FBti0211417_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359242
+FBti0211418_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211418_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211418_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359159
+FBti0211418_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359159
+FBti0211418_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359159
+FBti0211418_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359243
+FBti0211418_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359243
+FBti0211418_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359243
+FBti0211419_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211419_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211419_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359160
+FBti0211419_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359160
+FBti0211419_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359160
+FBti0211419_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359244
+FBti0211419_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359244
+FBti0211419_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359244
+FBti0211420_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211420_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211420_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359161
+FBti0211420_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359161
+FBti0211420_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359161
+FBti0211420_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359245
+FBti0211420_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359245
+FBti0211420_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359245
+FBti0211421_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211421_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211421_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359162
+FBti0211421_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359162
+FBti0211421_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359162
+FBti0211421_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359246
+FBti0211421_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359246
+FBti0211421_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359246
+FBti0211422_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211422_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211422_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359163
+FBti0211422_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359163
+FBti0211422_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359163
+FBti0211422_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359247
+FBti0211422_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359247
+FBti0211422_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359247
+FBti0211423_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211423_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211423_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359164
+FBti0211423_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359164
+FBti0211423_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359164
+FBti0211423_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359248
+FBti0211423_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359248
+FBti0211423_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359248
+FBti0211424_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211424_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211424_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359165
+FBti0211424_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359165
+FBti0211424_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359165
+FBti0211424_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359249
+FBti0211424_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359249
+FBti0211424_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359249
+FBti0211425_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211425_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211425_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359166
+FBti0211425_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359166
+FBti0211425_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359166
+FBti0211425_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359250
+FBti0211425_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359250
+FBti0211425_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359250
+FBti0211426_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211426_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211426_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359167
+FBti0211426_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359167
+FBti0211426_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359167
+FBti0211426_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359251
+FBti0211426_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359251
+FBti0211426_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359251
+FBti0211427_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211427_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211427_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359168
+FBti0211427_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359168
+FBti0211427_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359168
+FBti0211427_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359252
+FBti0211427_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359252
+FBti0211427_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359252
+FBti0211428_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211428_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211428_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359169
+FBti0211428_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359169
+FBti0211428_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359169
+FBti0211428_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359253
+FBti0211428_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359253
+FBti0211428_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359253
+FBti0211429_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211429_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211429_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359170
+FBti0211429_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359170
+FBti0211429_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359170
+FBti0211429_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359254
+FBti0211429_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359254
+FBti0211429_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359254
+FBti0211430_cas	encodes_tool	FBto0000158	FBrf0244475		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211430_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211430_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359171
+FBti0211430_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359171
+FBti0211430_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359290
+FBti0211430_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359290
+FBti0211431_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211431_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211431_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359172
+FBti0211431_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359172
+FBti0211431_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359172
+FBti0211431_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359255
+FBti0211431_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359255
+FBti0211431_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359255
+FBti0211432_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211432_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211432_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359173
+FBti0211432_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359173
+FBti0211432_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359173
+FBti0211432_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359256
+FBti0211432_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359256
+FBti0211432_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359256
+FBti0211433_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211433_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211433_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359174
+FBti0211433_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359174
+FBti0211433_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359174
+FBti0211433_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359257
+FBti0211433_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359257
+FBti0211433_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359257
+FBti0211434_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211434_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211434_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359175
+FBti0211434_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359175
+FBti0211434_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359175
+FBti0211434_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359258
+FBti0211434_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359258
+FBti0211434_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359258
+FBti0211435_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211435_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211435_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359176
+FBti0211435_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359176
+FBti0211435_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359176
+FBti0211435_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359260
+FBti0211435_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359260
+FBti0211435_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359260
+FBti0211436_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211436_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211436_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359177
+FBti0211436_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359177
+FBti0211436_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359177
+FBti0211436_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359261
+FBti0211436_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359261
+FBti0211436_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359261
+FBti0211437_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211437_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211437_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359178
+FBti0211437_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359178
+FBti0211437_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359178
+FBti0211437_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359262
+FBti0211437_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359262
+FBti0211437_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359262
+FBti0211438_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211438_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211438_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359179
+FBti0211438_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359179
+FBti0211438_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359179
+FBti0211438_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359263
+FBti0211438_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359263
+FBti0211438_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359263
+FBti0211439_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211439_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211439_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359180
+FBti0211439_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359180
+FBti0211439_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359180
+FBti0211439_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359264
+FBti0211439_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359264
+FBti0211439_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359264
+FBti0211440_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211440_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211440_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359181
+FBti0211440_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359181
+FBti0211440_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359181
+FBti0211440_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359265
+FBti0211440_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359265
+FBti0211440_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359265
+FBti0211441_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211441_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211441_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359182
+FBti0211441_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359182
+FBti0211441_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359182
+FBti0211441_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359266
+FBti0211441_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359266
+FBti0211441_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359266
+FBti0211442_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211442_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211442_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359183
+FBti0211442_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359183
+FBti0211442_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359183
+FBti0211442_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359267
+FBti0211442_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359267
+FBti0211442_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359267
+FBti0211443_cas	encodes_tool	FBto0000158	FBrf0244475		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211443_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211443_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359184
+FBti0211443_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359184
+FBti0211443_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359292
+FBti0211443_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359292
+FBti0211444_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359185
+FBti0211444_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359185
+FBti0211444_cas	tagged_with	FBto0000070	FBrf0244475		TOOL DATA from: FBal0359185
+FBti0211445_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211445_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211445_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359186
+FBti0211445_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359186
+FBti0211445_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359186
+FBti0211445_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359268
+FBti0211445_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359268
+FBti0211445_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359268
+FBti0211446_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359187
+FBti0211446_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359187
+FBti0211446_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359187
+FBti0211447_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211447_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211447_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359188
+FBti0211447_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359188
+FBti0211447_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359188
+FBti0211447_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359269
+FBti0211447_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359269
+FBti0211447_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359269
+FBti0211448_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359189
+FBti0211448_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359189
+FBti0211448_cas	tagged_with	FBto0000102	FBrf0244475		TOOL DATA from: FBal0359189
+FBti0211449_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211449_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211449_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359190
+FBti0211449_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359190
+FBti0211449_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359190
+FBti0211449_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359270
+FBti0211449_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359270
+FBti0211449_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359270
+FBti0211450_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211450_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211450_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359191
+FBti0211450_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359191
+FBti0211450_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359191
+FBti0211450_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359271
+FBti0211450_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359271
+FBti0211450_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359271
+FBti0211451_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211451_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211451_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359192
+FBti0211451_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359192
+FBti0211451_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359192
+FBti0211451_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359272
+FBti0211451_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359272
+FBti0211451_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359272
+FBti0211452_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211452_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211452_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359193
+FBti0211452_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359193
+FBti0211452_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359193
+FBti0211452_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359273
+FBti0211452_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359273
+FBti0211452_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359273
+FBti0211453_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211453_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211453_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359194
+FBti0211453_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359194
+FBti0211453_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359194
+FBti0211453_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359274
+FBti0211453_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359274
+FBti0211453_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359274
+FBti0211454_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211454_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211454_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359195
+FBti0211454_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359195
+FBti0211454_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359195
+FBti0211454_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359275
+FBti0211454_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359275
+FBti0211454_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359275
+FBti0211455_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211455_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211455_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359196
+FBti0211455_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359196
+FBti0211455_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359196
+FBti0211455_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359276
+FBti0211455_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359276
+FBti0211455_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359276
+FBti0211456_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211456_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211456_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359197
+FBti0211456_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359197
+FBti0211456_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359197
+FBti0211456_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359277
+FBti0211456_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359277
+FBti0211456_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359277
+FBti0211457_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211457_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211457_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359198
+FBti0211457_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359198
+FBti0211457_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359198
+FBti0211457_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359278
+FBti0211457_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359278
+FBti0211457_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359278
+FBti0211458_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211458_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211458_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359199
+FBti0211458_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359199
+FBti0211458_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359199
+FBti0211458_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359279
+FBti0211458_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359279
+FBti0211458_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359279
+FBti0211459_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211459_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211459_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359200
+FBti0211459_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359200
+FBti0211459_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359200
+FBti0211459_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359280
+FBti0211459_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359280
+FBti0211459_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359280
+FBti0211460_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211460_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211460_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359201
+FBti0211460_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359201
+FBti0211460_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359201
+FBti0211460_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359281
+FBti0211460_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359281
+FBti0211460_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359281
+FBti0211461_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211461_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211461_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359202
+FBti0211461_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359202
+FBti0211461_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359202
+FBti0211461_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359282
+FBti0211461_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359282
+FBti0211461_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359282
+FBti0211462_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211462_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211462_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359203
+FBti0211462_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359203
+FBti0211462_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359203
+FBti0211462_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359283
+FBti0211462_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359283
+FBti0211462_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359283
+FBti0211463_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211463_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211463_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359204
+FBti0211463_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359204
+FBti0211463_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359204
+FBti0211463_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359284
+FBti0211463_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359284
+FBti0211463_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359284
+FBti0211464_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211464_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211464_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359205
+FBti0211464_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359205
+FBti0211464_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359205
+FBti0211464_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359285
+FBti0211464_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359285
+FBti0211464_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359285
+FBti0211465_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211465_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211465_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359206
+FBti0211465_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359206
+FBti0211465_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359206
+FBti0211465_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359286
+FBti0211465_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359286
+FBti0211465_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359286
+FBti0211466_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211466_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211466_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359207
+FBti0211466_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359207
+FBti0211466_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359207
+FBti0211466_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359287
+FBti0211466_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359287
+FBti0211466_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359287
+FBti0211467_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211467_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211467_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359208
+FBti0211467_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359208
+FBti0211467_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359208
+FBti0211467_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359288
+FBti0211467_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359288
+FBti0211467_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359288
+FBti0211468_cas	encodes_tool	FBto0000135	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211468_cas	tool_uses	promoter trap	FBrf0244475		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211468_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359209
+FBti0211468_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359209
+FBti0211468_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359209
+FBti0211468_cas	carries_tool	FBto0000345	FBrf0244475		TOOL DATA from: FBal0359289
+FBti0211468_cas	carries_tool	FBto0000349	FBrf0244475		TOOL DATA from: FBal0359289
+FBti0211468_cas	carries_tool	FBto0000356	FBrf0244475		TOOL DATA from: FBal0359289
+FBti0211477_cas	encodes_tool	FBto0000135	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211477_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211477_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359444
+FBti0211477_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359487
+FBti0211478_cas	encodes_tool	FBto0000135	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211478_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211478_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359445
+FBti0211478_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359465
+FBti0211479_cas	encodes_tool	FBto0000135	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211479_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211479_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359446
+FBti0211479_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359466
+FBti0211480_cas	encodes_tool	FBto0000135	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211480_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211480_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359447
+FBti0211480_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359467
+FBti0211481_cas	encodes_tool	FBto0000135	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211481_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211481_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359448
+FBti0211481_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359468
+FBti0211482_cas	encodes_tool	FBto0000135	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211482_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211482_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359449
+FBti0211482_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359469
+FBti0211483_cas				FTA: unable to add tool information from FBal0359455 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211484_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359456
+FBti0211485_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359457
+FBti0211486_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359458
+FBti0211487_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359459
+FBti0211488_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359460
+FBti0211489_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359461
+FBti0211490_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359462
+FBti0211491_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359463
+FBti0211492_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359464
+FBti0211493_cas	encodes_tool	FBto0000158	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211493_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211493_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359470
+FBti0211493_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359490
+FBti0211494_cas	encodes_tool	FBto0000158	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211494_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211494_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359471
+FBti0211494_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359491
+FBti0211495_cas	encodes_tool	FBto0000158	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211495_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211495_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359472
+FBti0211495_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359492
+FBti0211496_cas	encodes_tool	FBto0000158	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211496_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211496_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359473
+FBti0211496_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359493
+FBti0211497_cas	encodes_tool	FBto0000158	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211497_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211497_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359474
+FBti0211497_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359494
+FBti0211498_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359475
+FBti0211498_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359475
+FBti0211499_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359476
+FBti0211499_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359476
+FBti0211500_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359477
+FBti0211500_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359477
+FBti0211501_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359478
+FBti0211501_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359478
+FBti0211502_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359479
+FBti0211502_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359479
+FBti0211503_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359480
+FBti0211503_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359480
+FBti0211504_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359481
+FBti0211504_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359481
+FBti0211505_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359482
+FBti0211505_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359482
+FBti0211506_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359483
+FBti0211506_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359483
+FBti0211507_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359484
+FBti0211507_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359484
+FBti0211508_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359485
+FBti0211508_cas	tagged_with	FBto0000076	FBrf0244200		TOOL DATA from: FBal0359485
+FBti0211509_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359486
+FBti0211509_cas	tagged_with	FBto0000031	FBrf0244200		TOOL DATA from: FBal0359486
+FBti0211510_cas	encodes_tool	FBto0000158	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211510_cas	tool_uses	promoter trap	FBrf0244200		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211510_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359488
+FBti0211510_cas	carries_tool	FBto0000349	FBrf0244200		TOOL DATA from: FBal0359489
+FBti0211563_cas	encodes_tool	FBto0000158	FBrf0245076		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211563_cas	tool_uses	promoter trap	FBrf0245076		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211563_cas	carries_tool	FBto0000328	FBrf0245076		TOOL DATA from: FBal0359570
+FBti0211564_cas	encodes_tool	FBto0000158	FBrf0245076		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211564_cas	tool_uses	promoter trap	FBrf0245076		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211565_cas	carries_tool	FBto0000330	FBrf0245076		TOOL DATA from: FBal0359574
+FBti0211565_cas	tagged_with	FBto0000093	FBrf0245076		TOOL DATA from: FBal0359574
+FBti0211571_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0359583
+FBti0211572_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0359584
+FBti0211573_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0359585
+FBti0211573_cas	tagged_with	FBto0000631	FBrf0228036		TOOL DATA from: FBal0359585
+FBti0211576_cas	encodes_tool	FBto0000140	FBrf0245112		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211576_cas	tool_uses	promoter trap	FBrf0245112		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211578_cas	tagged_with	FBto0000063	FBrf0245110		TOOL DATA from: FBal0359623
+FBti0211579_cas	tagged_with	FBto0000027	FBrf0244780		TOOL DATA from: FBal0359625
+FBti0211584_cas	carries_tool	FBto0000349	FBrf0244840		TOOL DATA from: FBal0359654
+FBti0211584_cas	carries_tool	FBto0000356	FBrf0244840		TOOL DATA from: FBal0359654
+FBti0211585_cas	tagged_with	FBto0000031	FBrf0244840		TOOL DATA from: FBal0359655
+FBti0211586_cas	tagged_with	FBto0000079	FBrf0244840		TOOL DATA from: FBal0359656
+FBti0211587_cas	tagged_with	FBto0000031	FBrf0244840		TOOL DATA from: FBal0359657
+FBti0211588_cas	tagged_with	FBto0000079	FBrf0244840		TOOL DATA from: FBal0359658
+FBti0211589_cas	tagged_with	FBto0000079	FBrf0244840		TOOL DATA from: FBal0359659
+FBti0211590_cas	tagged_with	FBto0000031	FBrf0244840		TOOL DATA from: FBal0359660
+FBti0211591_cas	tagged_with	FBto0000079	FBrf0244840		TOOL DATA from: FBal0359661
+FBti0211618_cas	encodes_tool	FBto0000135	FBrf0244961		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211618_cas	tool_uses	promoter trap	FBrf0244961		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211636_cas	carries_tool	FBto0000318	FBrf0245010		TOOL DATA from: FBal0359829
+FBti0211637_cas	carries_tool	FBto0000318	FBrf0245010		TOOL DATA from: FBal0359830
+FBti0211651_cas	tagged_with	FBto0000077	FBrf0245266		TOOL DATA from: FBal0359851
+FBti0211652_cas	tagged_with	FBto0000081	FBrf0245266		TOOL DATA from: FBal0359852
+FBti0211658_cas	tagged_with	FBto0000070	FBrf0245151		TOOL DATA from: FBal0359889
+FBti0211658_cas	tagged_with	FBto0000093	FBrf0245151		TOOL DATA from: FBal0359889
+FBti0211659_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359910
+FBti0211660_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359911
+FBti0211661_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359912
+FBti0211662_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359913
+FBti0211663_cas	tagged_with	FBto0000031	FBrf0245047		TOOL DATA from: FBal0359914
+FBti0211674_cas	tagged_with	FBto0000126	FBrf0245336		TOOL DATA from: FBal0359962
+FBti0211693_cas	carries_tool	FBto0000349	FBrf0238973		TOOL DATA from: FBal0360037
+FBti0211693_cas	tagged_with	FBto0000102	FBrf0238973		TOOL DATA from: FBal0360037
+FBti0211694_cas	carries_tool	FBto0000318	FBrf0243105		TOOL DATA from: FBal0360072
+FBti0211694_cas	tagged_with	FBto0000031	FBrf0243105		TOOL DATA from: FBal0360072
+FBti0211695_cas	carries_tool	FBto0000318	FBrf0243105		TOOL DATA from: FBal0360074
+FBti0211695_cas	carries_tool	FBto0000349	FBrf0243105		TOOL DATA from: FBal0360074
+FBti0211695_cas	tagged_with	FBto0000093	FBrf0243105		TOOL DATA from: FBal0360074
+FBti0211723_cas				FTA: unable to add tool information from FBal0360096 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0211742_cas	carries_tool	FBto0000349	FBrf0245480		TOOL DATA from: FBal0360116
+FBti0211742_cas	tagged_with	FBto0000118	FBrf0245480		TOOL DATA from: FBal0360116
+FBti0211743_cas	carries_tool	FBto0000349	FBrf0245480		TOOL DATA from: FBal0360118
+FBti0211743_cas	tagged_with	FBto0000077	FBrf0245480		TOOL DATA from: FBal0360118
+FBti0211745_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360147
+FBti0211745_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360147
+FBti0211746_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360148
+FBti0211746_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360148
+FBti0211747_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360149
+FBti0211747_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360149
+FBti0211748_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360150
+FBti0211748_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360150
+FBti0211749_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360151
+FBti0211749_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360151
+FBti0211750_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360152
+FBti0211750_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360152
+FBti0211751_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360153
+FBti0211751_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360153
+FBti0211752_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360154
+FBti0211752_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360154
+FBti0211753_cas	carries_tool	FBto0000349	FBrf0245406		TOOL DATA from: FBal0360155
+FBti0211753_cas	carries_tool	FBto0000356	FBrf0245406		TOOL DATA from: FBal0360155
+FBti0211756_cas	carries_tool	FBto0000349	FBrf0245267		TOOL DATA from: FBal0360161
+FBti0211767_cas	tagged_with	FBto0000063	FBrf0245244		TOOL DATA from: FBal0360193
+FBti0211773_cas	tagged_with	FBto0000027	FBrf0245489		TOOL DATA from: FBal0360203
+FBti0211774_cas	tagged_with	FBto0000027	FBrf0245489		TOOL DATA from: FBal0360204
+FBti0211781_cas	tagged_with	FBto0000077	FBrf0240007		TOOL DATA from: FBal0360217
+FBti0211781_cas	tagged_with	FBto0000083	FBrf0240007		TOOL DATA from: FBal0360217
+FBti0211781_cas	tagged_with	FBto0000341	FBrf0240007		TOOL DATA from: FBal0360217
+FBti0211781_cas	tagged_with	FBto0000648	FBrf0240007		TOOL DATA from: FBal0360217
+FBti0211792_cas	tagged_with	FBto0000079	FBrf0245546		TOOL DATA from: FBal0360254
+FBti0211793_cas	tagged_with	FBto0000623	FBrf0245546		TOOL DATA from: FBal0360255
+FBti0211800_cas	carries_tool	FBto0000318	FBrf0245549		TOOL DATA from: FBal0360263
+FBti0211812_cas	encodes_tool	FBto0000135	FBrf0245411		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211812_cas	tool_uses	promoter trap	FBrf0245411		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211812_cas	has_reg_region	FBgn0024184	FBrf0245411		TOOL DATA from: FBal0360280
+FBti0211813_cas	encodes_tool	FBto0000146	FBrf0245411		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211813_cas	tool_uses	promoter trap	FBrf0245411		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211813_cas	has_reg_region	FBgn0024184	FBrf0245411		TOOL DATA from: FBal0360281
+FBti0211816_cas	carries_tool	FBto0000318	FBrf0245411		TOOL DATA from: FBal0360285
+FBti0211816_cas	carries_tool	FBto0000356	FBrf0245411		TOOL DATA from: FBal0360285
+FBti0211818_cas	encodes_tool	FBto0000166	FBrf0245411		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211818_cas	tool_uses	promoter trap	FBrf0245411		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211819_cas	carries_tool	FBto0000349	FBrf0245582		TOOL DATA from: FBal0360294
+FBti0211819_cas	carries_tool	FBto0000356	FBrf0245582		TOOL DATA from: FBal0360294
+FBti0211829_cas	encodes_tool	FBto0000118	FBrf0245361		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211829_cas	tool_uses	promoter trap	FBrf0245361		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211829_cas	carries_tool	FBto0000320	FBrf0245361		TOOL DATA from: FBal0360341
+FBti0211829_cas	carries_tool	FBto0000349	FBrf0245361		TOOL DATA from: FBal0360341
+FBti0211829_cas	carries_tool	FBto0000356	FBrf0245361		TOOL DATA from: FBal0360341
+FBti0211837_cas	tagged_with	FBto0000102	FBrf0245401		TOOL DATA from: FBal0360412
+FBti0211843_cas	carries_tool	FBto0000318	FBrf0243127		TOOL DATA from: FBal0360428
+FBti0211865_cas	tagged_with	FBto0000027	FBrf0240504		TOOL DATA from: FBal0360440
+FBti0211868_cas	tagged_with	FBto0000027	FBrf0238303		TOOL DATA from: FBal0360454
+FBti0211887_cas	tagged_with	FBto0000375	FBrf0245670		TOOL DATA from: FBal0360508
+FBti0211888_cas	tagged_with	FBto0000063	FBrf0245670		TOOL DATA from: FBal0360509
+FBti0211889_cas	tagged_with	FBto0000063	FBrf0245670		TOOL DATA from: FBal0360511
+FBti0211890_cas	carries_tool	FBto0000349	FBrf0245649		TOOL DATA from: FBal0360512
+FBti0211890_cas	carries_tool	FBto0000356	FBrf0245649		TOOL DATA from: FBal0360512
+FBti0211891_cas	tagged_with	FBto0000077	FBrf0245649		TOOL DATA from: FBal0360513
+FBti0211895_cas	tagged_with	FBto0000076	FBrf0245656		TOOL DATA from: FBal0360516
+FBti0211895_cas	tagged_with	FBto0000077	FBrf0245656		TOOL DATA from: FBal0360516
+FBti0211896_cas	tagged_with	FBto0000076	FBrf0245656		TOOL DATA from: FBal0360517
+FBti0211896_cas	tagged_with	FBto0000077	FBrf0245656		TOOL DATA from: FBal0360517
+FBti0211897_cas	encodes_tool	FBto0000135	FBrf0245496		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211897_cas	tool_uses	promoter trap	FBrf0245496		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211897_cas	tagged_with	FBto0000349	FBrf0245496		TOOL DATA from: FBal0360518
+FBti0211897_cas	tagged_with	FBto0000349	FBrf0245496		TOOL DATA from: FBal0360522
+FBti0211898_cas	encodes_tool	FBto0000135	FBrf0245496		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211898_cas	tool_uses	promoter trap	FBrf0245496		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211898_cas	tagged_with	FBto0000079	FBrf0245496		TOOL DATA from: FBal0360519
+FBti0211898_cas	tagged_with	FBto0000079	FBrf0245496		TOOL DATA from: FBal0360521
+FBti0211965_cas	encodes_tool	FBto0000027	FBrf0245517		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211965_cas	tool_uses	promoter trap	FBrf0245517		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211966_cas	encodes_tool	FBto0000140	FBrf0245517		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211966_cas	tool_uses	promoter trap	FBrf0245517		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211967_cas	encodes_tool	FBto0000027	FBrf0245517		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211967_cas	tool_uses	promoter trap	FBrf0245517		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211968_cas	encodes_tool	FBto0000140	FBrf0245517		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211968_cas	tool_uses	promoter trap	FBrf0245517		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211969_cas	tagged_with	FBto0000076	FBrf0244403		TOOL DATA from: FBal0360585
+FBti0211969_cas	tagged_with	FBto0000403	FBrf0244403		TOOL DATA from: FBal0360585
+FBti0211970_cas	tagged_with	FBto0000076	FBrf0244403		TOOL DATA from: FBal0360586
+FBti0211970_cas	tagged_with	FBto0000403	FBrf0244403		TOOL DATA from: FBal0360586
+FBti0211973_cas	encodes_tool	FBto0000135	FBrf0245463		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211973_cas	tool_uses	promoter trap	FBrf0245463		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0211980_cas	carries_tool	FBto0000349	FBrf0235399		TOOL DATA from: FBal0360611
+FBti0211980_cas	carries_tool	FBto0000356	FBrf0235399		TOOL DATA from: FBal0360611
+FBti0211981_cas	carries_tool	FBto0000349	FBrf0235399		TOOL DATA from: FBal0360612
+FBti0211981_cas	carries_tool	FBto0000356	FBrf0235399		TOOL DATA from: FBal0360612
+FBti0211982_cas	carries_tool	FBto0000349	FBrf0235399		TOOL DATA from: FBal0360613
+FBti0211982_cas	carries_tool	FBto0000356	FBrf0235399		TOOL DATA from: FBal0360613
+FBti0211988_cas	tagged_with	FBto0000063	FBrf0245723		TOOL DATA from: FBal0360679
+FBti0211989_cas	tagged_with	FBto0000063	FBrf0245723		TOOL DATA from: FBal0360681
+FBti0211990_cas	tagged_with	FBto0000638	FBrf0245723		TOOL DATA from: FBal0360682
+FBti0211991_cas	tagged_with	FBto0000031	FBrf0245652		TOOL DATA from: FBal0360684
+FBti0212028_cas	tagged_with	FBto0000044	FBrf0245368		TOOL DATA from: FBal0360691
+FBti0212029_cas	tagged_with	FBto0000657	FBrf0245368		TOOL DATA from: FBal0360692
+FBti0212039_cas	carries_tool	FBto0000349	FBrf0236734		TOOL DATA from: FBal0360710
+FBti0212040_cas	carries_tool	FBto0000349	FBrf0236734		TOOL DATA from: FBal0360711
+FBti0212041_cas	carries_tool	FBto0000349	FBrf0236734		TOOL DATA from: FBal0360712
+FBti0212042_cas	carries_tool	FBto0000349	FBrf0236734		TOOL DATA from: FBal0360713
+FBti0212043_cas	carries_tool	FBto0000318	FBrf0236421		TOOL DATA from: FBal0360714
+FBti0212043_cas	tagged_with	FBto0000077	FBrf0236421		TOOL DATA from: FBal0360714
+FBti0212044_cas	carries_tool	FBto0000318	FBrf0236421		TOOL DATA from: FBal0360715
+FBti0212044_cas	tagged_with	FBto0000077	FBrf0236421		TOOL DATA from: FBal0360715
+FBti0212045_cas	carries_tool	FBto0000318	FBrf0236421		TOOL DATA from: FBal0360716
+FBti0212045_cas	tagged_with	FBto0000031	FBrf0236421		TOOL DATA from: FBal0360716
+FBti0212045_cas	tagged_with	FBto0000077	FBrf0236421		TOOL DATA from: FBal0360716
+FBti0212045_cas	tagged_with	FBto0000208	FBrf0236421		TOOL DATA from: FBal0360716
+FBti0212049_cas	encodes_tool	FBto0000135	FBrf0245728		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212049_cas	tool_uses	promoter trap	FBrf0245728		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212050_cas	encodes_tool	FBto0000166	FBrf0245728		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212050_cas	tool_uses	promoter trap	FBrf0245728		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212051_cas	carries_tool	FBto0000349	FBrf0245680		TOOL DATA from: FBal0360757
+FBti0212051_cas	tagged_with	FBto0000087	FBrf0245680		TOOL DATA from: FBal0360757
+FBti0212052_cas	carries_tool	FBto0000349	FBrf0245680		TOOL DATA from: FBal0360758
+FBti0212053_cas	carries_tool	FBto0000349	FBrf0245680		TOOL DATA from: FBal0360759
+FBti0212053_cas	tagged_with	FBto0000093	FBrf0245680		TOOL DATA from: FBal0360759
+FBti0212054_cas	carries_tool	FBto0000318	FBrf0245817		TOOL DATA from: FBal0360829
+FBti0212054_cas	tagged_with	FBto0000027	FBrf0245817		TOOL DATA from: FBal0360829
+FBti0212055_cas	carries_tool	FBto0000318	FBrf0245817		TOOL DATA from: FBal0360830
+FBti0212055_cas	tagged_with	FBto0000027	FBrf0245817		TOOL DATA from: FBal0360830
+FBti0212056_cas	carries_tool	FBto0000318	FBrf0245817		TOOL DATA from: FBal0360832
+FBti0212056_cas	tagged_with	FBto0000027	FBrf0245817		TOOL DATA from: FBal0360832
+FBti0212057_cas	carries_tool	FBto0000318	FBrf0245817		TOOL DATA from: FBal0360833
+FBti0212057_cas	tagged_with	FBto0000027	FBrf0245817		TOOL DATA from: FBal0360833
+FBti0212058_cas	tagged_with	FBto0000059	FBrf0237415		TOOL DATA from: FBal0360835
+FBti0212058_cas	tagged_with	FBto0000093	FBrf0237415		TOOL DATA from: FBal0360835
+FBti0212059_cas	tagged_with	FBto0000027	FBrf0244153		TOOL DATA from: FBal0360844
+FBti0212060_cas	carries_tool	FBto0000318	FBrf0244135		TOOL DATA from: FBal0360845
+FBti0212060_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360845
+FBti0212061_cas	carries_tool	FBto0000318	FBrf0244135		TOOL DATA from: FBal0360846
+FBti0212061_cas	tagged_with	FBto0000079	FBrf0244135		TOOL DATA from: FBal0360846
+FBti0212062_cas				FTA: unable to add tool information from FBal0360847 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212063_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360848
+FBti0212064_cas	carries_tool	FBto0000318	FBrf0244135		TOOL DATA from: FBal0360849
+FBti0212064_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360849
+FBti0212065_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360850
+FBti0212066_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360851
+FBti0212067_cas				FTA: unable to add tool information from FBal0360858 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212068_cas	tagged_with	FBto0000076	FBrf0244135		TOOL DATA from: FBal0360859
+FBti0212070_cas	tagged_with	FBto0000077	FBrf0245745		TOOL DATA from: FBal0360882
+FBti0212071_cas	tagged_with	FBto0000077	FBrf0245745		TOOL DATA from: FBal0360883
+FBti0212072_cas	tagged_with	FBto0000077	FBrf0245745		TOOL DATA from: FBal0360884
+FBti0212073_cas	has_reg_region	FBto0000180	FBrf0245624		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212073_cas	tool_uses	misexpression element	FBrf0245624		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212074_cas	tagged_with	FBto0000031	FBrf0245625		TOOL DATA from: FBal0360900
+FBti0212075_cas	tagged_with	FBto0000031	FBrf0245625		TOOL DATA from: FBal0360901
+FBti0212076_cas	tagged_with	FBto0000031	FBrf0245625		TOOL DATA from: FBal0360902
+FBti0212077_cas	tagged_with	FBto0000031	FBrf0245625		TOOL DATA from: FBal0360903
+FBti0212078_cas	tagged_with	FBto0000027	FBrf0245610		TOOL DATA from: FBal0360907
+FBti0212078_cas	tagged_with	FBto0000645	FBrf0245610		TOOL DATA from: FBal0360907
+FBti0212108_cas	tagged_with	FBto0000118	FBrf0230036		TOOL DATA from: FBal0361023
+FBti0212109_cas	tagged_with	FBto0000031	FBrf0230036		TOOL DATA from: FBal0361024
+FBti0212110_cas	tagged_with	FBto0000031	FBrf0230036		TOOL DATA from: FBal0361025
+FBti0212111_cas	tagged_with	FBto0000031	FBrf0230036		TOOL DATA from: FBal0361026
+FBti0212127_cas	tagged_with	FBto0000031	FBrf0235463		TOOL DATA from: FBal0361063
+FBti0212128_cas	tagged_with	FBto0000031	FBrf0235463		TOOL DATA from: FBal0361064
+FBti0212129_cas	tagged_with	FBto0000098	FBrf0235463		TOOL DATA from: FBal0361065
+FBti0212130_cas	tagged_with	FBto0000335	FBrf0235463		TOOL DATA from: FBal0361066
+FBti0212132_cas				FTA: unable to add tool information from FBal0361089 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212133_cas	tagged_with	FBto0000077	FBrf0245714		TOOL DATA from: FBal0361093
+FBti0212162_cas	carries_tool	FBto0000349	FBrf0236127		TOOL DATA from: FBal0361096
+FBti0212162_cas	carries_tool	FBto0000356	FBrf0236127		TOOL DATA from: FBal0361096
+FBti0212164_cas	tagged_with	FBto0000077	FBrf0236127		TOOL DATA from: FBal0361098
+FBti0212164_cas	tagged_with	FBto0000118	FBrf0236127		TOOL DATA from: FBal0361098
+FBti0212165_cas	tagged_with	FBto0000118	FBrf0236127		TOOL DATA from: FBal0361100
+FBti0212165_cas	tagged_with	FBto0000389	FBrf0236127		TOOL DATA from: FBal0361100
+FBti0212166_cas	tagged_with	FBto0000077	FBrf0236127		TOOL DATA from: FBal0361101
+FBti0212167_cas	tagged_with	FBto0000389	FBrf0236127		TOOL DATA from: FBal0361102
+FBti0212168_cas	tagged_with	FBto0000027	FBrf0236127		TOOL DATA from: FBal0361103
+FBti0212169_cas	tagged_with	FBto0000118	FBrf0236127		TOOL DATA from: FBal0361104
+FBti0212169_cas	tagged_with	FBto0000389	FBrf0236127		TOOL DATA from: FBal0361104
+FBti0212170_cas	tagged_with	FBto0000118	FBrf0236127		TOOL DATA from: FBal0361105
+FBti0212172_cas	carries_tool	FBto0000349	FBrf0244288		TOOL DATA from: FBal0361108
+FBti0212194_cas	tagged_with	FBto0000383	FBrf0245675		TOOL DATA from: FBal0361143
+FBti0212194_cas	tagged_with	FBto0000623	FBrf0245675		TOOL DATA from: FBal0361143
+FBti0212249_cas	tagged_with	FBto0000118	FBrf0237927		TOOL DATA from: FBal0361228
+FBti0212250_cas	tagged_with	FBto0000118	FBrf0237927		TOOL DATA from: FBal0361229
+FBti0212251_cas	tagged_with	FBto0000118	FBrf0237927		TOOL DATA from: FBal0361230
+FBti0212260_cas	encodes_tool	FBto0000659	FBrf0245837		TOOL DATA from: FBtp0142855, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212260_cas	tool_uses	promoter trap	FBrf0245837		TOOL DATA from: FBtp0142855, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212435_cas	tagged_with	FBto0000126	FBrf0245622		TOOL DATA from: FBal0361564
+FBti0212436_cas	tagged_with	FBto0000118	FBrf0245622		TOOL DATA from: FBal0361565
+FBti0212439_cas				FTA: unable to add tool information from FBal0361572 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212441_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361606
+FBti0212441_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361611
+FBti0212442_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361607
+FBti0212442_cas	tagged_with	FBto0000088	FBrf0245820		TOOL DATA from: FBal0361607
+FBti0212442_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361613
+FBti0212442_cas	tagged_with	FBto0000088	FBrf0245820		TOOL DATA from: FBal0361613
+FBti0212443_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361608
+FBti0212443_cas	tagged_with	FBto0000088	FBrf0245820		TOOL DATA from: FBal0361608
+FBti0212443_cas	carries_tool	FBto0000349	FBrf0245820		TOOL DATA from: FBal0361612
+FBti0212443_cas	tagged_with	FBto0000088	FBrf0245820		TOOL DATA from: FBal0361612
+FBti0212455_cas	carries_tool	FBto0000349	FBrf0245851		TOOL DATA from: FBal0361663
+FBti0212455_cas	carries_tool	FBto0000356	FBrf0245851		TOOL DATA from: FBal0361663
+FBti0212472_cas	carries_tool	FBto0000356	FBrf0240602		TOOL DATA from: FBal0361792
+FBti0212473_cas	encodes_tool	FBto0000031	FBrf0240602		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212473_cas	tool_uses	promoter trap	FBrf0240602		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212474_cas	carries_tool	FBto0000356	FBrf0240602		TOOL DATA from: FBal0361794
+FBti0212475_cas	encodes_tool	FBto0000158	FBrf0245907		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212475_cas	tool_uses	promoter trap	FBrf0245907		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212476_cas	encodes_tool	FBto0000118	FBrf0245208		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212476_cas	tool_uses	promoter trap	FBrf0245208		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212476_cas	carries_tool	FBto0000320	FBrf0245208		TOOL DATA from: FBal0361817
+FBti0212476_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361817
+FBti0212476_cas	carries_tool	FBto0000356	FBrf0245208		TOOL DATA from: FBal0361817
+FBti0212476_cas	carries_tool	FBto0000320	FBrf0245208		TOOL DATA from: FBal0361825
+FBti0212476_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361825
+FBti0212476_cas	carries_tool	FBto0000356	FBrf0245208		TOOL DATA from: FBal0361825
+FBti0212477_cas	encodes_tool	FBto0000135	FBrf0245208		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212477_cas	tool_uses	promoter trap	FBrf0245208		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212478_cas	encodes_tool	FBto0000135	FBrf0245208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212478_cas	tool_uses	promoter trap	FBrf0245208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212478_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361821
+FBti0212478_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361826
+FBti0212479_cas	encodes_tool	FBto0000135	FBrf0245208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212479_cas	tool_uses	promoter trap	FBrf0245208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212479_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361822
+FBti0212479_cas	carries_tool	FBto0000349	FBrf0245208		TOOL DATA from: FBal0361827
+FBti0212494_cas	carries_tool	FBto0000349	FBrf0245934		TOOL DATA from: FBal0361909
+FBti0212495_cas				FTA: unable to add tool information from FBal0361910 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212498_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361916
+FBti0212498_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361916
+FBti0212498_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361916
+FBti0212499_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361917
+FBti0212499_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361917
+FBti0212499_cas	tagged_with	FBto0000118	FBrf0239019		TOOL DATA from: FBal0361917
+FBti0212500_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361918
+FBti0212500_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361918
+FBti0212500_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361918
+FBti0212501_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361919
+FBti0212501_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361919
+FBti0212501_cas	tagged_with	FBto0000118	FBrf0239019		TOOL DATA from: FBal0361919
+FBti0212502_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361920
+FBti0212502_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361920
+FBti0212502_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361920
+FBti0212503_cas				FTA: unable to add tool information from FBal0361921 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212504_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361922
+FBti0212504_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361922
+FBti0212504_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361922
+FBti0212505_cas				FTA: unable to add tool information from FBal0361923 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212506_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361924
+FBti0212506_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361924
+FBti0212506_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361924
+FBti0212507_cas				FTA: unable to add tool information from FBal0361925 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212508_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361926
+FBti0212508_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361926
+FBti0212508_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361926
+FBti0212509_cas				FTA: unable to add tool information from FBal0361927 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212510_cas	carries_tool	FBto0000318	FBrf0239019		TOOL DATA from: FBal0361928
+FBti0212510_cas	carries_tool	FBto0000349	FBrf0239019		TOOL DATA from: FBal0361928
+FBti0212510_cas	tagged_with	FBto0000031	FBrf0239019		TOOL DATA from: FBal0361928
+FBti0212511_cas				FTA: unable to add tool information from FBal0361929 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212535_cas	tagged_with	FBto0000031	FBrf0245969		TOOL DATA from: FBal0362005
+FBti0212542_cas	tagged_with	FBto0000076	FBrf0246239		TOOL DATA from: FBal0362028
+FBti0212563_cas	tagged_with	FBto0000093	FBrf0246013		TOOL DATA from: FBal0362049
+FBti0212595_cas				FTA: unable to add tool information from FBal0362192 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212596_cas				FTA: unable to add tool information from FBal0362197 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212638_cas	tagged_with	FBto0000079	FBrf0239855		TOOL DATA from: FBal0362366
+FBti0212658_cas	carries_tool	FBto0000349	FBrf0246291		TOOL DATA from: FBal0362379
+FBti0212659_cas	carries_tool	FBto0000349	FBrf0246291		TOOL DATA from: FBal0362380
+FBti0212662_cas	encodes_tool	FBto0000027	FBrf0239978		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212662_cas	tool_uses	promoter trap	FBrf0239978		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212662_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0362384
+FBti0212662_cas	carries_tool	FBto0000349	FBrf0239978		TOOL DATA from: FBal0362386
+FBti0212662_cas	tagged_with	FBto0000242	FBrf0239978		TOOL DATA from: FBal0362386
+FBti0212663_cas	tagged_with	FBto0000077	FBrf0246343		TOOL DATA from: FBal0362400
+FBti0212664_cas	tagged_with	FBto0000077	FBrf0246343		TOOL DATA from: FBal0362401
+FBti0212679_cas	tagged_with	FBto0000031	FBrf0246316		TOOL DATA from: FBal0362413
+FBti0212681_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362428
+FBti0212681_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362428
+FBti0212681_cas	tagged_with	FBto0000102	FBrf0246393		TOOL DATA from: FBal0362428
+FBti0212682_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362429
+FBti0212682_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362429
+FBti0212682_cas	tagged_with	FBto0000102	FBrf0246393		TOOL DATA from: FBal0362429
+FBti0212683_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362430
+FBti0212683_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362430
+FBti0212684_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362431
+FBti0212684_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362431
+FBti0212685_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362432
+FBti0212685_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362432
+FBti0212686_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362433
+FBti0212686_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362433
+FBti0212687_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362434
+FBti0212687_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362434
+FBti0212688_cas	tagged_with	FBto0000076	FBrf0246393		TOOL DATA from: FBal0362435
+FBti0212688_cas	tagged_with	FBto0000088	FBrf0246393		TOOL DATA from: FBal0362435
+FBti0212689_cas	tagged_with	FBto0000118	FBrf0246393		TOOL DATA from: FBal0362436
+FBti0212690_cas	tagged_with	FBto0000118	FBrf0246393		TOOL DATA from: FBal0362437
+FBti0212691_cas	tagged_with	FBto0000349	FBrf0246393		TOOL DATA from: FBal0362438
+FBti0212692_cas	tagged_with	FBto0000349	FBrf0246393		TOOL DATA from: FBal0362439
+FBti0212712_cas				FTA: unable to add tool information from FBal0361571 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212713_cas	tagged_with	FBto0000063	FBrf0246352		TOOL DATA from: FBal0362482
+FBti0212714_cas	tagged_with	FBto0000063	FBrf0246352		TOOL DATA from: FBal0362483
+FBti0212715_cas	carries_tool	FBto0000349	FBrf0246352		TOOL DATA from: FBal0362484
+FBti0212715_cas	tagged_with	FBto0000027	FBrf0246352		TOOL DATA from: FBal0362484
+FBti0212835_cas	encodes_tool	FBto0000031	FBrf0246658		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212835_cas	tool_uses	promoter trap	FBrf0246658		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212838_cas	tagged_with	FBto0000063	FBrf0246491		TOOL DATA from: FBal0362633
+FBti0212839_cas				FTA: unable to add tool information from FBal0362634 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212840_cas	carries_tool	FBto0000356	FBrf0246334		TOOL DATA from: FBal0362644
+FBti0212852_cas	encodes_tool	FBto0000146	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212852_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212852_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362679
+FBti0212852_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362697
+FBti0212853_cas	encodes_tool	FBto0000146	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212853_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212853_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362680
+FBti0212853_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362706
+FBti0212854_cas	encodes_tool	FBto0000146	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212854_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212854_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362681
+FBti0212854_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362709
+FBti0212855_cas	encodes_tool	FBto0000146	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212855_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212855_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362682
+FBti0212855_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362713
+FBti0212856_cas	encodes_tool	FBto0000146	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212856_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212856_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362683
+FBti0212856_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362718
+FBti0212857_cas	encodes_tool	FBto0000146	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212857_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212857_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362684
+FBti0212857_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362721
+FBti0212859_cas	encodes_tool	FBto0000166	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212859_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212859_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362686
+FBti0212859_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362692
+FBti0212860_cas	encodes_tool	FBto0000166	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212860_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212860_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362687
+FBti0212860_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362698
+FBti0212861_cas	encodes_tool	FBto0000166	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212861_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212861_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362688
+FBti0212861_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362707
+FBti0212862_cas	encodes_tool	FBto0000166	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212862_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212862_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362689
+FBti0212862_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362714
+FBti0212863_cas	encodes_tool	FBto0000166	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212863_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212863_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362690
+FBti0212863_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362719
+FBti0212864_cas	encodes_tool	FBto0000166	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212864_cas	tool_uses	promoter trap	FBrf0246669		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0212864_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362691
+FBti0212864_cas	carries_tool	FBto0000349	FBrf0246669		TOOL DATA from: FBal0362722
+FBti0212876_cas	tagged_with	FBto0000063	FBrf0246472		TOOL DATA from: FBal0362737
+FBti0212877_cas	tagged_with	FBto0000076	FBrf0246472		TOOL DATA from: FBal0362738
+FBti0212884_cas	tagged_with	FBto0000076	FBrf0246152		TOOL DATA from: FBal0362756
+FBti0212884_cas	tagged_with	FBto0000077	FBrf0246152		TOOL DATA from: FBal0362756
+FBti0212885_cas	tagged_with	FBto0000077	FBrf0240108		TOOL DATA from: FBal0362757
+FBti0212886_cas	tagged_with	FBto0000063	FBrf0246424		TOOL DATA from: FBal0362758
+FBti0212889_cas	tagged_with	FBto0000077	FBrf0245204		TOOL DATA from: FBal0362762
+FBti0212890_cas				FTA: unable to add tool information from FBal0362770 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0212906_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362797
+FBti0212906_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362797
+FBti0212907_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362798
+FBti0212907_cas	tagged_with	FBto0000118	FBrf0246756		TOOL DATA from: FBal0362798
+FBti0212908_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362799
+FBti0212908_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362799
+FBti0212908_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362808
+FBti0212908_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362808
+FBti0212909_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362800
+FBti0212909_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362800
+FBti0212909_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362804
+FBti0212909_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362804
+FBti0212910_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362801
+FBti0212910_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362801
+FBti0212910_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362805
+FBti0212910_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362805
+FBti0212911_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362802
+FBti0212911_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362802
+FBti0212911_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362806
+FBti0212911_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362806
+FBti0212912_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362803
+FBti0212912_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362803
+FBti0212912_cas	carries_tool	FBto0000349	FBrf0246756		TOOL DATA from: FBal0362807
+FBti0212912_cas	tagged_with	FBto0000076	FBrf0246756		TOOL DATA from: FBal0362807
+FBti0212913_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362809
+FBti0212913_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362809
+FBti0212913_cas	tagged_with	FBto0000027	FBrf0246730		TOOL DATA from: FBal0362809
+FBti0212914_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362811
+FBti0212914_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362811
+FBti0212914_cas	tagged_with	FBto0000014	FBrf0246730		TOOL DATA from: FBal0362811
+FBti0212914_cas	tagged_with	FBto0000643	FBrf0246730		TOOL DATA from: FBal0362811
+FBti0212915_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362812
+FBti0212915_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362812
+FBti0212915_cas	tagged_with	FBto0000027	FBrf0246730		TOOL DATA from: FBal0362812
+FBti0212916_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362813
+FBti0212916_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362813
+FBti0212916_cas	tagged_with	FBto0000027	FBrf0246730		TOOL DATA from: FBal0362813
+FBti0212916_cas	tagged_with	FBto0000643	FBrf0246730		TOOL DATA from: FBal0362813
+FBti0212917_cas	carries_tool	FBto0000349	FBrf0246730		TOOL DATA from: FBal0362815
+FBti0212917_cas	carries_tool	FBto0000356	FBrf0246730		TOOL DATA from: FBal0362815
+FBti0212917_cas	tagged_with	FBto0000027	FBrf0246730		TOOL DATA from: FBal0362815
+FBti0213045_cas	tagged_with	FBto0000081	FBrf0246671		TOOL DATA from: FBal0363093
+FBti0213045_cas	tagged_with	FBto0000213	FBrf0246671		TOOL DATA from: FBal0363093
+FBti0213048_cas				FTA: unable to add tool information from FBal0363113 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213049_cas	tagged_with	FBto0000077	FBrf0246134		TOOL DATA from: FBal0363114
+FBti0213050_cas				FTA: unable to add tool information from FBal0363116 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213051_cas	tagged_with	FBto0000077	FBrf0246134		TOOL DATA from: FBal0363118
+FBti0213052_cas				FTA: unable to add tool information from FBal0363121 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213053_cas	tagged_with	FBto0000077	FBrf0246134		TOOL DATA from: FBal0363123
+FBti0213054_cas				FTA: unable to add tool information from FBal0363126 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213055_cas	tagged_with	FBto0000077	FBrf0246134		TOOL DATA from: FBal0363127
+FBti0213089_cas				FTA: unable to add tool information from FBal0363195 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213090_cas				FTA: unable to add tool information from FBal0363196 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213099_cas	tagged_with	FBto0000076	FBrf0246833		TOOL DATA from: FBal0363276
+FBti0213099_cas	tagged_with	FBto0000093	FBrf0246833		TOOL DATA from: FBal0363276
+FBti0213100_cas	tagged_with	FBto0000076	FBrf0246833		TOOL DATA from: FBal0363277
+FBti0213100_cas	tagged_with	FBto0000093	FBrf0246833		TOOL DATA from: FBal0363277
+FBti0213145_cas				FTA: unable to add tool information from FBal0363343 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213153_cas	carries_tool	FBto0000349	FBrf0222906		TOOL DATA from: FBal0363450
+FBti0213154_cas	carries_tool	FBto0000349	FBrf0222906		TOOL DATA from: FBal0363451
+FBti0213159_cas	carries_tool	FBto0000349	FBrf0246761		TOOL DATA from: FBal0363459
+FBti0213197_cas	tagged_with	FBto0000102	FBrf0246880		TOOL DATA from: FBal0363552
+FBti0213198_cas	tagged_with	FBto0000099	FBrf0246880		TOOL DATA from: FBal0363554
+FBti0213199_cas	encodes_tool	FBto0000135	FBrf0246737		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213199_cas	tool_uses	promoter trap	FBrf0246737		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213200_cas	encodes_tool	FBto0000135	FBrf0246737		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213200_cas	tool_uses	promoter trap	FBrf0246737		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213201_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363561
+FBti0213201_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363561
+FBti0213202_cas	encodes_tool	FBto0000031	FBrf0246737		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213202_cas	tool_uses	promoter trap	FBrf0246737		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213202_cas	tagged_with	FBto0000242	FBrf0246737		TOOL DATA from: FBal0363576
+FBti0213203_cas	carries_tool	FBto0000320	FBrf0246737		TOOL DATA from: FBal0363563
+FBti0213204_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363564
+FBti0213204_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363564
+FBti0213205_cas	tagged_with	FBto0000031	FBrf0246737		TOOL DATA from: FBal0363565
+FBti0213206_cas	encodes_tool	FBto0000031	FBrf0246737		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213206_cas	tool_uses	promoter trap	FBrf0246737		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213206_cas	tagged_with	FBto0000242	FBrf0246737		TOOL DATA from: FBal0363575
+FBti0213207_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363571
+FBti0213207_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363571
+FBti0213208_cas	encodes_tool	FBto0000031	FBrf0246737		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213208_cas	tool_uses	promoter trap	FBrf0246737		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213208_cas	tagged_with	FBto0000242	FBrf0246737		TOOL DATA from: FBal0363577
+FBti0213209_cas	encodes_tool	FBto0000031	FBrf0246737		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213209_cas	tool_uses	promoter trap	FBrf0246737		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213209_cas	tagged_with	FBto0000242	FBrf0246737		TOOL DATA from: FBal0363578
+FBti0213210_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363579
+FBti0213210_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363579
+FBti0213211_cas	tagged_with	FBto0000077	FBrf0246737		TOOL DATA from: FBal0363580
+FBti0213212_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363583
+FBti0213212_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363583
+FBti0213213_cas	carries_tool	FBto0000349	FBrf0246737		TOOL DATA from: FBal0363585
+FBti0213213_cas	carries_tool	FBto0000356	FBrf0246737		TOOL DATA from: FBal0363585
+FBti0213214_cas	tagged_with	FBto0000031	FBrf0246737		TOOL DATA from: FBal0363586
+FBti0213234_cas	tagged_with	FBto0000099	FBrf0243017		TOOL DATA from: FBal0363669
+FBti0213242_cas	tagged_with	FBto0000076	FBrf0242056		TOOL DATA from: FBal0363694
+FBti0213244_cas	carries_tool	FBto0000349	FBrf0246147		TOOL DATA from: FBal0363739
+FBti0213244_cas	carries_tool	FBto0000356	FBrf0246147		TOOL DATA from: FBal0363739
+FBti0213245_cas	tagged_with	FBto0000076	FBrf0246147		TOOL DATA from: FBal0363741
+FBti0213245_cas	tagged_with	FBto0000077	FBrf0246147		TOOL DATA from: FBal0363741
+FBti0213246_cas	carries_tool	FBto0000349	FBrf0246147		TOOL DATA from: FBal0363744
+FBti0213246_cas	carries_tool	FBto0000356	FBrf0246147		TOOL DATA from: FBal0363744
+FBti0213247_cas	carries_tool	FBto0000349	FBrf0246147		TOOL DATA from: FBal0363745
+FBti0213247_cas	carries_tool	FBto0000356	FBrf0246147		TOOL DATA from: FBal0363745
+FBti0213385_cas	encodes_tool	FBto0000158	FBrf0246203		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213385_cas	tool_uses	promoter trap	FBrf0246203		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213385_cas	carries_tool	FBto0000328	FBrf0246203		TOOL DATA from: FBal0363913
+FBti0213386_cas	encodes_tool	FBto0000158	FBrf0246203		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213386_cas	tool_uses	promoter trap	FBrf0246203		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213386_cas	carries_tool	FBto0000328	FBrf0246203		TOOL DATA from: FBal0363914
+FBti0213386_cas	carries_tool	FBto0000328	FBrf0246203		TOOL DATA from: FBal0363918
+FBti0213386_cas	has_reg_region	FBgn0050446	FBrf0246203		TOOL DATA from: FBal0363918
+FBti0213387_cas	encodes_tool	FBto0000168	FBrf0246203		TOOL DATA from: FBtp0144644, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213387_cas	tool_uses	promoter trap	FBrf0246203		TOOL DATA from: FBtp0144644, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213387_cas	carries_tool	FBto0000323	FBrf0246203		TOOL DATA from: FBal0363919
+FBti0213388_cas	encodes_tool	FBto0000168	FBrf0246203		TOOL DATA from: FBtp0144644, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213388_cas	tool_uses	promoter trap	FBrf0246203		TOOL DATA from: FBtp0144644, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213388_cas	carries_tool	FBto0000323	FBrf0246203		TOOL DATA from: FBal0363920
+FBti0213388_cas	carries_tool	FBto0000323	FBrf0246203		TOOL DATA from: FBal0363921
+FBti0213388_cas	has_reg_region	FBgn0004619	FBrf0246203		TOOL DATA from: FBal0363921
+FBti0213398_cas	tagged_with	FBto0000093	FBrf0246470		TOOL DATA from: FBal0363990
+FBti0213398_cas	tagged_with	FBto0000589	FBrf0246470		TOOL DATA from: FBal0363990
+FBti0213399_cas	tagged_with	FBto0000031	FBrf0246839		TOOL DATA from: FBal0363992
+FBti0213400_cas	carries_tool	FBto0000349	FBrf0246839		TOOL DATA from: FBal0363999
+FBti0213400_cas	carries_tool	FBto0000356	FBrf0246839		TOOL DATA from: FBal0363999
+FBti0213412_cas				FTA: unable to add tool information from FBal0364007 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213413_cas	tagged_with	FBto0000389	FBrf0246834		TOOL DATA from: FBal0364008
+FBti0213414_cas	tagged_with	FBto0000389	FBrf0246834		TOOL DATA from: FBal0364009
+FBti0213415_cas				FTA: unable to add tool information from FBal0364010 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213416_cas	tagged_with	FBto0000389	FBrf0246834		TOOL DATA from: FBal0364011
+FBti0213417_cas	tagged_with	FBto0000389	FBrf0246834		TOOL DATA from: FBal0364012
+FBti0213424_cas	has_reg_region	FBgn0261019	FBrf0247098		TOOL DATA from: FBal0364090
+FBti0213558_cas	encodes_tool	FBto0000140	FBrf0243806		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213558_cas	tool_uses	promoter trap	FBrf0243806		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0213594_cas	carries_tool	FBto0000349	FBrf0220649		TOOL DATA from: FBal0364428
+FBti0213594_cas	carries_tool	FBto0000356	FBrf0220649		TOOL DATA from: FBal0364428
+FBti0213594_cas	carries_tool	FBto0000357	FBrf0220649		TOOL DATA from: FBal0364428
+FBti0213597_cas	tagged_with	FBto0000077	FBrf0247007		TOOL DATA from: FBal0364439
+FBti0213618_cas	tagged_with	FBto0000031	FBrf0246245|FBrf0249020		TOOL DATA from: FBal0364505
+FBti0213664_cas	tagged_with	FBto0000031	FBrf0247069		TOOL DATA from: FBal0364880
+FBti0213664_cas	tagged_with	FBto0000093	FBrf0247069		TOOL DATA from: FBal0364880
+FBti0213665_cas	tagged_with	FBto0000031	FBrf0247069		TOOL DATA from: FBal0364883
+FBti0213665_cas	tagged_with	FBto0000079	FBrf0247069		TOOL DATA from: FBal0364883
+FBti0213686_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0364910
+FBti0213686_cas	tagged_with	FBto0000093	FBrf0228036		TOOL DATA from: FBal0364910
+FBti0213686_cas	tagged_with	FBto0000631	FBrf0228036		TOOL DATA from: FBal0364910
+FBti0213687_cas	tagged_with	FBto0000079	FBrf0228036		TOOL DATA from: FBal0364911
+FBti0213687_cas	tagged_with	FBto0000093	FBrf0228036		TOOL DATA from: FBal0364911
+FBti0213687_cas	tagged_with	FBto0000631	FBrf0228036		TOOL DATA from: FBal0364911
+FBti0213875_cas				FTA: unable to add tool information from FBal0343866 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213916_cas	tagged_with	FBto0000694	FBrf0247068		TOOL DATA from: FBal0365216
+FBti0213918_cas				FTA: unable to add tool information from FBal0365222 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213919_cas	carries_tool	FBto0000349	FBrf0247226		TOOL DATA from: FBal0365223
+FBti0213920_cas	carries_tool	FBto0000349	FBrf0247226		TOOL DATA from: FBal0365224
+FBti0213921_cas	carries_tool	FBto0000349	FBrf0247226		TOOL DATA from: FBal0365225
+FBti0213922_cas	tagged_with	FBto0000076	FBrf0247226		TOOL DATA from: FBal0365232
+FBti0213923_cas	tagged_with	FBto0000076	FBrf0247226		TOOL DATA from: FBal0365235
+FBti0213933_cas	tagged_with	FBto0000522	FBrf0244621		TOOL DATA from: FBal0365249
+FBti0213933_cas	tagged_with	FBto0000585	FBrf0244621		TOOL DATA from: FBal0365249
+FBti0213934_cas				FTA: unable to add tool information from FBal0365256 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213935_cas				FTA: unable to add tool information from FBal0365257 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213936_cas				FTA: unable to add tool information from FBal0365258 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0213937_cas	carries_tool	FBto0000318	FBrf0224708		TOOL DATA from: FBal0365262
+FBti0213940_cas	tagged_with	FBto0000063	FBrf0247123		TOOL DATA from: FBal0365277
+FBti0214014_cas	tagged_with	FBto0000079	FBrf0230844		TOOL DATA from: FBal0365289
+FBti0214017_cas	tagged_with	FBto0000403	FBrf0247412		TOOL DATA from: FBal0365301
+FBti0214081_cas	carries_tool	FBto0000349	FBrf0247081		TOOL DATA from: FBal0365341
+FBti0214117_cas	tagged_with	FBto0000076	FBrf0247174		TOOL DATA from: FBal0365409
+FBti0214117_cas	tagged_with	FBto0000083	FBrf0247174		TOOL DATA from: FBal0365409
+FBti0214117_cas	tagged_with	FBto0000341	FBrf0247174		TOOL DATA from: FBal0365409
+FBti0214135_cas	encodes_tool	FBto0000027	FBrf0247170		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214135_cas	tool_uses	promoter trap	FBrf0247170		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214177_cas	encodes_tool	FBto0000158	FBrf0247550		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214177_cas	tool_uses	promoter trap	FBrf0247550		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214178_cas	carries_tool	FBto0000349	FBrf0247550		TOOL DATA from: FBal0365538
+FBti0214178_cas	carries_tool	FBto0000356	FBrf0247550		TOOL DATA from: FBal0365538
+FBti0214222_cas	tagged_with	FBto0000093	FBrf0247523		TOOL DATA from: FBal0365590
+FBti0214256_cas	tagged_with	FBto0000031	FBrf0247340		TOOL DATA from: FBal0365655
+FBti0214257_cas	tagged_with	FBto0000076	FBrf0247340		TOOL DATA from: FBal0365656
+FBti0214258_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365657
+FBti0214258_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365657
+FBti0214259_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365658
+FBti0214259_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365658
+FBti0214260_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365659
+FBti0214260_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365659
+FBti0214261_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365660
+FBti0214261_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365660
+FBti0214262_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365661
+FBti0214262_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365661
+FBti0214263_cas	carries_tool	FBto0000349	FBrf0247396		TOOL DATA from: FBal0365662
+FBti0214263_cas	carries_tool	FBto0000356	FBrf0247396		TOOL DATA from: FBal0365662
+FBti0214277_cas				FTA: unable to add tool information from FBal0365691 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0214278_cas				FTA: unable to add tool information from FBal0365692 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0214325_cas				FTA: unable to add tool information from FBal0365766 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0214362_cas	encodes_tool	FBto0000135	FBrf0247901		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214362_cas	tool_uses	promoter trap	FBrf0247901		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214373_cas	encodes_tool	FBto0000135	FBrf0247752		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214373_cas	tool_uses	promoter trap	FBrf0247752		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214373_cas	has_reg_region	FBgn0262381	FBrf0247752		TOOL DATA from: FBal0365947
+FBti0214376_cas	tagged_with	FBto0000118	FBrf0247271		TOOL DATA from: FBal0365838
+FBti0214398_cas	tagged_with	FBto0000076	FBrf0247665		TOOL DATA from: FBal0365915
+FBti0214421_cas	tagged_with	FBto0000031	FBrf0247474		TOOL DATA from: FBal0365959
+FBti0214422_cas	encodes_tool	FBto0000158	FBrf0105495		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214422_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0214422_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0365975
+FBti0214422_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0365975
+FBti0214422_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0365975
+FBti0214422_cas	has_reg_region	FBgn0031424	FBrf0247391		TOOL DATA from: FBal0365975
+FBti0214422_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0365983
+FBti0214422_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0365983
+FBti0214422_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0365983
+FBti0214423_cas	has_reg_region	FBgn0013720	FBrf0247845		TOOL DATA from: FBal0365987
+FBti0214423_cas	tagged_with	FBto0000104	FBrf0247845		TOOL DATA from: FBal0365987
+FBti0214424_cas	has_reg_region	FBgn0010238	FBrf0247845		TOOL DATA from: FBal0365988
+FBti0214424_cas	tagged_with	FBto0000031	FBrf0247845		TOOL DATA from: FBal0365988
+FBti0214432_cas	tagged_with	FBto0000102	FBrf0247526		TOOL DATA from: FBal0366013
+FBti0214433_cas	tagged_with	FBto0000102	FBrf0247526		TOOL DATA from: FBal0366019
+FBti0214434_cas	tagged_with	FBto0000102	FBrf0247526		TOOL DATA from: FBal0366020
+FBti0214435_cas	tagged_with	FBto0000102	FBrf0247526		TOOL DATA from: FBal0366021
+FBti0214436_cas	tagged_with	FBto0000707	FBrf0247526		TOOL DATA from: FBal0366022
+FBti0214490_cas	tagged_with	FBto0000076	FBrf0247676		TOOL DATA from: FBal0366112
+FBti0214491_cas	tagged_with	FBto0000076	FBrf0247676		TOOL DATA from: FBal0366113
+FBti0214491_cas	tagged_with	FBto0000076	FBrf0247676		TOOL DATA from: FBal0366116
+FBti0214492_cas	tagged_with	FBto0000077	FBrf0247676		TOOL DATA from: FBal0366117
+FBti0214497_cas	has_reg_region	FBgn0026257	FBrf0213318		TOOL DATA from: FBal0367053
+FBti0214497_cas	tagged_with	FBto0000027	FBrf0213318		TOOL DATA from: FBal0367053
+FBti0214536_cas	carries_tool	FBto0000330	FBrf0247657		TOOL DATA from: FBal0366197
+FBti0214536_cas	tagged_with	FBto0000093	FBrf0247657		TOOL DATA from: FBal0366197
+FBti0214546_cas	tagged_with	FBto0000389	FBrf0223858		TOOL DATA from: FBal0295469
+FBti0214858_cas	carries_tool	FBto0000349	FBrf0247740		TOOL DATA from: FBal0366568
+FBti0214858_cas	tagged_with	FBto0000716	FBrf0247740		TOOL DATA from: FBal0366568
+FBti0214859_cas	tagged_with	FBto0000601	FBrf0247740		TOOL DATA from: FBal0366570
+FBti0214978_cas	tagged_with	FBto0000077	FBrf0247921		TOOL DATA from: FBal0366851
+FBti0214980_cas	tagged_with	FBto0000093	FBrf0247967		TOOL DATA from: FBal0366865
+FBti0215070_cas	encodes_tool	FBto0000158	FBrf0233600		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215070_cas	tool_uses	promoter trap	FBrf0233600		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215070_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0367038
+FBti0215070_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0367038
+FBti0215070_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0367038
+FBti0215070_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0367039
+FBti0215070_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0367039
+FBti0215070_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0367039
+FBti0215404_cas	tagged_with	FBto0000076	FBrf0245859		TOOL DATA from: FBal0367093
+FBti0215405_cas				FTA: unable to add tool information from FBal0367098 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215406_cas	carries_tool	FBto0000349	FBrf0248471		TOOL DATA from: FBal0367099
+FBti0215406_cas	carries_tool	FBto0000356	FBrf0248471		TOOL DATA from: FBal0367099
+FBti0215407_cas	carries_tool	FBto0000349	FBrf0248471		TOOL DATA from: FBal0367100
+FBti0215407_cas	carries_tool	FBto0000356	FBrf0248471		TOOL DATA from: FBal0367100
+FBti0215417_cas	carries_tool	FBto0000349	FBrf0244216		TOOL DATA from: FBal0367132
+FBti0215417_cas	carries_tool	FBto0000356	FBrf0244216		TOOL DATA from: FBal0367132
+FBti0215418_cas	tagged_with	FBto0000027	FBrf0244216		TOOL DATA from: FBal0367133
+FBti0215419_cas	tagged_with	FBto0000582	FBrf0244216		TOOL DATA from: FBal0367134
+FBti0215420_cas	tagged_with	FBto0000027	FBrf0244216		TOOL DATA from: FBal0367135
+FBti0215420_cas	tagged_with	FBto0000582	FBrf0244216		TOOL DATA from: FBal0367135
+FBti0215421_cas	tagged_with	FBto0000098	FBrf0244216		TOOL DATA from: FBal0367136
+FBti0215421_cas	tagged_with	FBto0000582	FBrf0244216		TOOL DATA from: FBal0367136
+FBti0215422_cas	tagged_with	FBto0000098	FBrf0244216		TOOL DATA from: FBal0367137
+FBti0215422_cas	tagged_with	FBto0000699	FBrf0244216		TOOL DATA from: FBal0367137
+FBti0215423_cas	tagged_with	FBto0000583	FBrf0244216		TOOL DATA from: FBal0367138
+FBti0215424_cas	tagged_with	FBto0000063	FBrf0248448		TOOL DATA from: FBal0367148
+FBti0215425_cas	tagged_with	FBto0000014	FBrf0248448		TOOL DATA from: FBal0367149
+FBti0215426_cas	tagged_with	FBto0000063	FBrf0248448		TOOL DATA from: FBal0367150
+FBti0215430_cas	tagged_with	FBto0000077	FBrf0248542		TOOL DATA from: FBal0367170
+FBti0215431_cas	tagged_with	FBto0000063	FBrf0246607		TOOL DATA from: FBal0367175
+FBti0215438_cas				FTA: unable to add tool information from FBal0367203 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215440_cas	tagged_with	FBto0000063	FBrf0247840		TOOL DATA from: FBal0367204
+FBti0215441_cas	tagged_with	FBto0000063	FBrf0247840		TOOL DATA from: FBal0367211
+FBti0215442_cas				FTA: unable to add tool information from FBal0367213 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215443_cas				FTA: unable to add tool information from FBal0367234 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215444_cas				FTA: unable to add tool information from FBal0367235 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215445_cas	carries_tool	FBto0000318	FBrf0248082		TOOL DATA from: FBal0367236
+FBti0215445_cas	carries_tool	FBto0000349	FBrf0248082		TOOL DATA from: FBal0367236
+FBti0215455_cas	carries_tool	FBto0000349	FBrf0248667		TOOL DATA from: FBal0367246
+FBti0215455_cas	carries_tool	FBto0000356	FBrf0248667		TOOL DATA from: FBal0367246
+FBti0215456_cas	carries_tool	FBto0000349	FBrf0248667		TOOL DATA from: FBal0367247
+FBti0215457_cas	carries_tool	FBto0000349	FBrf0248667		TOOL DATA from: FBal0367248
+FBti0215458_cas				FTA: unable to add tool information from FBal0367249 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215459_cas				FTA: unable to add tool information from FBal0367250 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215460_cas				FTA: unable to add tool information from FBal0367251 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215560_cas	encodes_tool	FBto0000135	FBrf0247735		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215560_cas	tool_uses	promoter trap	FBrf0247735		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215707_cas	tagged_with	FBto0000076	FBrf0248665		TOOL DATA from: FBal0367628
+FBti0215708_cas	tagged_with	FBto0000077	FBrf0248665		TOOL DATA from: FBal0367629
+FBti0215709_cas	tagged_with	FBto0000076	FBrf0248665		TOOL DATA from: FBal0367630
+FBti0215710_cas	tagged_with	FBto0000077	FBrf0248665		TOOL DATA from: FBal0367631
+FBti0215711_cas	tagged_with	FBto0000093	FBrf0248665		TOOL DATA from: FBal0367632
+FBti0215712_cas	tagged_with	FBto0000093	FBrf0248665		TOOL DATA from: FBal0367633
+FBti0215715_cas	encodes_tool	FBto0000135	FBrf0248620		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215715_cas	tool_uses	promoter trap	FBrf0248620		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215715_cas	has_reg_region	FBgn0003300	FBrf0248620		TOOL DATA from: FBal0367636
+FBti0215715_cas	has_reg_region	FBgn0003300	FBrf0248620		TOOL DATA from: FBal0367637
+FBti0215719_cas	tagged_with	FBto0000079	FBrf0248517		TOOL DATA from: FBal0367654
+FBti0215720_cas	tagged_with	FBto0000077	FBrf0248517		TOOL DATA from: FBal0367655
+FBti0215740_cas	tagged_with	FBto0000403	FBrf0248673		TOOL DATA from: FBal0367671
+FBti0215741_cas	tagged_with	FBto0000601	FBrf0248673		TOOL DATA from: FBal0367672
+FBti0215751_cas	encodes_tool	FBto0000135	FBrf0248243		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215751_cas	tool_uses	promoter trap	FBrf0248243		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215752_cas	has_reg_region	FBto0000180	FBrf0238514		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215752_cas	tool_uses	misexpression element	FBrf0238514		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215752_cas				FTA: unable to add tool information from FBal0367699 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215769_cas	tagged_with	FBto0000077	FBrf0247295		TOOL DATA from: FBal0367760
+FBti0215770_cas	tagged_with	FBto0000077	FBrf0247295		TOOL DATA from: FBal0367761
+FBti0215779_cas	carries_tool	FBto0000349	FBrf0248749		TOOL DATA from: FBal0367778
+FBti0215779_cas	carries_tool	FBto0000356	FBrf0248749		TOOL DATA from: FBal0367778
+FBti0215779_cas	carries_tool	FBto0000349	FBrf0248749		TOOL DATA from: FBal0367784
+FBti0215779_cas	carries_tool	FBto0000356	FBrf0248749		TOOL DATA from: FBal0367784
+FBti0215782_cas	tagged_with	FBto0000126	FBrf0248547		TOOL DATA from: FBal0367805
+FBti0215783_cas	tagged_with	FBto0000426	FBrf0248547		TOOL DATA from: FBal0367806
+FBti0215795_cas	tagged_with	FBto0000126	FBrf0248225		TOOL DATA from: FBal0367825
+FBti0215796_cas	tagged_with	FBto0000126	FBrf0248225		TOOL DATA from: FBal0367832
+FBti0215800_cas	tagged_with	FBto0000063	FBrf0248795		TOOL DATA from: FBal0367850
+FBti0215801_cas	tagged_with	FBto0000063	FBrf0248795		TOOL DATA from: FBal0367851
+FBti0215832_cas	encodes_tool	FBto0000146	FBrf0247975		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215832_cas	tool_uses	promoter trap	FBrf0247975		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215834_cas	encodes_tool	FBto0000166	FBrf0247975		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215834_cas	tool_uses	promoter trap	FBrf0247975		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215838_cas	tagged_with	FBto0000031	FBrf0248472		TOOL DATA from: FBal0367942
+FBti0215839_cas	tagged_with	FBto0000126	FBrf0248472		TOOL DATA from: FBal0367943
+FBti0215840_cas				FTA: unable to add tool information from FBal0367944 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215841_cas	tagged_with	FBto0000046	FBrf0248472		TOOL DATA from: FBal0367945
+FBti0215844_cas	carries_tool	FBto0000349	FBrf0248830		TOOL DATA from: FBal0367960
+FBti0215845_cas	carries_tool	FBto0000349	FBrf0248830		TOOL DATA from: FBal0367961
+FBti0215853_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215853_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215869_cas	tagged_with	FBto0000102	FBrf0232782		TOOL DATA from: FBal0368001
+FBti0215870_cas				FTA: unable to add tool information from FBal0368002 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0215890_cas	encodes_tool	FBto0000168	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215890_cas	tool_uses	promoter trap	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215890_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368018
+FBti0215890_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368024
+FBti0215891_cas	encodes_tool	FBto0000168	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215891_cas	tool_uses	promoter trap	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215891_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368019
+FBti0215891_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368025
+FBti0215892_cas	encodes_tool	FBto0000168	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215892_cas	tool_uses	promoter trap	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215892_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368020
+FBti0215892_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368026
+FBti0215893_cas	encodes_tool	FBto0000168	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215893_cas	tool_uses	promoter trap	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215893_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368021
+FBti0215893_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368027
+FBti0215894_cas	encodes_tool	FBto0000168	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215894_cas	tool_uses	promoter trap	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215894_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368022
+FBti0215894_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368028
+FBti0215895_cas	encodes_tool	FBto0000168	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215895_cas	tool_uses	promoter trap	FBrf0249066		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215895_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368023
+FBti0215895_cas	carries_tool	FBto0000349	FBrf0249066		TOOL DATA from: FBal0368029
+FBti0215896_cas	encodes_tool	FBto0000135	FBrf0248683		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215896_cas	tool_uses	promoter trap	FBrf0248683		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215896_cas	tagged_with	FBto0000027	FBrf0248683		TOOL DATA from: FBal0368033
+FBti0215897_cas	carries_tool	FBto0000349	FBrf0248683		TOOL DATA from: FBal0368032
+FBti0215897_cas	carries_tool	FBto0000356	FBrf0248683		TOOL DATA from: FBal0368032
+FBti0215906_cas	carries_tool	FBto0000349	FBrf0249068		TOOL DATA from: FBal0368037
+FBti0215907_cas	encodes_tool	FBto0000135	FBrf0248703		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215907_cas	tool_uses	promoter trap	FBrf0248703		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0215926_cas	tagged_with	FBto0000077	FBrf0248983		TOOL DATA from: FBal0368065
+FBti0215927_cas				FTA: unable to add tool information from FBal0368066 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216052_cas	tagged_with	FBto0000027	FBrf0248474		TOOL DATA from: FBal0368292
+FBti0216052_cas	tagged_with	FBto0000077	FBrf0248474		TOOL DATA from: FBal0368292
+FBti0216071_cas	carries_tool	FBto0000349	FBrf0248996		TOOL DATA from: FBal0368321
+FBti0216072_cas				FTA: unable to add tool information from FBal0368322 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216074_cas	carries_tool	FBto0000318	FBrf0248878		TOOL DATA from: FBal0368324
+FBti0216091_cas	tagged_with	FBto0000738	FBrf0249049		TOOL DATA from: FBal0368351
+FBti0216092_cas	tagged_with	FBto0000389	FBrf0249049		TOOL DATA from: FBal0368352
+FBti0216092_cas	tagged_with	FBto0000738	FBrf0249049		TOOL DATA from: FBal0368352
+FBti0216159_cas	encodes_tool	FBto0000135	FBrf0249084		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216159_cas	tool_uses	promoter trap	FBrf0249084		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216163_cas				FTA: unable to add tool information from FBal0368461 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216311_cas	tagged_with	FBto0000375	FBrf0249038		TOOL DATA from: FBal0368707
+FBti0216312_cas	tagged_with	FBto0000031	FBrf0249038		TOOL DATA from: FBal0368709
+FBti0216315_cas	encodes_tool	FBto0000135	FBrf0248839		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216315_cas	tool_uses	promoter trap	FBrf0248839		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216354_cas	carries_tool	FBto0000349	FBrf0249305		TOOL DATA from: FBal0368758
+FBti0216354_cas	tagged_with	FBto0000102	FBrf0249305		TOOL DATA from: FBal0368758
+FBti0216355_cas	carries_tool	FBto0000349	FBrf0249305		TOOL DATA from: FBal0368759
+FBti0216355_cas	tagged_with	FBto0000102	FBrf0249305		TOOL DATA from: FBal0368759
+FBti0216356_cas	carries_tool	FBto0000349	FBrf0249127		TOOL DATA from: FBal0368760
+FBti0216356_cas	tagged_with	FBto0000070	FBrf0249127		TOOL DATA from: FBal0368760
+FBti0216356_cas	tagged_with	FBto0000077	FBrf0249127		TOOL DATA from: FBal0368760
+FBti0216357_cas	carries_tool	FBto0000349	FBrf0249127		TOOL DATA from: FBal0368762
+FBti0216357_cas	tagged_with	FBto0000070	FBrf0249127		TOOL DATA from: FBal0368762
+FBti0216357_cas	tagged_with	FBto0000077	FBrf0249127		TOOL DATA from: FBal0368762
+FBti0216378_cas	encodes_tool	FBto0000308	FBrf0249021		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216378_cas	tool_uses	promoter trap	FBrf0249021		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216379_cas	encodes_tool	FBto0000155	FBrf0249021		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216379_cas	tool_uses	promoter trap	FBrf0249021		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216379_cas	carries_tool	FBto0000318	FBrf0249021		TOOL DATA from: FBal0368791
+FBti0216379_cas	carries_tool	FBto0000318	FBrf0249021		TOOL DATA from: FBal0368793
+FBti0216380_cas	tagged_with	FBto0000031	FBrf0249101		TOOL DATA from: FBal0368799
+FBti0216381_cas	tagged_with	FBto0000031	FBrf0249101		TOOL DATA from: FBal0368807
+FBti0216382_cas	tagged_with	FBto0000031	FBrf0249101		TOOL DATA from: FBal0368813
+FBti0216406_cas	tagged_with	FBto0000031	FBrf0248794		TOOL DATA from: FBal0368875
+FBti0216407_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368882
+FBti0216407_cas	carries_tool	FBto0000356	FBrf0248618		TOOL DATA from: FBal0368882
+FBti0216408_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368883
+FBti0216409_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368884
+FBti0216410_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368885
+FBti0216411_cas	carries_tool	FBto0000349	FBrf0248618		TOOL DATA from: FBal0368886
+FBti0216419_cas	carries_tool	FBto0000318	FBrf0244135		TOOL DATA from: FBal0368900
+FBti0216423_cas	encodes_tool	FBto0000155	FBrf0244265		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216423_cas	tool_uses	promoter trap	FBrf0244265		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216423_cas	carries_tool	FBto0000349	FBrf0244265		TOOL DATA from: FBal0368910
+FBti0216424_cas	tagged_with	FBto0000031	FBrf0235092		TOOL DATA from: FBal0368913
+FBti0216428_cas	carries_tool	FBto0000356	FBrf0241076		TOOL DATA from: FBal0368922
+FBti0216429_cas	carries_tool	FBto0000356	FBrf0241076		TOOL DATA from: FBal0368923
+FBti0216430_cas	carries_tool	FBto0000356	FBrf0241076		TOOL DATA from: FBal0368924
+FBti0216432_cas				FTA: unable to add tool information from FBal0368945 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216433_cas	carries_tool	FBto0000349	FBrf0238744		TOOL DATA from: FBal0368946
+FBti0216433_cas	tagged_with	FBto0000383	FBrf0238744		TOOL DATA from: FBal0368946
+FBti0216456_cas				FTA: unable to add tool information from FBal0368956 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216457_cas	tagged_with	FBto0000031	FBrf0249270		TOOL DATA from: FBal0368962
+FBti0216458_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216458_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216459_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216459_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216460_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216460_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216461_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216461_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216462_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216462_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216463_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216463_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216464_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216464_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216465_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216465_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216466_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216466_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216467_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216467_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216468_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216468_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216469_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216469_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216470_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216470_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216471_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216471_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216472_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216472_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216473_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216473_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216474_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216474_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216475_cas	encodes_tool	FBto0000135	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216475_cas	tool_uses	promoter trap	FBrf0248460		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216494_cas	tagged_with	FBto0000696	FBrf0246064		TOOL DATA from: FBal0369026
+FBti0216495_cas	tagged_with	FBto0000118	FBrf0246064		TOOL DATA from: FBal0369027
+FBti0216495_cas	tagged_with	FBto0000696	FBrf0246064		TOOL DATA from: FBal0369027
+FBti0216496_cas	tagged_with	FBto0000118	FBrf0246064		TOOL DATA from: FBal0369028
+FBti0216497_cas	carries_tool	FBto0000349	FBrf0239819		TOOL DATA from: FBal0369030
+FBti0216497_cas	tagged_with	FBto0000383	FBrf0239819		TOOL DATA from: FBal0369030
+FBti0216498_cas				FTA: unable to add tool information from FBal0369029 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216498_cas				FTA: unable to add tool information from FBal0369031 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216499_cas				FTA: unable to add tool information from FBal0369031 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216504_cas	tagged_with	FBto0000077	FBrf0249139		TOOL DATA from: FBal0369042
+FBti0216505_cas	tagged_with	FBto0000093	FBrf0249139		TOOL DATA from: FBal0369043
+FBti0216506_cas	tagged_with	FBto0000077	FBrf0249139		TOOL DATA from: FBal0369044
+FBti0216508_cas	tagged_with	FBto0000077	FBrf0249139		TOOL DATA from: FBal0369046
+FBti0216509_cas	tagged_with	FBto0000093	FBrf0249139		TOOL DATA from: FBal0369047
+FBti0216511_cas	tagged_with	FBto0000093	FBrf0249139		TOOL DATA from: FBal0369049
+FBti0216519_cas	carries_tool	FBto0000349	FBrf0249279		TOOL DATA from: FBal0369058
+FBti0216519_cas	carries_tool	FBto0000356	FBrf0249279		TOOL DATA from: FBal0369058
+FBti0216534_cas				FTA: unable to add tool information from FBal0369081 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216535_cas				FTA: unable to add tool information from FBal0369082 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216536_cas				FTA: unable to add tool information from FBal0369083 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216537_cas				FTA: unable to add tool information from FBal0369084 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216538_cas				FTA: unable to add tool information from FBal0369085 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216539_cas				FTA: unable to add tool information from FBal0369086 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216540_cas				FTA: unable to add tool information from FBal0369087 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216541_cas				FTA: unable to add tool information from FBal0369088 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216548_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369109
+FBti0216548_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369109
+FBti0216549_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369110
+FBti0216549_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369110
+FBti0216550_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369111
+FBti0216550_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369111
+FBti0216551_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369112
+FBti0216551_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369112
+FBti0216552_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369113
+FBti0216552_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369113
+FBti0216553_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369114
+FBti0216553_cas	tagged_with	FBto0000383	FBrf0249089		TOOL DATA from: FBal0369114
+FBti0216554_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369115
+FBti0216554_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369115
+FBti0216555_cas				FTA: unable to add tool information from FBal0369116 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216556_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369117
+FBti0216556_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369117
+FBti0216557_cas	carries_tool	FBto0000349	FBrf0249089		TOOL DATA from: FBal0369118
+FBti0216557_cas	tagged_with	FBto0000389	FBrf0249089		TOOL DATA from: FBal0369118
+FBti0216559_cas				FTA: unable to add tool information from FBal0369119 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216559_cas				FTA: unable to add tool information from FBal0369120 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216560_cas				FTA: unable to add tool information from FBal0369120 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216563_cas	carries_tool	FBto0000349	FBrf0249403		TOOL DATA from: FBal0369127
+FBti0216643_cas				FTA: unable to add tool information from FBal0369273 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216644_cas	tagged_with	FBto0000077	FBrf0250889		TOOL DATA from: FBal0369274
+FBti0216649_cas	tagged_with	FBto0000102	FBrf0249753		TOOL DATA from: FBal0369278
+FBti0216650_cas	carries_tool	FBto0000349	FBrf0249480		TOOL DATA from: FBal0369279
+FBti0216650_cas	carries_tool	FBto0000356	FBrf0249480		TOOL DATA from: FBal0369279
+FBti0216673_cas	tagged_with	FBto0000031	FBrf0249591		TOOL DATA from: FBal0369299
+FBti0216674_cas	carries_tool	FBto0000076	FBrf0249591		TOOL DATA from: FBal0369300
+FBti0216675_cas	carries_tool	FBto0000349	FBrf0251008		TOOL DATA from: FBal0369308
+FBti0216675_cas	carries_tool	FBto0000349	FBrf0251008		TOOL DATA from: FBal0369309
+FBti0216675_cas	tagged_with	FBto0000076	FBrf0251008		TOOL DATA from: FBal0369309
+FBti0216737_cas	tagged_with	FBto0000031	FBrf0248770		TOOL DATA from: FBal0369382
+FBti0216738_cas	tagged_with	FBto0000121	FBrf0248770		TOOL DATA from: FBal0369383
+FBti0216740_cas				FTA: unable to add tool information from FBal0369380 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216742_cas	carries_tool	FBto0000349	FBrf0248805		TOOL DATA from: FBal0369387
+FBti0216745_cas	encodes_tool	FBto0000027	FBrf0251346		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216745_cas	tool_uses	promoter trap	FBrf0251346		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216745_cas				FTA: unable to add tool information from FBal0369396 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216746_cas	encodes_tool	FBto0000022	FBrf0251346		TOOL DATA from: FBtp0148518, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216746_cas				FTA: unable to add tool information from FBal0369397 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216787_cas	encodes_tool	FBto0000118	FBrf0250949		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216787_cas	tool_uses	promoter trap	FBrf0250949		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216787_cas	carries_tool	FBto0000320	FBrf0250949		TOOL DATA from: FBal0369449
+FBti0216787_cas	carries_tool	FBto0000349	FBrf0250949		TOOL DATA from: FBal0369449
+FBti0216787_cas	carries_tool	FBto0000356	FBrf0250949		TOOL DATA from: FBal0369449
+FBti0216807_cas				FTA: unable to add tool information from FBal0369500 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0216849_cas	tagged_with	FBto0000031	FBrf0249790		TOOL DATA from: FBal0369541
+FBti0216849_cas	tagged_with	FBto0000307	FBrf0249790		TOOL DATA from: FBal0369541
+FBti0216855_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369574
+FBti0216855_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369574
+FBti0216856_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369575
+FBti0216856_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369575
+FBti0216857_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369576
+FBti0216857_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369576
+FBti0216858_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369577
+FBti0216858_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369577
+FBti0216859_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369578
+FBti0216859_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369578
+FBti0216860_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369579
+FBti0216860_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369579
+FBti0216861_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369580
+FBti0216861_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369580
+FBti0216862_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369581
+FBti0216862_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369581
+FBti0216863_cas	tagged_with	FBto0000076	FBrf0247302		TOOL DATA from: FBal0369582
+FBti0216863_cas	tagged_with	FBto0000077	FBrf0247302		TOOL DATA from: FBal0369582
+FBti0216869_cas	encodes_tool	FBto0000135	FBrf0250203		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216869_cas	tool_uses	promoter trap	FBrf0250203		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0216869_cas	carries_tool	FBto0000345	FBrf0250203		TOOL DATA from: FBal0369592
+FBti0216869_cas	carries_tool	FBto0000349	FBrf0250203		TOOL DATA from: FBal0369592
+FBti0216869_cas	carries_tool	FBto0000356	FBrf0250203		TOOL DATA from: FBal0369592
+FBti0216869_cas	carries_tool	FBto0000345	FBrf0250203		TOOL DATA from: FBal0369595
+FBti0216869_cas	carries_tool	FBto0000349	FBrf0250203		TOOL DATA from: FBal0369595
+FBti0216869_cas	carries_tool	FBto0000356	FBrf0250203		TOOL DATA from: FBal0369595
+FBti0216933_cas	carries_tool	FBto0000349	FBrf0250163		TOOL DATA from: FBal0369714
+FBti0216933_cas	tagged_with	FBto0000750	FBrf0250163		TOOL DATA from: FBal0369714
+FBti0216945_cas	tagged_with	FBto0000077	FBrf0251238		TOOL DATA from: FBal0369742
+FBti0217045_cas	carries_tool	FBto0000349	FBrf0250944		TOOL DATA from: FBal0369967
+FBti0217045_cas	carries_tool	FBto0000356	FBrf0250944		TOOL DATA from: FBal0369967
+FBti0217046_cas	carries_tool	FBto0000349	FBrf0250944		TOOL DATA from: FBal0369968
+FBti0217046_cas	carries_tool	FBto0000356	FBrf0250944		TOOL DATA from: FBal0369968
+FBti0217047_cas	carries_tool	FBto0000349	FBrf0250944		TOOL DATA from: FBal0369969
+FBti0217047_cas	tagged_with	FBto0000077	FBrf0250944		TOOL DATA from: FBal0369969
+FBti0217048_cas	carries_tool	FBto0000349	FBrf0250944		TOOL DATA from: FBal0369970
+FBti0217048_cas	tagged_with	FBto0000077	FBrf0250944		TOOL DATA from: FBal0369970
+FBti0217052_cas	carries_tool	FBto0000349	FBrf0251068		TOOL DATA from: FBal0370060
+FBti0217052_cas	carries_tool	FBto0000356	FBrf0251068		TOOL DATA from: FBal0370060
+FBti0217065_cas	tagged_with	FBto0000063	FBrf0249586		TOOL DATA from: FBal0370083
+FBti0217117_cas	tagged_with	FBto0000077	FBrf0248591		TOOL DATA from: FBal0370212
+FBti0217118_cas	tagged_with	FBto0000027	FBrf0251462		TOOL DATA from: FBal0370221
+FBti0217120_cas	carries_tool	FBto0000349	FBrf0251393		TOOL DATA from: FBal0370244
+FBti0217217_cas	tagged_with	FBto0000093	FBrf0251632		TOOL DATA from: FBal0370449
+FBti0217239_cas	encodes_tool	FBto0000135	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217239_cas	tool_uses	promoter trap	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217239_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370483
+FBti0217240_cas				FTA: unable to add tool information from FBal0370484 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217241_cas	encodes_tool	FBto0000135	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217241_cas	tool_uses	promoter trap	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217241_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370485
+FBti0217242_cas	encodes_tool	FBto0000135	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217242_cas	tool_uses	promoter trap	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217242_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370486
+FBti0217243_cas				FTA: unable to add tool information from FBal0370487 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217244_cas				FTA: unable to add tool information from FBal0370488 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217245_cas				FTA: unable to add tool information from FBal0370489 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217246_cas				FTA: unable to add tool information from FBal0370490 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217247_cas	encodes_tool	FBto0000135	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217247_cas	tool_uses	promoter trap	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217247_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370491
+FBti0217248_cas				FTA: unable to add tool information from FBal0370492 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217249_cas	encodes_tool	FBto0000135	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217249_cas	tool_uses	promoter trap	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217249_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370493
+FBti0217250_cas				FTA: unable to add tool information from FBal0370494 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217251_cas				FTA: unable to add tool information from FBal0370495 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217252_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370496
+FBti0217253_cas				FTA: unable to add tool information from FBal0370497 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217254_cas				FTA: unable to add tool information from FBal0370498 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217255_cas	encodes_tool	FBto0000135	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217255_cas	tool_uses	promoter trap	FBrf0248569		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217255_cas	carries_tool	FBto0000349	FBrf0248569		TOOL DATA from: FBal0370499
+FBti0217279_cas	encodes_tool	FBto0000118	FBrf0251374		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217279_cas	tool_uses	promoter trap	FBrf0251374		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217280_cas	encodes_tool	FBto0000135	FBrf0251374		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217280_cas	tool_uses	promoter trap	FBrf0251374		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217289_cas	carries_tool	FBto0000349	FBrf0251492		TOOL DATA from: FBal0370558
+FBti0217289_cas	carries_tool	FBto0000356	FBrf0251492		TOOL DATA from: FBal0370558
+FBti0217291_cas	tagged_with	FBto0000031	FBrf0251847		TOOL DATA from: FBal0370579
+FBti0217292_cas	tagged_with	FBto0000031	FBrf0251848		TOOL DATA from: FBal0370580
+FBti0217293_cas	tagged_with	FBto0000031	FBrf0251849		TOOL DATA from: FBal0370581
+FBti0217309_cas				FTA: unable to add tool information from FBal0370599 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217310_cas				FTA: unable to add tool information from FBal0360099 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217311_cas	encodes_tool	FBto0000031	FBrf0251850		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217311_cas	tool_uses	promoter trap	FBrf0251850		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217312_cas	encodes_tool	FBto0000031	FBrf0251850		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217312_cas	tool_uses	promoter trap	FBrf0251850		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217313_cas	tagged_with	FBto0000031	FBrf0251850		TOOL DATA from: FBal0370602
+FBti0217314_cas	encodes_tool	FBto0000031	FBrf0251850		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217314_cas	tool_uses	promoter trap	FBrf0251850		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217315_cas	tagged_with	FBto0000031	FBrf0251850		TOOL DATA from: FBal0370604
+FBti0217446_cas	encodes_tool	FBto0000135	FBrf0251799		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217446_cas	tool_uses	promoter trap	FBrf0251799		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217446_cas	carries_tool	FBto0000349	FBrf0251799		TOOL DATA from: FBal0370819
+FBti0217446_cas	carries_tool	FBto0000349	FBrf0251799		TOOL DATA from: FBal0370822
+FBti0217447_cas	encodes_tool	FBto0000118	FBrf0251799		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217447_cas	tool_uses	promoter trap	FBrf0251799		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217447_cas	carries_tool	FBto0000320	FBrf0251799		TOOL DATA from: FBal0370821
+FBti0217447_cas	carries_tool	FBto0000349	FBrf0251799		TOOL DATA from: FBal0370821
+FBti0217447_cas	carries_tool	FBto0000356	FBrf0251799		TOOL DATA from: FBal0370821
+FBti0217448_cas	encodes_tool	FBto0000118	FBrf0251787		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217448_cas	tool_uses	promoter trap	FBrf0251787		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217448_cas	carries_tool	FBto0000320	FBrf0251787		TOOL DATA from: FBal0370826
+FBti0217448_cas	carries_tool	FBto0000349	FBrf0251787		TOOL DATA from: FBal0370826
+FBti0217448_cas	carries_tool	FBto0000356	FBrf0251787		TOOL DATA from: FBal0370826
+FBti0217449_cas	encodes_tool	FBto0000135	FBrf0251787		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217449_cas	tool_uses	promoter trap	FBrf0251787		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217449_cas	carries_tool	FBto0000349	FBrf0251787		TOOL DATA from: FBal0370827
+FBti0217449_cas	carries_tool	FBto0000349	FBrf0251787		TOOL DATA from: FBal0370832
+FBti0217521_cas				FTA: unable to add tool information from FBal0370911 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217522_cas	carries_tool	FBto0000349	FBrf0252036		TOOL DATA from: FBal0370912
+FBti0217523_cas				FTA: unable to add tool information from FBal0370913 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217539_cas				FTA: unable to add tool information from FBal0370934 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217542_cas	tagged_with	FBto0000079	FBrf0251724		TOOL DATA from: FBal0370939
+FBti0217543_cas				FTA: unable to add tool information from FBal0370942 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217600_cas	encodes_tool	FBto0000158	FBrf0252365		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217600_cas	tool_uses	promoter trap	FBrf0252365		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217601_cas	encodes_tool	FBto0000158	FBrf0252365		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217601_cas	tool_uses	promoter trap	FBrf0252365		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217704_cas	tagged_with	FBto0000126	FBrf0252194		TOOL DATA from: FBal0371380
+FBti0217705_cas				FTA: unable to add tool information from FBal0371385 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217712_cas	tagged_with	FBto0000522	FBrf0252184		TOOL DATA from: FBal0371408
+FBti0217713_cas	tagged_with	FBto0000522	FBrf0252184		TOOL DATA from: FBal0371409
+FBti0217714_cas	tagged_with	FBto0000585	FBrf0252184		TOOL DATA from: FBal0371410
+FBti0217715_cas	tagged_with	FBto0000585	FBrf0252184		TOOL DATA from: FBal0371411
+FBti0217720_cas	encodes_tool	FBto0000135	FBrf0246238		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217720_cas	tool_uses	promoter trap	FBrf0246238		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217721_cas	encodes_tool	FBto0000135	FBrf0246238		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217721_cas	tool_uses	promoter trap	FBrf0246238		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217722_cas	encodes_tool	FBto0000135	FBrf0246238		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217722_cas	tool_uses	promoter trap	FBrf0246238		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217723_cas	encodes_tool	FBto0000135	FBrf0246238		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217723_cas	tool_uses	promoter trap	FBrf0246238		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217746_cas	encodes_tool	FBto0000135	FBrf0234251		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217746_cas	tool_uses	promoter trap	FBrf0234251		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217747_cas	encodes_tool	FBto0000146	FBrf0234251		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217747_cas	tool_uses	promoter trap	FBrf0234251		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217748_cas	encodes_tool	FBto0000158	FBrf0234251		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217748_cas	tool_uses	promoter trap	FBrf0234251		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217748_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0371482
+FBti0217748_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0371482
+FBti0217748_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0371482
+FBti0217748_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0371491
+FBti0217748_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0371491
+FBti0217748_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0371491
+FBti0217749_cas	encodes_tool	FBto0000158	FBrf0234251		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217749_cas	tool_uses	promoter trap	FBrf0234251		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217749_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0371483
+FBti0217749_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0371483
+FBti0217749_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0371483
+FBti0217749_cas	carries_tool	FBto0000328	FBrf0234251		TOOL DATA from: FBal0371493
+FBti0217749_cas	carries_tool	FBto0000349	FBrf0234251		TOOL DATA from: FBal0371493
+FBti0217749_cas	carries_tool	FBto0000356	FBrf0234251		TOOL DATA from: FBal0371493
+FBti0217750_cas	encodes_tool	FBto0000158	FBrf0234251		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217750_cas	tool_uses	promoter trap	FBrf0234251		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217752_cas	encodes_tool	FBto0000777	FBrf0234251		TOOL DATA from: FBtp0149613, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217752_cas	tool_uses	promoter trap	FBrf0234251		TOOL DATA from: FBtp0149613, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217779_cas	tagged_with	FBto0000027	FBrf0251782		TOOL DATA from: FBal0371534
+FBti0217780_cas	tagged_with	FBto0000027	FBrf0251782		TOOL DATA from: FBal0371535
+FBti0217781_cas	tagged_with	FBto0000118	FBrf0251782		TOOL DATA from: FBal0371536
+FBti0217811_cas	tagged_with	FBto0000077	FBrf0251844		TOOL DATA from: FBal0371610
+FBti0217811_cas	tagged_with	FBto0000081	FBrf0251844		TOOL DATA from: FBal0371610
+FBti0217813_cas	carries_tool	FBto0000318	FBrf0251844		TOOL DATA from: FBal0371613
+FBti0217813_cas	tagged_with	FBto0000077	FBrf0251844		TOOL DATA from: FBal0371613
+FBti0217817_cas	tagged_with	FBto0000081	FBrf0252121		TOOL DATA from: FBal0371626
+FBti0217818_cas	carries_tool	FBto0000349	FBrf0252318		TOOL DATA from: FBal0371627
+FBti0217818_cas	carries_tool	FBto0000356	FBrf0252318		TOOL DATA from: FBal0371627
+FBti0217819_cas	encodes_tool	FBto0000135	FBrf0252318		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217819_cas	tool_uses	promoter trap	FBrf0252318		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217829_cas				FTA: unable to add tool information from FBal0371646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217830_cas	tagged_with	FBto0000031	FBrf0252329		TOOL DATA from: FBal0371647
+FBti0217831_cas	tagged_with	FBto0000077	FBrf0252329		TOOL DATA from: FBal0371648
+FBti0217840_cas	carries_tool	FBto0000349	FBrf0252413		TOOL DATA from: FBal0371677
+FBti0217840_cas	carries_tool	FBto0000356	FBrf0252413		TOOL DATA from: FBal0371677
+FBti0217841_cas				FTA: unable to add tool information from FBal0371678 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217842_cas	tagged_with	FBto0000093	FBrf0252413		TOOL DATA from: FBal0371679
+FBti0217843_cas	tagged_with	FBto0000093	FBrf0252413		TOOL DATA from: FBal0371683
+FBti0217902_cas	encodes_tool	FBto0000135	FBrf0252465		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217902_cas	tool_uses	promoter trap	FBrf0252465		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0217902_cas	tagged_with	FBto0000092	FBrf0252465		TOOL DATA from: FBal0371751
+FBti0217906_cas	tagged_with	FBto0000077	FBrf0236455		TOOL DATA from: FBal0371757
+FBti0217929_cas				FTA: unable to add tool information from FBal0371806 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0217930_cas	carries_tool	FBto0000349	FBrf0252264		TOOL DATA from: FBal0371807
+FBti0217930_cas	tagged_with	FBto0000077	FBrf0252264		TOOL DATA from: FBal0371807
+FBti0217931_cas	carries_tool	FBto0000349	FBrf0252264		TOOL DATA from: FBal0371808
+FBti0217931_cas	tagged_with	FBto0000077	FBrf0252264		TOOL DATA from: FBal0371808
+FBti0217937_cas	tagged_with	FBto0000077	FBrf0251588		TOOL DATA from: FBal0371823
+FBti0219083_cas	encodes_tool	FBto0000135	FBrf0252701		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219083_cas	tool_uses	promoter trap	FBrf0252701		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219085_cas				FTA: unable to add tool information from FBal0373166 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219086_cas	carries_tool	FBto0000349	FBrf0252532		TOOL DATA from: FBal0373167
+FBti0219086_cas	carries_tool	FBto0000356	FBrf0252532		TOOL DATA from: FBal0373167
+FBti0219094_cas				FTA: unable to add tool information from FBal0373181 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219095_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373183
+FBti0219095_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373183
+FBti0219096_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373184
+FBti0219096_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373184
+FBti0219096_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373184
+FBti0219097_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373186
+FBti0219097_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373186
+FBti0219097_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373186
+FBti0219099_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373188
+FBti0219099_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373188
+FBti0219099_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373188
+FBti0219100_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373189
+FBti0219100_cas	tagged_with	FBto0000118	FBrf0248198		TOOL DATA from: FBal0373189
+FBti0219100_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373189
+FBti0219101_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373190
+FBti0219101_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373190
+FBti0219101_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373190
+FBti0219102_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373191
+FBti0219102_cas	tagged_with	FBto0000118	FBrf0248198		TOOL DATA from: FBal0373191
+FBti0219102_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373191
+FBti0219103_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373192
+FBti0219103_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373192
+FBti0219103_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373192
+FBti0219104_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373193
+FBti0219104_cas	tagged_with	FBto0000118	FBrf0248198		TOOL DATA from: FBal0373193
+FBti0219104_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373193
+FBti0219105_cas	carries_tool	FBto0000318	FBrf0248198		TOOL DATA from: FBal0373194
+FBti0219105_cas	tagged_with	FBto0000031	FBrf0248198		TOOL DATA from: FBal0373194
+FBti0219105_cas	tagged_with	FBto0000403	FBrf0248198		TOOL DATA from: FBal0373194
+FBti0219106_cas	tagged_with	FBto0000077	FBrf0248198		TOOL DATA from: FBal0373195
+FBti0219106_cas	tagged_with	FBto0000118	FBrf0248198		TOOL DATA from: FBal0373195
+FBti0219106_cas	tagged_with	FBto0000739	FBrf0248198		TOOL DATA from: FBal0373195
+FBti0219107_cas	encodes_tool	FBto0000135	FBrf0248198		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219107_cas	tool_uses	promoter trap	FBrf0248198		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219108_cas	encodes_tool	FBto0000167	FBrf0248198		TOOL DATA from: FBtp0099206, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219108_cas	tool_uses	promoter trap	FBrf0248198		TOOL DATA from: FBtp0099206, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219111_cas	tagged_with	FBto0000335	FBrf0252719		TOOL DATA from: FBal0373209
+FBti0219113_cas	tagged_with	FBto0000031	FBrf0252880		TOOL DATA from: FBal0373218
+FBti0219114_cas	tagged_with	FBto0000031	FBrf0252880		TOOL DATA from: FBal0373219
+FBti0219115_cas	tagged_with	FBto0000031	FBrf0252880		TOOL DATA from: FBal0373220
+FBti0219116_cas	tagged_with	FBto0000031	FBrf0252880		TOOL DATA from: FBal0373221
+FBti0219126_cas	carries_tool	FBto0000349	FBrf0252516		TOOL DATA from: FBal0373246
+FBti0219126_cas	tagged_with	FBto0000077	FBrf0252516		TOOL DATA from: FBal0373246
+FBti0219129_cas	carries_tool	FBto0000349	FBrf0252566		TOOL DATA from: FBal0373252
+FBti0219130_cas	carries_tool	FBto0000349	FBrf0252566		TOOL DATA from: FBal0373253
+FBti0219131_cas	tagged_with	FBto0000070	FBrf0252566		TOOL DATA from: FBal0373255
+FBti0219139_cas	tagged_with	FBto0000102	FBrf0251965		TOOL DATA from: FBal0373271
+FBti0219140_cas	tagged_with	FBto0000047	FBrf0251916		TOOL DATA from: FBal0373272
+FBti0219251_cas				FTA: unable to add tool information from FBal0373473 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219255_cas	tagged_with	FBto0000787	FBrf0252708		TOOL DATA from: FBal0373492
+FBti0219256_cas	tagged_with	FBto0000785	FBrf0252708		TOOL DATA from: FBal0373493
+FBti0219257_cas	tagged_with	FBto0000787	FBrf0252708		TOOL DATA from: FBal0373494
+FBti0219288_cas	carries_tool	FBto0000349	FBrf0252657		TOOL DATA from: FBal0373534
+FBti0219288_cas	carries_tool	FBto0000356	FBrf0252657		TOOL DATA from: FBal0373534
+FBti0219289_cas	carries_tool	FBto0000349	FBrf0252657		TOOL DATA from: FBal0373535
+FBti0219289_cas	carries_tool	FBto0000356	FBrf0252657		TOOL DATA from: FBal0373535
+FBti0219291_cas	carries_tool	FBto0000349	FBrf0252657		TOOL DATA from: FBal0373537
+FBti0219291_cas	carries_tool	FBto0000356	FBrf0252657		TOOL DATA from: FBal0373537
+FBti0219291_cas	tagged_with	FBto0000077	FBrf0252657		TOOL DATA from: FBal0373537
+FBti0219295_cas	carries_tool	FBto0000349	FBrf0252934		TOOL DATA from: FBal0373571
+FBti0219296_cas				FTA: unable to add tool information from FBal0373573 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219297_cas	tagged_with	FBto0000027	FBrf0252717		TOOL DATA from: FBal0373576
+FBti0219301_cas	encodes_tool	FBto0000143	FBrf0252816		TOOL DATA from: FBtp0150003, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219301_cas	tool_uses	promoter trap	FBrf0252816		TOOL DATA from: FBtp0150003, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219306_cas	encodes_tool	FBto0000143	FBrf0252648		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219306_cas	tool_uses	promoter trap	FBrf0252648		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219307_cas	encodes_tool	FBto0000146	FBrf0252199		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219307_cas	tool_uses	promoter trap	FBrf0252199		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219307_cas	carries_tool	FBto0000349	FBrf0252199		TOOL DATA from: FBal0373628
+FBti0219307_cas	carries_tool	FBto0000349	FBrf0252199		TOOL DATA from: FBal0373630
+FBti0219329_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373693
+FBti0219329_cas	carries_tool	FBto0000356	FBrf0251832		TOOL DATA from: FBal0373693
+FBti0219330_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373694
+FBti0219330_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373694
+FBti0219331_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373695
+FBti0219331_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373695
+FBti0219332_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373696
+FBti0219332_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373696
+FBti0219333_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373697
+FBti0219333_cas	carries_tool	FBto0000356	FBrf0251832		TOOL DATA from: FBal0373697
+FBti0219333_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373697
+FBti0219334_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373698
+FBti0219334_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373698
+FBti0219335_cas	carries_tool	FBto0000349	FBrf0251832		TOOL DATA from: FBal0373699
+FBti0219335_cas	tagged_with	FBto0000031	FBrf0251832		TOOL DATA from: FBal0373699
+FBti0219337_cas	tagged_with	FBto0000031	FBrf0252920		TOOL DATA from: FBal0373715
+FBti0219348_cas	carries_tool	FBto0000349	FBrf0235886		TOOL DATA from: FBal0373746
+FBti0219348_cas	carries_tool	FBto0000356	FBrf0235886		TOOL DATA from: FBal0373746
+FBti0219348_cas	tagged_with	FBto0000079	FBrf0235886		TOOL DATA from: FBal0373746
+FBti0219349_cas	carries_tool	FBto0000349	FBrf0235886		TOOL DATA from: FBal0373749
+FBti0219349_cas	carries_tool	FBto0000356	FBrf0235886		TOOL DATA from: FBal0373749
+FBti0219362_cas	carries_tool	FBto0000349	FBrf0253229		TOOL DATA from: FBal0373770
+FBti0219362_cas	carries_tool	FBto0000356	FBrf0253229		TOOL DATA from: FBal0373770
+FBti0219373_cas	carries_tool	FBto0000318	FBrf0253111		TOOL DATA from: FBtp0150177, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219374_cas	carries_tool	FBto0000318	FBrf0253111		TOOL DATA from: FBtp0150177, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219425_cas	carries_tool	FBto0000349	FBrf0248551		TOOL DATA from: FBal0373855
+FBti0219425_cas	tagged_with	FBto0000389	FBrf0248551		TOOL DATA from: FBal0373855
+FBti0219479_cas	carries_tool	FBto0000326	FBrf0252818		TOOL DATA from: FBal0373907
+FBti0219479_cas	tagged_with	FBto0000076	FBrf0252818		TOOL DATA from: FBal0373907
+FBti0219480_cas	carries_tool	FBto0000326	FBrf0252818		TOOL DATA from: FBal0373908
+FBti0219480_cas	tagged_with	FBto0000076	FBrf0252818		TOOL DATA from: FBal0373908
+FBti0219597_cas	encodes_tool	FBto0000135	FBrf0246949		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219597_cas	tool_uses	promoter trap	FBrf0246949		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219598_cas	encodes_tool	FBto0000031	FBrf0246949		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219598_cas	tool_uses	promoter trap	FBrf0246949		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219598_cas	carries_tool	FBto0000349	FBrf0246949		TOOL DATA from: FBal0374049
+FBti0219598_cas	carries_tool	FBto0000349	FBrf0246949		TOOL DATA from: FBal0374058
+FBti0219599_cas	carries_tool	FBto0000318	FBrf0246949		TOOL DATA from: FBal0374050
+FBti0219599_cas	encodes_tool	FBto0000031	FBrf0246949		TOOL DATA from: FBal0374050
+FBti0219599_cas	tagged_with	FBto0000281	FBrf0246949		TOOL DATA from: FBal0374050
+FBti0219599_cas	carries_tool	FBto0000318	FBrf0246949		TOOL DATA from: FBal0374064
+FBti0219600_cas	encodes_tool	FBto0000623	FBrf0105495		TOOL DATA from: FBtp0150835, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219600_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0150835, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219600_cas	tagged_with	FBto0000077	FBrf0246949		TOOL DATA from: FBal0374051
+FBti0219600_cas	tagged_with	FBto0000631	FBrf0246949		TOOL DATA from: FBal0374051
+FBti0219601_cas	encodes_tool	FBto0000795	FBrf0246949		TOOL DATA from: FBtp0150467, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219601_cas	tool_uses	promoter trap	FBrf0246949		TOOL DATA from: FBtp0150467, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219601_cas	tagged_with	FBto0000077	FBrf0246949		TOOL DATA from: FBal0374052
+FBti0219601_cas	tagged_with	FBto0000631	FBrf0246949		TOOL DATA from: FBal0374052
+FBti0219602_cas	encodes_tool	FBto0000795	FBrf0246949		TOOL DATA from: FBtp0150467, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219602_cas	tool_uses	promoter trap	FBrf0246949		TOOL DATA from: FBtp0150467, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219602_cas	tagged_with	FBto0000694	FBrf0246949		TOOL DATA from: FBal0374053
+FBti0219603_cas				FTA: unable to add tool information from FBal0374055 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219604_cas				FTA: unable to add tool information from FBal0374057 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219605_cas	carries_tool	FBto0000356	FBrf0246949		TOOL DATA from: FBal0374059
+FBti0219606_cas	carries_tool	FBto0000318	FBrf0246949		TOOL DATA from: FBal0374063
+FBti0219606_cas	tagged_with	FBto0000077	FBrf0246949		TOOL DATA from: FBal0374063
+FBti0219608_cas	encodes_tool	FBto0000791	FBrf0252177		TOOL DATA from: FBtp0150465, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219608_cas	tool_uses	promoter trap	FBrf0252177		TOOL DATA from: FBtp0150465, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219608_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374069
+FBti0219608_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374079
+FBti0219609_cas	encodes_tool	FBto0000791	FBrf0252177		TOOL DATA from: FBtp0150465, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219609_cas	tool_uses	promoter trap	FBrf0252177		TOOL DATA from: FBtp0150465, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219609_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374070
+FBti0219609_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374080
+FBti0219610_cas	encodes_tool	FBto0000791	FBrf0252177		TOOL DATA from: FBtp0150465, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219610_cas	tool_uses	promoter trap	FBrf0252177		TOOL DATA from: FBtp0150465, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219610_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374071
+FBti0219610_cas	carries_tool	FBto0000349	FBrf0252177		TOOL DATA from: FBal0374081
+FBti0219611_cas	tagged_with	FBto0000683	FBrf0252177		TOOL DATA from: FBal0374072
+FBti0219612_cas	carries_tool	FBto0000318	FBrf0252177		TOOL DATA from: FBal0374073
+FBti0219612_cas	tagged_with	FBto0000077	FBrf0252177		TOOL DATA from: FBal0374073
+FBti0219637_cas	carries_tool	FBto0000349	FBrf0253037		TOOL DATA from: FBal0374097
+FBti0219637_cas	tagged_with	FBto0000076	FBrf0253037		TOOL DATA from: FBal0374097
+FBti0219638_cas	carries_tool	FBto0000349	FBrf0253037		TOOL DATA from: FBal0374098
+FBti0219638_cas	tagged_with	FBto0000076	FBrf0253037		TOOL DATA from: FBal0374098
+FBti0219639_cas	tagged_with	FBto0000083	FBrf0251869		TOOL DATA from: FBal0374101
+FBti0219639_cas	tagged_with	FBto0000790	FBrf0251869		TOOL DATA from: FBal0374101
+FBti0219689_cas	carries_tool	FBto0000356	FBrf0253136		TOOL DATA from: FBal0374221
+FBti0219690_cas	tagged_with	FBto0000126	FBrf0253136		TOOL DATA from: FBal0374222
+FBti0219702_cas	tagged_with	FBto0000077	FBrf0251969		TOOL DATA from: FBal0374305
+FBti0219702_cas	tagged_with	FBto0000589	FBrf0251969		TOOL DATA from: FBal0374305
+FBti0219703_cas	tagged_with	FBto0000077	FBrf0251969		TOOL DATA from: FBal0374306
+FBti0219703_cas	tagged_with	FBto0000590	FBrf0251969		TOOL DATA from: FBal0374306
+FBti0219704_cas	tagged_with	FBto0000077	FBrf0251969		TOOL DATA from: FBal0374307
+FBti0219704_cas	tagged_with	FBto0000588	FBrf0251969		TOOL DATA from: FBal0374307
+FBti0219727_cas	encodes_tool	FBto0000135	FBrf0252790		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219727_cas	tool_uses	promoter trap	FBrf0252790		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219727_cas	carries_tool	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374335
+FBti0219727_cas	carries_tool	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374339
+FBti0219728_cas	encodes_tool	FBto0000155	FBrf0252790		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219728_cas	tool_uses	promoter trap	FBrf0252790		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219728_cas	tagged_with	FBto0000242	FBrf0252790		TOOL DATA from: FBal0374337
+FBti0219728_cas	tagged_with	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374337
+FBti0219728_cas	tagged_with	FBto0000242	FBrf0252790		TOOL DATA from: FBal0374343
+FBti0219728_cas	tagged_with	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374343
+FBti0219729_cas	carries_tool	FBto0000155	FBrf0252790		TOOL DATA from: FBal0374338
+FBti0219729_cas	tagged_with	FBto0000242	FBrf0252790		TOOL DATA from: FBal0374338
+FBti0219729_cas	tagged_with	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374338
+FBti0219729_cas	tagged_with	FBto0000349	FBrf0252790		TOOL DATA from: FBal0374341
+FBti0219731_cas	encodes_tool	FBto0000143	FBrf0249194		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219731_cas	tool_uses	promoter trap	FBrf0249194		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219751_cas	tagged_with	FBto0000389	FBrf0252858		TOOL DATA from: FBal0374402
+FBti0219775_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374431
+FBti0219776_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374432
+FBti0219777_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374433
+FBti0219778_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374436
+FBti0219779_cas	tagged_with	FBto0000118	FBrf0252860		TOOL DATA from: FBal0374437
+FBti0219785_cas	carries_tool	FBto0000356	FBrf0248779		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219785_cas	tool_uses	docking element	FBrf0248779		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219788_cas	tagged_with	FBto0000031	FBrf0248779		TOOL DATA from: FBal0374449
+FBti0219789_cas	tagged_with	FBto0000031	FBrf0248779		TOOL DATA from: FBal0374450
+FBti0219790_cas	tagged_with	FBto0000031	FBrf0248779		TOOL DATA from: FBal0374451
+FBti0219791_cas	tagged_with	FBto0000031	FBrf0248779		TOOL DATA from: FBal0374452
+FBti0219838_cas	carries_tool	FBto0000356	FBrf0253099		TOOL DATA from: FBal0374546
+FBti0219842_cas	carries_tool	FBto0000356	FBrf0253099		TOOL DATA from: FBal0374550
+FBti0219852_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374574
+FBti0219853_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374575
+FBti0219853_cas	tagged_with	FBto0000093	FBrf0247204		TOOL DATA from: FBal0374575
+FBti0219854_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374576
+FBti0219855_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374577
+FBti0219856_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374578
+FBti0219856_cas	tagged_with	FBto0000077	FBrf0247204		TOOL DATA from: FBal0374578
+FBti0219857_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374580
+FBti0219857_cas	tagged_with	FBto0000093	FBrf0247204		TOOL DATA from: FBal0374580
+FBti0219858_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374581
+FBti0219859_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374582
+FBti0219859_cas	tagged_with	FBto0000093	FBrf0247204		TOOL DATA from: FBal0374582
+FBti0219860_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374583
+FBti0219861_cas	carries_tool	FBto0000330	FBrf0247204		TOOL DATA from: FBal0374584
+FBti0219861_cas	tagged_with	FBto0000093	FBrf0247204		TOOL DATA from: FBal0374584
+FBti0219863_cas	carries_tool	FBto0000349	FBrf0252652		TOOL DATA from: FBal0374588
+FBti0219863_cas	tagged_with	FBto0000027	FBrf0252652		TOOL DATA from: FBal0374588
+FBti0219866_cas				FTA: unable to add tool information from FBal0374593 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219867_cas				FTA: unable to add tool information from FBal0374594 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0219868_cas	encodes_tool	FBto0000135	FBrf0253240		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219868_cas	tool_uses	promoter trap	FBrf0253240		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0219868_cas	carries_tool	FBto0000349	FBrf0253240		TOOL DATA from: FBal0374595
+FBti0219868_cas	carries_tool	FBto0000356	FBrf0253240		TOOL DATA from: FBal0374595
+FBti0219868_cas	carries_tool	FBto0000349	FBrf0253240		TOOL DATA from: FBal0374601
+FBti0219868_cas	carries_tool	FBto0000356	FBrf0253240		TOOL DATA from: FBal0374601
+FBti0219901_cas	tagged_with	FBto0000076	FBrf0249020		TOOL DATA from: FBal0374678
+FBti0219902_cas	tagged_with	FBto0000076	FBrf0249020		TOOL DATA from: FBal0374680
+FBti0219903_cas	tagged_with	FBto0000031	FBrf0249020		TOOL DATA from: FBal0374681
+FBti0219904_cas	carries_tool	FBto0000356	FBrf0249020		TOOL DATA from: FBal0374682
+FBti0219905_cas	tagged_with	FBto0000076	FBrf0249020		TOOL DATA from: FBal0374683
+FBti0219906_cas	tagged_with	FBto0000076	FBrf0249020		TOOL DATA from: FBal0374685
+FBti0219909_cas	carries_tool	FBto0000318	FBrf0253290		TOOL DATA from: FBal0374690
+FBti0219909_cas	tagged_with	FBto0000077	FBrf0253290		TOOL DATA from: FBal0374690
+FBti0219909_cas	tagged_with	FBto0000739	FBrf0253290		TOOL DATA from: FBal0374690
+FBti0219910_cas	carries_tool	FBto0000318	FBrf0253290		TOOL DATA from: FBal0374691
+FBti0219910_cas	tagged_with	FBto0000031	FBrf0253290		TOOL DATA from: FBal0374691
+FBti0219910_cas	tagged_with	FBto0000403	FBrf0253290		TOOL DATA from: FBal0374691
+FBti0219911_cas	carries_tool	FBto0000318	FBrf0253290		TOOL DATA from: FBal0374692
+FBti0219911_cas	tagged_with	FBto0000077	FBrf0253290		TOOL DATA from: FBal0374692
+FBti0219911_cas	tagged_with	FBto0000118	FBrf0253290		TOOL DATA from: FBal0374692
+FBti0219911_cas	tagged_with	FBto0000739	FBrf0253290		TOOL DATA from: FBal0374692
+FBti0220024_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374831
+FBti0220025_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374832
+FBti0220026_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374833
+FBti0220027_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374834
+FBti0220028_cas	tagged_with	FBto0000802	FBrf0253221		TOOL DATA from: FBal0374835
+FBti0220029_cas	tagged_with	FBto0000389	FBrf0253221		TOOL DATA from: FBal0374836
+FBti0220037_cas	encodes_tool	FBto0000135	FBrf0253280		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220037_cas	tool_uses	promoter trap	FBrf0253280		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220047_cas	tagged_with	FBto0000027	FBrf0253239		TOOL DATA from: FBal0374903
+FBti0220048_cas	tagged_with	FBto0000027	FBrf0253239		TOOL DATA from: FBal0374904
+FBti0220049_cas	tagged_with	FBto0000027	FBrf0253239		TOOL DATA from: FBal0374905
+FBti0220050_cas	tagged_with	FBto0000027	FBrf0253239		TOOL DATA from: FBal0374906
+FBti0220068_cas	tagged_with	FBto0000031	FBrf0253559		TOOL DATA from: FBal0374956
+FBti0220069_cas	tagged_with	FBto0000031	FBrf0253559		TOOL DATA from: FBal0374958
+FBti0220098_cas				FTA: unable to add tool information from FBal0374997 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220099_cas				FTA: unable to add tool information from FBal0374998 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220101_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375012
+FBti0220101_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375012
+FBti0220102_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375013
+FBti0220102_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375013
+FBti0220102_cas	tagged_with	FBto0000088	FBrf0253425		TOOL DATA from: FBal0375013
+FBti0220102_cas	tagged_with	FBto0000102	FBrf0253425		TOOL DATA from: FBal0375013
+FBti0220103_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375014
+FBti0220103_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375014
+FBti0220104_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375015
+FBti0220104_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375015
+FBti0220105_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375016
+FBti0220105_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375016
+FBti0220106_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375017
+FBti0220106_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375017
+FBti0220107_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375018
+FBti0220107_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375018
+FBti0220108_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375019
+FBti0220108_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375019
+FBti0220108_cas	tagged_with	FBto0000088	FBrf0253425		TOOL DATA from: FBal0375019
+FBti0220108_cas	tagged_with	FBto0000102	FBrf0253425		TOOL DATA from: FBal0375019
+FBti0220109_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375020
+FBti0220109_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375020
+FBti0220110_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375021
+FBti0220110_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375021
+FBti0220111_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375022
+FBti0220111_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375022
+FBti0220111_cas	tagged_with	FBto0000088	FBrf0253425		TOOL DATA from: FBal0375022
+FBti0220111_cas	tagged_with	FBto0000102	FBrf0253425		TOOL DATA from: FBal0375022
+FBti0220112_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375023
+FBti0220112_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375023
+FBti0220113_cas	carries_tool	FBto0000349	FBrf0253425		TOOL DATA from: FBal0375024
+FBti0220113_cas	tagged_with	FBto0000076	FBrf0253425		TOOL DATA from: FBal0375024
+FBti0220113_cas	tagged_with	FBto0000088	FBrf0253425		TOOL DATA from: FBal0375024
+FBti0220113_cas	tagged_with	FBto0000102	FBrf0253425		TOOL DATA from: FBal0375024
+FBti0220131_cas	tagged_with	FBto0000789	FBrf0250332		TOOL DATA from: FBal0375118
+FBti0220132_cas	tagged_with	FBto0000789	FBrf0250332		TOOL DATA from: FBal0375119
+FBti0220133_cas	tagged_with	FBto0000118	FBrf0250332		TOOL DATA from: FBal0375120
+FBti0220133_cas	tagged_with	FBto0000789	FBrf0250332		TOOL DATA from: FBal0375120
+FBti0220134_cas	tagged_with	FBto0000118	FBrf0250332		TOOL DATA from: FBal0375121
+FBti0220134_cas	tagged_with	FBto0000807	FBrf0250332		TOOL DATA from: FBal0375121
+FBti0220135_cas	tagged_with	FBto0000118	FBrf0250332		TOOL DATA from: FBal0375122
+FBti0220135_cas	tagged_with	FBto0000808	FBrf0250332		TOOL DATA from: FBal0375122
+FBti0220136_cas	tagged_with	FBto0000118	FBrf0250332		TOOL DATA from: FBal0375123
+FBti0220136_cas	tagged_with	FBto0000809	FBrf0250332		TOOL DATA from: FBal0375123
+FBti0220148_cas	carries_tool	FBto0000349	FBrf0253558		TOOL DATA from: FBal0375146
+FBti0220148_cas	carries_tool	FBto0000356	FBrf0253558		TOOL DATA from: FBal0375146
+FBti0220149_cas	carries_tool	FBto0000349	FBrf0253558		TOOL DATA from: FBal0375147
+FBti0220149_cas	carries_tool	FBto0000356	FBrf0253558		TOOL DATA from: FBal0375147
+FBti0220338_cas	tagged_with	FBto0000077	FBrf0236830		TOOL DATA from: FBal0375520
+FBti0220340_cas				FTA: unable to add tool information from FBal0375530 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220341_cas	carries_tool	FBto0000349	FBrf0253731		TOOL DATA from: FBal0375531
+FBti0220341_cas	tagged_with	FBto0000126	FBrf0253731		TOOL DATA from: FBal0375531
+FBti0220342_cas	carries_tool	FBto0000349	FBrf0253731		TOOL DATA from: FBal0375532
+FBti0220342_cas	tagged_with	FBto0000126	FBrf0253731		TOOL DATA from: FBal0375532
+FBti0220344_cas	tagged_with	FBto0000076	FBrf0253598		TOOL DATA from: FBal0375536
+FBti0220344_cas	tagged_with	FBto0000088	FBrf0253598		TOOL DATA from: FBal0375536
+FBti0220368_cas	tagged_with	FBto0000102	FBrf0253831		TOOL DATA from: FBal0375598
+FBti0220369_cas	tagged_with	FBto0000063	FBrf0253899		TOOL DATA from: FBal0375765
+FBti0220370_cas	tagged_with	FBto0000063	FBrf0253899		TOOL DATA from: FBal0375766
+FBti0220371_cas	tagged_with	FBto0000063	FBrf0253899		TOOL DATA from: FBal0375767
+FBti0220480_cas				FTA: unable to add tool information from FBal0375768 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220489_cas	carries_tool	FBto0000349	FBrf0253546		TOOL DATA from: FBal0375789
+FBti0220489_cas	tagged_with	FBto0000027	FBrf0253546		TOOL DATA from: FBal0375789
+FBti0220528_cas	encodes_tool	FBto0000020	FBrf0253956		TOOL DATA from: FBtp0099208, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220528_cas	tool_uses	promoter trap	FBrf0253956		TOOL DATA from: FBtp0099208, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220529_cas	encodes_tool	FBto0000020	FBrf0253956		TOOL DATA from: FBtp0099208, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220529_cas	tool_uses	promoter trap	FBrf0253956		TOOL DATA from: FBtp0099208, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220649_cas	encodes_tool	FBto0000143	FBrf0253396		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220649_cas	tool_uses	promoter trap	FBrf0253396		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220649_cas	carries_tool	FBto0000356	FBrf0253396		TOOL DATA from: FBal0375994
+FBti0220649_cas	carries_tool	FBto0000356	FBrf0253396		TOOL DATA from: FBal0375999
+FBti0220659_cas	carries_tool	FBto0000349	FBrf0250623		TOOL DATA from: FBal0376015
+FBti0220659_cas	carries_tool	FBto0000356	FBrf0250623		TOOL DATA from: FBal0376015
+FBti0220664_cas	carries_tool	FBto0000356	FBrf0253814		TOOL DATA from: FBal0376045
+FBti0220666_cas				FTA: unable to add tool information from FBal0376047 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220667_cas	carries_tool	FBto0000318	FBrf0253814		TOOL DATA from: FBal0376048
+FBti0220668_cas	carries_tool	FBto0000318	FBrf0253814		TOOL DATA from: FBal0376049
+FBti0220674_cas	tagged_with	FBto0000815	FBrf0253726		TOOL DATA from: FBal0376070
+FBti0220776_cas	carries_tool	FBto0000349	FBrf0253833		TOOL DATA from: FBal0376105
+FBti0220776_cas	tagged_with	FBto0000076	FBrf0253833		TOOL DATA from: FBal0376105
+FBti0220777_cas	carries_tool	FBto0000349	FBrf0253833		TOOL DATA from: FBal0376106
+FBti0220777_cas	tagged_with	FBto0000076	FBrf0253833		TOOL DATA from: FBal0376106
+FBti0220778_cas	carries_tool	FBto0000349	FBrf0253833		TOOL DATA from: FBal0376107
+FBti0220778_cas	tagged_with	FBto0000076	FBrf0253833		TOOL DATA from: FBal0376107
+FBti0220784_cas	carries_tool	FBto0000356	FBrf0254168		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220784_cas	tool_uses	docking element	FBrf0254168		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220784_cas				FTA: unable to add tool information from FBal0376119 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0220795_cas	tagged_with	FBto0000076	FBrf0253978		TOOL DATA from: FBal0376164
+FBti0220796_cas	tagged_with	FBto0000076	FBrf0253978		TOOL DATA from: FBal0376167
+FBti0220800_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376169
+FBti0220801_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376170
+FBti0220802_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376171
+FBti0220803_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376172
+FBti0220804_cas	tagged_with	FBto0000522	FBrf0253970		TOOL DATA from: FBal0376173
+FBti0220817_cas	carries_tool	FBto0000349	FBrf0254170		TOOL DATA from: FBal0376180
+FBti0220817_cas	carries_tool	FBto0000356	FBrf0254170		TOOL DATA from: FBal0376180
+FBti0220818_cas	tagged_with	FBto0000076	FBrf0253888		TOOL DATA from: FBal0376185
+FBti0220819_cas	tagged_with	FBto0000076	FBrf0253888		TOOL DATA from: FBal0376186
+FBti0220860_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376228
+FBti0220861_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376231
+FBti0220862_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376238
+FBti0220863_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376239
+FBti0220864_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376240
+FBti0220865_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376241
+FBti0220866_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376242
+FBti0220867_cas	tagged_with	FBto0000126	FBrf0254031		TOOL DATA from: FBal0376243
+FBti0220878_cas	carries_tool	FBto0000349	FBrf0253864		TOOL DATA from: FBal0376263
+FBti0220878_cas	carries_tool	FBto0000356	FBrf0253864		TOOL DATA from: FBal0376263
+FBti0220880_cas	encodes_tool	FBto0000135	FBrf0253864		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220880_cas	tool_uses	promoter trap	FBrf0253864		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220881_cas	tagged_with	FBto0000076	FBrf0253864		TOOL DATA from: FBal0376270
+FBti0220882_cas	tagged_with	FBto0000076	FBrf0253864		TOOL DATA from: FBal0376271
+FBti0220883_cas	tagged_with	FBto0000076	FBrf0253864		TOOL DATA from: FBal0376272
+FBti0220886_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376274
+FBti0220886_cas	carries_tool	FBto0000356	FBrf0253894		TOOL DATA from: FBal0376274
+FBti0220887_cas	encodes_tool	FBto0000158	FBrf0253894		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220887_cas	tool_uses	promoter trap	FBrf0253894		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220887_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376275
+FBti0220887_cas	tagged_with	FBto0000093	FBrf0253894		TOOL DATA from: FBal0376275
+FBti0220887_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376280
+FBti0220888_cas	encodes_tool	FBto0000135	FBrf0253894		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220888_cas	tool_uses	promoter trap	FBrf0253894		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220888_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376276
+FBti0220888_cas	tagged_with	FBto0000027	FBrf0253894		TOOL DATA from: FBal0376276
+FBti0220888_cas	carries_tool	FBto0000349	FBrf0253894		TOOL DATA from: FBal0376279
+FBti0220910_cas	encodes_tool	FBto0000135	FBrf0253944		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220910_cas	tool_uses	promoter trap	FBrf0253944		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220910_cas	carries_tool	FBto0000349	FBrf0253944		TOOL DATA from: FBal0376334
+FBti0220910_cas	carries_tool	FBto0000349	FBrf0253944		TOOL DATA from: FBal0376338
+FBti0220913_cas	encodes_tool	FBto0000135	FBrf0253971		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220913_cas	tool_uses	promoter trap	FBrf0253971		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220913_cas	carries_tool	FBto0000349	FBrf0253971		TOOL DATA from: FBal0376344
+FBti0220913_cas	carries_tool	FBto0000349	FBrf0253971		TOOL DATA from: FBal0376348
+FBti0220914_cas	carries_tool	FBto0000356	FBrf0253971		TOOL DATA from: FBal0376345
+FBti0220915_cas	carries_tool	FBto0000349	FBrf0253971		TOOL DATA from: FBal0376346
+FBti0220915_cas	tagged_with	FBto0000118	FBrf0253971		TOOL DATA from: FBal0376346
+FBti0220929_cas	encodes_tool	FBto0000143	FBrf0254101		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220929_cas	tool_uses	promoter trap	FBrf0254101		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220929_cas	carries_tool	FBto0000349	FBrf0254101		TOOL DATA from: FBal0376354
+FBti0220930_cas	encodes_tool	FBto0000155	FBrf0254101		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220930_cas	tool_uses	promoter trap	FBrf0254101		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0220930_cas	carries_tool	FBto0000349	FBrf0254101		TOOL DATA from: FBal0376356
+FBti0220934_cas	tagged_with	FBto0000118	FBrf0254123		TOOL DATA from: FBal0376372
+FBti0220935_cas	tagged_with	FBto0000022	FBrf0254123		TOOL DATA from: FBal0376373
+FBti0220936_cas	tagged_with	FBto0000027	FBrf0254123		TOOL DATA from: FBal0376374
+FBti0220937_cas	carries_tool	FBto0000330	FBrf0252993		TOOL DATA from: FBal0376379
+FBti0220937_cas	tagged_with	FBto0000093	FBrf0252993		TOOL DATA from: FBal0376379
+FBti0220938_cas	carries_tool	FBto0000330	FBrf0252993		TOOL DATA from: FBal0376380
+FBti0220938_cas	tagged_with	FBto0000093	FBrf0252993		TOOL DATA from: FBal0376380
+FBti0221011_cas	tagged_with	FBto0000638	FBrf0254383		TOOL DATA from: FBal0376525
+FBti0221037_cas	carries_tool	FBto0000349	FBrf0254489		TOOL DATA from: FBal0376565
+FBti0221037_cas	tagged_with	FBto0000093	FBrf0254489		TOOL DATA from: FBal0376565
+FBti0221141_cas	carries_tool	FBto0000349	FBrf0254302		TOOL DATA from: FBal0376687
+FBti0221142_cas	carries_tool	FBto0000349	FBrf0254302		TOOL DATA from: FBal0376688
+FBti0221142_cas	carries_tool	FBto0000356	FBrf0254302		TOOL DATA from: FBal0376688
+FBti0221146_cas	tagged_with	FBto0000063	FBrf0254188		TOOL DATA from: FBal0376697
+FBti0221147_cas	carries_tool	FBto0000349	FBrf0254188		TOOL DATA from: FBal0376698
+FBti0221147_cas	tagged_with	FBto0000079	FBrf0254188		TOOL DATA from: FBal0376698
+FBti0221165_cas				FTA: unable to add tool information from FBal0376735 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0225521_cas	tagged_with	FBto0000076	FBrf0254696|FBrf0255181		TOOL DATA from: FBal0384519
+FBti0225523_cas	carries_tool	FBto0000349	FBrf0254213		TOOL DATA from: FBal0384547
+FBti0225523_cas	carries_tool	FBto0000356	FBrf0254213		TOOL DATA from: FBal0384547
+FBti0225541_cas	tagged_with	FBto0000077	FBrf0254265		TOOL DATA from: FBal0384557
+FBti0225542_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384560
+FBti0225542_cas	carries_tool	FBto0000349	FBrf0254036		TOOL DATA from: FBal0384560
+FBti0225542_cas	tagged_with	FBto0000093	FBrf0254036		TOOL DATA from: FBal0384560
+FBti0225543_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384561
+FBti0225543_cas	tagged_with	FBto0000076	FBrf0254036		TOOL DATA from: FBal0384561
+FBti0225544_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384564
+FBti0225544_cas	carries_tool	FBto0000349	FBrf0254036		TOOL DATA from: FBal0384564
+FBti0225544_cas	tagged_with	FBto0000093	FBrf0254036		TOOL DATA from: FBal0384564
+FBti0225545_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384565
+FBti0225545_cas	tagged_with	FBto0000076	FBrf0254036		TOOL DATA from: FBal0384565
+FBti0225546_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384566
+FBti0225546_cas	carries_tool	FBto0000349	FBrf0254036		TOOL DATA from: FBal0384566
+FBti0225546_cas	tagged_with	FBto0000093	FBrf0254036		TOOL DATA from: FBal0384566
+FBti0225547_cas	carries_tool	FBto0000318	FBrf0254036		TOOL DATA from: FBal0384567
+FBti0225547_cas	tagged_with	FBto0000076	FBrf0254036		TOOL DATA from: FBal0384567
+FBti0225959_cas	carries_tool	FBto0000356	FBrf0254633		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0225959_cas	tool_uses	docking element	FBrf0254633		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0225959_cas				FTA: unable to add tool information from FBal0385047 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0225960_cas	carries_tool	FBto0000356	FBrf0254633		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0225960_cas	tool_uses	docking element	FBrf0254633		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0225960_cas				FTA: unable to add tool information from FBal0385048 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0225961_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385051
+FBti0225962_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385052
+FBti0225963_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385053
+FBti0225964_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385054
+FBti0225965_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385055
+FBti0225966_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385056
+FBti0225967_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385057
+FBti0225968_cas	tagged_with	FBto0000031	FBrf0254633		TOOL DATA from: FBal0385060
+FBti0225968_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385060
+FBti0225968_cas	tagged_with	FBto0000093	FBrf0254633		TOOL DATA from: FBal0385060
+FBti0225969_cas	tagged_with	FBto0000031	FBrf0254633		TOOL DATA from: FBal0385061
+FBti0225969_cas	tagged_with	FBto0000076	FBrf0254633		TOOL DATA from: FBal0385061
+FBti0225969_cas	tagged_with	FBto0000093	FBrf0254633		TOOL DATA from: FBal0385061
+FBti0226008_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385070
+FBti0226008_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385070
+FBti0226008_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385070
+FBti0226009_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385071
+FBti0226009_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385071
+FBti0226010_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385072
+FBti0226010_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385072
+FBti0226010_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385072
+FBti0226011_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385073
+FBti0226011_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385073
+FBti0226012_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385074
+FBti0226012_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385074
+FBti0226012_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385074
+FBti0226013_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385075
+FBti0226013_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385075
+FBti0226014_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385076
+FBti0226014_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385076
+FBti0226014_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385076
+FBti0226015_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385077
+FBti0226015_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385077
+FBti0226016_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385078
+FBti0226016_cas	carries_tool	FBto0000349	FBrf0254816		TOOL DATA from: FBal0385078
+FBti0226016_cas	tagged_with	FBto0000093	FBrf0254816		TOOL DATA from: FBal0385078
+FBti0226017_cas	carries_tool	FBto0000318	FBrf0254816		TOOL DATA from: FBal0385079
+FBti0226017_cas	tagged_with	FBto0000076	FBrf0254816		TOOL DATA from: FBal0385079
+FBti0226218_cas	tagged_with	FBto0000076	FBrf0254644		TOOL DATA from: FBal0385303
+FBti0226218_cas	tagged_with	FBto0000079	FBrf0254644		TOOL DATA from: FBal0385303
+FBti0226219_cas	tagged_with	FBto0000076	FBrf0254644		TOOL DATA from: FBal0385304
+FBti0226219_cas	tagged_with	FBto0000093	FBrf0254644		TOOL DATA from: FBal0385304
+FBti0226228_cas	carries_tool	FBto0000349	FBrf0254671		TOOL DATA from: FBal0385314
+FBti0226228_cas	tagged_with	FBto0000102	FBrf0254671		TOOL DATA from: FBal0385314
+FBti0226229_cas	carries_tool	FBto0000349	FBrf0254546		TOOL DATA from: FBal0385328
+FBti0226229_cas	tagged_with	FBto0000077	FBrf0254546		TOOL DATA from: FBal0385328
+FBti0226230_cas	carries_tool	FBto0000349	FBrf0254546		TOOL DATA from: FBal0385329
+FBti0226230_cas	tagged_with	FBto0000077	FBrf0254546		TOOL DATA from: FBal0385329
+FBti0226231_cas	carries_tool	FBto0000356	FBrf0254546		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226231_cas	tool_uses	docking element	FBrf0254546		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226243_cas	encodes_tool	FBto0000146	FBrf0254474		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226243_cas	tool_uses	promoter trap	FBrf0254474		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226243_cas	carries_tool	FBto0000349	FBrf0254474		TOOL DATA from: FBal0385332
+FBti0226243_cas	carries_tool	FBto0000349	FBrf0254474		TOOL DATA from: FBal0385333
+FBti0226247_cas	tagged_with	FBto0000027	FBrf0227637		TOOL DATA from: FBal0385338
+FBti0226256_cas	tagged_with	FBto0000079	FBrf0254752		TOOL DATA from: FBal0385353
+FBti0226293_cas	encodes_tool	FBto0000155	FBrf0254483		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226293_cas	tool_uses	promoter trap	FBrf0254483		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226294_cas				FTA: unable to add tool information from FBal0385410 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226295_cas				FTA: unable to add tool information from FBal0385412 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226296_cas	tagged_with	FBto0000076	FBrf0254714		TOOL DATA from: FBal0385415
+FBti0226297_cas	carries_tool	FBto0000349	FBrf0254662		TOOL DATA from: FBal0385416
+FBti0226298_cas	encodes_tool	FBto0000135	FBrf0254347		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226298_cas	tool_uses	promoter trap	FBrf0254347		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226315_cas	carries_tool	FBto0000356	FBrf0254602		TOOL DATA from: FBal0385472
+FBti0226351_cas	carries_tool	FBto0000349	FBrf0254607		TOOL DATA from: FBal0385529
+FBti0226351_cas	carries_tool	FBto0000356	FBrf0254607		TOOL DATA from: FBal0385529
+FBti0226352_cas				FTA: unable to add tool information from FBal0385530 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226353_cas	tagged_with	FBto0000093	FBrf0254607		TOOL DATA from: FBal0385531
+FBti0226353_cas	tagged_with	FBto0000118	FBrf0254607		TOOL DATA from: FBal0385531
+FBti0226356_cas	tagged_with	FBto0000027	FBrf0254801		TOOL DATA from: FBal0385534
+FBti0226357_cas	tagged_with	FBto0000118	FBrf0254801		TOOL DATA from: FBal0385535
+FBti0226364_cas	encodes_tool	FBto0000027	FBrf0254973		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226364_cas	tool_uses	promoter trap	FBrf0254973		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226365_cas	encodes_tool	FBto0000027	FBrf0254973		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226365_cas	tool_uses	promoter trap	FBrf0254973		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226380_cas	encodes_tool	FBto0000143	FBrf0254561		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226380_cas	tool_uses	promoter trap	FBrf0254561		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226381_cas	tagged_with	FBto0000070	FBrf0254561		TOOL DATA from: FBal0385585
+FBti0226398_cas	encodes_tool	FBto0000031	FBrf0254842		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226398_cas	tool_uses	promoter trap	FBrf0254842		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226399_cas	encodes_tool	FBto0000118	FBrf0254842		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226399_cas	tool_uses	promoter trap	FBrf0254842		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226400_cas	encodes_tool	FBto0000135	FBrf0254842		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226400_cas	tool_uses	promoter trap	FBrf0254842		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226401_cas	encodes_tool	FBto0000135	FBrf0254842		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226401_cas	tool_uses	promoter trap	FBrf0254842		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226405_cas	carries_tool	FBto0000349	FBrf0254731		TOOL DATA from: FBal0385621
+FBti0226405_cas	tagged_with	FBto0000027	FBrf0254731		TOOL DATA from: FBal0385621
+FBti0226416_cas	carries_tool	FBto0000349	FBrf0254511		TOOL DATA from: FBal0385651
+FBti0226416_cas	carries_tool	FBto0000356	FBrf0254511		TOOL DATA from: FBal0385651
+FBti0226416_cas	tagged_with	FBto0000027	FBrf0254511		TOOL DATA from: FBal0385651
+FBti0226417_cas	tagged_with	FBto0000077	FBrf0254847		TOOL DATA from: FBal0385653
+FBti0226417_cas	tagged_with	FBto0000093	FBrf0254847		TOOL DATA from: FBal0385653
+FBti0226417_cas	tagged_with	FBto0000077	FBrf0254847		TOOL DATA from: FBal0385655
+FBti0226417_cas	tagged_with	FBto0000093	FBrf0254847		TOOL DATA from: FBal0385655
+FBti0226418_cas	tagged_with	FBto0000076	FBrf0254847		TOOL DATA from: FBal0385654
+FBti0226418_cas	tagged_with	FBto0000093	FBrf0254847		TOOL DATA from: FBal0385654
+FBti0226419_cas	carries_tool	FBto0000349	FBrf0254693		TOOL DATA from: FBal0385657
+FBti0226441_cas	carries_tool	FBto0000349	FBrf0254765		TOOL DATA from: FBal0385712
+FBti0226442_cas	carries_tool	FBto0000349	FBrf0254765		TOOL DATA from: FBal0385714
+FBti0226443_cas	carries_tool	FBto0000349	FBrf0254765		TOOL DATA from: FBal0385716
+FBti0226502_cas	tagged_with	FBto0000031	FBrf0254313		TOOL DATA from: FBal0385812
+FBti0226511_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385819
+FBti0226511_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385819
+FBti0226512_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385820
+FBti0226512_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385820
+FBti0226513_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385821
+FBti0226513_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385821
+FBti0226514_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385822
+FBti0226514_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385822
+FBti0226515_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385823
+FBti0226515_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385823
+FBti0226516_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385824
+FBti0226516_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385824
+FBti0226517_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385825
+FBti0226517_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385825
+FBti0226518_cas	carries_tool	FBto0000318	FBrf0252912		TOOL DATA from: FBal0385826
+FBti0226518_cas	carries_tool	FBto0000349	FBrf0252912		TOOL DATA from: FBal0385826
+FBti0226520_cas	carries_tool	FBto0000349	FBrf0254362		TOOL DATA from: FBal0385828
+FBti0226520_cas	carries_tool	FBto0000356	FBrf0254362		TOOL DATA from: FBal0385828
+FBti0226521_cas	carries_tool	FBto0000349	FBrf0254362		TOOL DATA from: FBal0385829
+FBti0226527_cas	encodes_tool	FBto0000150	FBrf0253483		TOOL DATA from: FBtp0146569, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226527_cas	tool_uses	promoter trap	FBrf0253483		TOOL DATA from: FBtp0146569, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226528_cas	tagged_with	FBto0000334	FBrf0254195		TOOL DATA from: FBal0385846
+FBti0226529_cas	tagged_with	FBto0000031	FBrf0254195		TOOL DATA from: FBal0385847
+FBti0226532_cas	carries_tool	FBto0000349	FBrf0254439		TOOL DATA from: FBal0385861
+FBti0226532_cas	carries_tool	FBto0000356	FBrf0254439		TOOL DATA from: FBal0385861
+FBti0226537_cas	encodes_tool	FBto0000135	FBrf0254952		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226537_cas	tool_uses	promoter trap	FBrf0254952		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226537_cas	carries_tool	FBto0000349	FBrf0254952		TOOL DATA from: FBal0385892
+FBti0226537_cas	carries_tool	FBto0000349	FBrf0254952		TOOL DATA from: FBal0385900
+FBti0226538_cas				FTA: unable to add tool information from FBal0385899 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226543_cas	tagged_with	FBto0000638	FBrf0254903		TOOL DATA from: FBal0385904
+FBti0226550_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385916
+FBti0226550_cas	carries_tool	FBto0000356	FBrf0244382		TOOL DATA from: FBal0385916
+FBti0226551_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385917
+FBti0226551_cas	carries_tool	FBto0000356	FBrf0244382		TOOL DATA from: FBal0385917
+FBti0226552_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385918
+FBti0226553_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385919
+FBti0226554_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385920
+FBti0226555_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385921
+FBti0226556_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385922
+FBti0226557_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385923
+FBti0226558_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385924
+FBti0226559_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385925
+FBti0226560_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385926
+FBti0226561_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385927
+FBti0226562_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385928
+FBti0226563_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385929
+FBti0226564_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385930
+FBti0226565_cas	carries_tool	FBto0000349	FBrf0244382		TOOL DATA from: FBal0385931
+FBti0226595_cas	tagged_with	FBto0000118	FBrf0253556		TOOL DATA from: FBal0385974
+FBti0226596_cas	tagged_with	FBto0000048	FBrf0253556		TOOL DATA from: FBal0385975
+FBti0226597_cas				FTA: unable to add tool information from FBal0385976 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226672_cas	tagged_with	FBto0000118	FBrf0253391		TOOL DATA from: FBal0386154
+FBti0226673_cas	tagged_with	FBto0000077	FBrf0254083		TOOL DATA from: FBal0386159
+FBti0226674_cas				FTA: unable to add tool information from FBal0386161 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226675_cas				FTA: unable to add tool information from FBal0386165 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226731_cas	tagged_with	FBto0000077	FBrf0255083		TOOL DATA from: FBal0386301
+FBti0226732_cas	tagged_with	FBto0000063	FBrf0255083		TOOL DATA from: FBal0386302
+FBti0226733_cas	tagged_with	FBto0000063	FBrf0255083		TOOL DATA from: FBal0386304
+FBti0226750_cas	carries_tool	FBto0000356	FBrf0235537		TOOL DATA from: FBal0386338
+FBti0226760_cas	tagged_with	FBto0000031	FBrf0235537		TOOL DATA from: FBal0386349
+FBti0226761_cas	tagged_with	FBto0000118	FBrf0235537		TOOL DATA from: FBal0386350
+FBti0226762_cas	tagged_with	FBto0000031	FBrf0235537		TOOL DATA from: FBal0386356
+FBti0226801_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386447
+FBti0226801_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386447
+FBti0226802_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386448
+FBti0226802_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386448
+FBti0226803_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386449
+FBti0226803_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386449
+FBti0226804_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386450
+FBti0226804_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386450
+FBti0226805_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386451
+FBti0226805_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386451
+FBti0226806_cas	carries_tool	FBto0000349	FBrf0217510		TOOL DATA from: FBal0386452
+FBti0226806_cas	carries_tool	FBto0000356	FBrf0217510		TOOL DATA from: FBal0386452
+FBti0226811_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226811_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226811_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386470
+FBti0226812_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226812_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226812_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386471
+FBti0226813_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226813_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226813_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386472
+FBti0226814_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226814_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226814_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386473
+FBti0226815_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226815_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226815_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386474
+FBti0226816_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226816_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226816_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386475
+FBti0226817_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226817_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226817_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386476
+FBti0226818_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226818_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226818_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386477
+FBti0226819_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226819_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226819_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386478
+FBti0226820_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226820_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226820_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386479
+FBti0226821_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226821_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226821_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386480
+FBti0226822_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226822_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226822_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386481
+FBti0226823_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226823_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226823_cas	tagged_with	FBto0000208	FBrf0223399		TOOL DATA from: FBal0386482
+FBti0226824_cas	encodes_tool	FBto0000135	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226824_cas	tool_uses	promoter trap	FBrf0223399		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226827_cas	tagged_with	FBto0000031	FBrf0255104		TOOL DATA from: FBal0386585
+FBti0226827_cas	tagged_with	FBto0000307	FBrf0255104		TOOL DATA from: FBal0386585
+FBti0226828_cas	encodes_tool	FBto0000135	FBrf0254890		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226828_cas	tool_uses	promoter trap	FBrf0254890		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226828_cas	carries_tool	FBto0000349	FBrf0254890		TOOL DATA from: FBal0386586
+FBti0226828_cas	carries_tool	FBto0000349	FBrf0254890		TOOL DATA from: FBal0386588
+FBti0226836_cas	tagged_with	FBto0000093	FBrf0255456		TOOL DATA from: FBal0386617
+FBti0226837_cas	tagged_with	FBto0000093	FBrf0255457		TOOL DATA from: FBal0386618
+FBti0226838_cas	tagged_with	FBto0000093	FBrf0255458		TOOL DATA from: FBal0386619
+FBti0226841_cas				FTA: unable to add tool information from FBal0386622 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0226842_cas	tagged_with	FBto0000076	FBrf0255205		TOOL DATA from: FBal0386623
+FBti0226851_cas	encodes_tool	FBto0000135	FBrf0255059		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226851_cas	tool_uses	promoter trap	FBrf0255059		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226851_cas	carries_tool	FBto0000375	FBrf0255059		TOOL DATA from: FBal0386646
+FBti0226968_cas	encodes_tool	FBto0000158	FBrf0253980		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226968_cas	tool_uses	promoter trap	FBrf0253980		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226969_cas	encodes_tool	FBto0000135	FBrf0253980		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226969_cas	tool_uses	promoter trap	FBrf0253980		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0226986_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386973
+FBti0226986_cas	carries_tool	FBto0000356	FBrf0255070		TOOL DATA from: FBal0386973
+FBti0226987_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386974
+FBti0226987_cas	carries_tool	FBto0000356	FBrf0255070		TOOL DATA from: FBal0386974
+FBti0226988_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386975
+FBti0226989_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386976
+FBti0226990_cas	carries_tool	FBto0000349	FBrf0255070		TOOL DATA from: FBal0386977
+FBti0226994_cas	carries_tool	FBto0000349	FBrf0255056		TOOL DATA from: FBal0386984
+FBti0226994_cas	tagged_with	FBto0000076	FBrf0255056		TOOL DATA from: FBal0386984
+FBti0227026_cas	tagged_with	FBto0000076	FBrf0254977		TOOL DATA from: FBal0387074
+FBti0227027_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387075
+FBti0227028_cas				FTA: unable to add tool information from FBal0387076 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227029_cas				FTA: unable to add tool information from FBal0387077 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227030_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387079
+FBti0227031_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387080
+FBti0227032_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387081
+FBti0227033_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387082
+FBti0227034_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387083
+FBti0227035_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387084
+FBti0227036_cas	tagged_with	FBto0000522	FBrf0254977		TOOL DATA from: FBal0387085
+FBti0227071_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387133
+FBti0227071_cas	carries_tool	FBto0000356	FBrf0255045		TOOL DATA from: FBal0387133
+FBti0227072_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387134
+FBti0227073_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387135
+FBti0227074_cas	encodes_tool	FBto0000135	FBrf0255045		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227074_cas	tool_uses	promoter trap	FBrf0255045		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227074_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387136
+FBti0227074_cas	carries_tool	FBto0000349	FBrf0255045		TOOL DATA from: FBal0387138
+FBti0227112_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227112_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227112_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387182
+FBti0227112_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387193
+FBti0227113_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227113_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227113_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387183
+FBti0227113_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387194
+FBti0227114_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227114_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227114_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387184
+FBti0227114_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387195
+FBti0227115_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227115_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227115_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387185
+FBti0227115_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387196
+FBti0227116_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227116_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227116_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387186
+FBti0227116_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387197
+FBti0227117_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227117_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227117_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387187
+FBti0227117_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387198
+FBti0227118_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227118_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227118_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387188
+FBti0227118_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387199
+FBti0227119_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227119_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227119_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387189
+FBti0227119_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387200
+FBti0227120_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227120_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227120_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387190
+FBti0227120_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387201
+FBti0227121_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227121_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227121_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387191
+FBti0227121_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387202
+FBti0227122_cas	encodes_tool	FBto0000135	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227122_cas	tool_uses	promoter trap	FBrf0239400		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227122_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387192
+FBti0227122_cas	carries_tool	FBto0000349	FBrf0239400		TOOL DATA from: FBal0387203
+FBti0227124_cas	encodes_tool	FBto0000135	FBrf0238759		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227124_cas	tool_uses	promoter trap	FBrf0238759		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227139_cas	carries_tool	FBto0000349	FBrf0254982		TOOL DATA from: FBal0387248
+FBti0227139_cas	carries_tool	FBto0000356	FBrf0254982		TOOL DATA from: FBal0387248
+FBti0227139_cas	tagged_with	FBto0000031	FBrf0254982		TOOL DATA from: FBal0387248
+FBti0227234_cas	tagged_with	FBto0000027	FBrf0255082		TOOL DATA from: FBal0387340
+FBti0227235_cas	tagged_with	FBto0000070	FBrf0255330		TOOL DATA from: FBal0387354
+FBti0227235_cas	tagged_with	FBto0000081	FBrf0255330		TOOL DATA from: FBal0387354
+FBti0227236_cas	tagged_with	FBto0000070	FBrf0255330		TOOL DATA from: FBal0387358
+FBti0227236_cas	tagged_with	FBto0000076	FBrf0255330		TOOL DATA from: FBal0387358
+FBti0227237_cas	tagged_with	FBto0000070	FBrf0255330		TOOL DATA from: FBal0387359
+FBti0227237_cas	tagged_with	FBto0000090	FBrf0255330		TOOL DATA from: FBal0387359
+FBti0227241_cas	tagged_with	FBto0000076	FBrf0242826		TOOL DATA from: FBal0387400
+FBti0227243_cas	encodes_tool	FBto0000135	FBrf0235717		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227243_cas	tool_uses	promoter trap	FBrf0235717		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227286_cas	has_reg_region	FBto0000180	FBrf0233282		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227286_cas	tool_uses	misexpression element	FBrf0233282		TOOL DATA from: FBtp0117267, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227305_cas	carries_tool	FBto0000349	FBrf0255544		TOOL DATA from: FBal0387543
+FBti0227305_cas	tagged_with	FBto0000118	FBrf0255544		TOOL DATA from: FBal0387543
+FBti0227344_cas	tagged_with	FBto0000031	FBrf0255710		TOOL DATA from: FBal0387700
+FBti0227348_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387713
+FBti0227349_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387714
+FBti0227350_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387715
+FBti0227351_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387716
+FBti0227352_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387717
+FBti0227353_cas	tagged_with	FBto0000027	FBrf0255255		TOOL DATA from: FBal0387718
+FBti0227354_cas	carries_tool	FBto0000349	FBrf0241006		TOOL DATA from: FBal0387723
+FBti0227355_cas	carries_tool	FBto0000349	FBrf0241006		TOOL DATA from: FBal0387724
+FBti0227356_cas	carries_tool	FBto0000349	FBrf0241006		TOOL DATA from: FBal0387725
+FBti0227357_cas				FTA: unable to add tool information from FBal0387736 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227382_cas				FTA: unable to add tool information from FBal0387769 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227383_cas	carries_tool	FBto0000349	FBrf0233428		TOOL DATA from: FBal0387770
+FBti0227383_cas	carries_tool	FBto0000356	FBrf0233428		TOOL DATA from: FBal0387770
+FBti0227385_cas	tagged_with	FBto0000046	FBrf0233428		TOOL DATA from: FBal0387772
+FBti0227386_cas	tagged_with	FBto0000046	FBrf0233428		TOOL DATA from: FBal0387773
+FBti0227387_cas	tagged_with	FBto0000046	FBrf0233428		TOOL DATA from: FBal0387774
+FBti0227388_cas	tagged_with	FBto0000046	FBrf0233428		TOOL DATA from: FBal0387775
+FBti0227409_cas	tagged_with	FBto0000623	FBrf0255484		TOOL DATA from: FBal0387843
+FBti0227420_cas	carries_tool	FBto0000349	FBrf0255767		TOOL DATA from: FBal0387865
+FBti0227420_cas	carries_tool	FBto0000356	FBrf0255767		TOOL DATA from: FBal0387865
+FBti0227421_cas	carries_tool	FBto0000349	FBrf0255767		TOOL DATA from: FBal0387866
+FBti0227421_cas	carries_tool	FBto0000356	FBrf0255767		TOOL DATA from: FBal0387866
+FBti0227422_cas	carries_tool	FBto0000349	FBrf0255767		TOOL DATA from: FBal0387867
+FBti0227422_cas	carries_tool	FBto0000356	FBrf0255767		TOOL DATA from: FBal0387867
+FBti0227423_cas				FTA: unable to add tool information from FBal0387868 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227425_cas	carries_tool	FBto0000349	FBrf0255770		TOOL DATA from: FBal0387871
+FBti0227425_cas	carries_tool	FBto0000356	FBrf0255770		TOOL DATA from: FBal0387871
+FBti0227442_cas	tagged_with	FBto0000031	FBrf0255555		TOOL DATA from: FBal0387906
+FBti0227443_cas	tagged_with	FBto0000118	FBrf0239824		TOOL DATA from: FBal0387927
+FBti0227491_cas	tagged_with	FBto0000076	FBrf0255740		TOOL DATA from: FBal0388076
+FBti0227491_cas	tagged_with	FBto0000077	FBrf0255740		TOOL DATA from: FBal0388076
+FBti0227492_cas				FTA: unable to add tool information from FBal0388077 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227724_cas	tagged_with	FBto0000093	FBrf0255496		TOOL DATA from: FBal0388206
+FBti0227725_cas	tagged_with	FBto0000093	FBrf0255496		TOOL DATA from: FBal0388207
+FBti0227729_cas				FTA: unable to add tool information from FBal0388241 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227730_cas	tagged_with	FBto0000077	FBrf0255671		TOOL DATA from: FBal0388243
+FBti0227749_cas	encodes_tool	FBto0000135	FBrf0227716		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227749_cas	tool_uses	promoter trap	FBrf0227716		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227749_cas	carries_tool	FBto0000349	FBrf0227716		TOOL DATA from: FBal0388307
+FBti0227750_cas	encodes_tool	FBto0000135	FBrf0227716		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227750_cas	tool_uses	promoter trap	FBrf0227716		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227750_cas	carries_tool	FBto0000349	FBrf0227716		TOOL DATA from: FBal0388295
+FBti0227750_cas	carries_tool	FBto0000349	FBrf0227716		TOOL DATA from: FBal0388308
+FBti0227764_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388332
+FBti0227764_cas	carries_tool	FBto0000356	FBrf0247874		TOOL DATA from: FBal0388332
+FBti0227765_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388333
+FBti0227766_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388334
+FBti0227767_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388335
+FBti0227768_cas	carries_tool	FBto0000349	FBrf0247874		TOOL DATA from: FBal0388336
+FBti0227812_cas	tagged_with	FBto0000077	FBrf0235737		TOOL DATA from: FBal0388383
+FBti0227840_cas				FTA: unable to add tool information from FBal0388440 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227841_cas				FTA: unable to add tool information from FBal0388441 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227842_cas				FTA: unable to add tool information from FBal0388442 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0227843_cas	encodes_tool	FBto0000135	FBrf0255652		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227843_cas	tool_uses	promoter trap	FBrf0255652		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227844_cas	tagged_with	FBto0000031	FBrf0255652		TOOL DATA from: FBal0388444
+FBti0227846_cas	encodes_tool	FBto0000135	FBrf0245894		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227846_cas	tool_uses	promoter trap	FBrf0245894		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227846_cas	carries_tool	FBto0000349	FBrf0245894		TOOL DATA from: FBal0388447
+FBti0227846_cas	carries_tool	FBto0000349	FBrf0245894		TOOL DATA from: FBal0388448
+FBti0227847_cas	encodes_tool	FBto0000322	FBrf0245894		TOOL DATA from: FBtp0159032, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227847_cas	tool_uses	promoter trap	FBrf0245894		TOOL DATA from: FBtp0159032, used single pub_curie from FBti->FBtp producedby f_r
+FBti0227847_cas	carries_tool	FBto0000349	FBrf0245894		TOOL DATA from: FBal0388449
+FBti0227847_cas	carries_tool	FBto0000349	FBrf0245894		TOOL DATA from: FBal0388450
+FBti0227860_cas	carries_tool	FBto0000349	FBrf0255737		TOOL DATA from: FBal0388465
+FBti0227860_cas	carries_tool	FBto0000356	FBrf0255737		TOOL DATA from: FBal0388465
+FBti0227861_cas	carries_tool	FBto0000349	FBrf0255737		TOOL DATA from: FBal0388466
+FBti0227862_cas	carries_tool	FBto0000349	FBrf0255737		TOOL DATA from: FBal0388467
+FBti0227863_cas	carries_tool	FBto0000349	FBrf0255737		TOOL DATA from: FBal0388468
+FBti0227887_cas	tool_uses	fluorescent protein	FBrf0236978		TOOL DATA from: FBal0388508
+FBti0227887_cas	tool_uses	mechanical force sensor	FBrf0236978		TOOL DATA from: FBal0388508
+FBti0227888_cas	tool_uses	fluorescent protein	FBrf0236978		TOOL DATA from: FBal0388509
+FBti0227889_cas	tagged_with	FBto0000025	FBrf0236978		TOOL DATA from: FBal0388510
+FBti0227890_cas	tagged_with	FBto0000030	FBrf0236978		TOOL DATA from: FBal0388511
+FBti0227909_cas				FTA: unable to add tool information from FBal0388536 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0228028_cas	encodes_tool	FBto0000601	FBrf0255638		TOOL DATA from: FBtp0159279, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228028_cas	tool_uses	promoter trap	FBrf0255638		TOOL DATA from: FBtp0159279, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228052_cas	carries_tool	FBto0000349	FBrf0233364		TOOL DATA from: FBal0388750
+FBti0228052_cas	tagged_with	FBto0000093	FBrf0233364		TOOL DATA from: FBal0388750
+FBti0228052_cas	tagged_with	FBto0000295	FBrf0233364		TOOL DATA from: FBal0388750
+FBti0228052_cas	tagged_with	FBto0000340	FBrf0233364		TOOL DATA from: FBal0388750
+FBti0228053_cas	carries_tool	FBto0000349	FBrf0233364		TOOL DATA from: FBal0388751
+FBti0228053_cas	tagged_with	FBto0000093	FBrf0233364		TOOL DATA from: FBal0388751
+FBti0228053_cas	tagged_with	FBto0000295	FBrf0233364		TOOL DATA from: FBal0388751
+FBti0228053_cas	tagged_with	FBto0000340	FBrf0233364		TOOL DATA from: FBal0388751
+FBti0228287_cas	carries_tool	FBto0000349	FBrf0256005		TOOL DATA from: FBal0389322
+FBti0228288_cas				FTA: unable to add tool information from FBal0389323 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0228289_cas				FTA: unable to add tool information from FBal0389324 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0228294_cas	tagged_with	FBto0000099	FBrf0242829		TOOL DATA from: FBal0389337
+FBti0228322_cas	carries_tool	FBto0000349	FBrf0241714		TOOL DATA from: FBal0389433
+FBti0228322_cas	carries_tool	FBto0000356	FBrf0241714		TOOL DATA from: FBal0389433
+FBti0228367_cas	tagged_with	FBto0000077	FBrf0256014		TOOL DATA from: FBal0389522
+FBti0228369_cas	tagged_with	FBto0000869	FBrf0255785		TOOL DATA from: FBal0389536
+FBti0228370_cas	tagged_with	FBto0000869	FBrf0255785		TOOL DATA from: FBal0389537
+FBti0228371_cas	tagged_with	FBto0000869	FBrf0255785		TOOL DATA from: FBal0389538
+FBti0228444_cas	tagged_with	FBto0000077	FBrf0255847		TOOL DATA from: FBal0389628
+FBti0228520_cas	encodes_tool	FBto0000118	FBrf0255995		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228520_cas	tool_uses	promoter trap	FBrf0255995		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228663_cas	tagged_with	FBto0000031	FBrf0243377		TOOL DATA from: FBal0389815
+FBti0228664_cas	encodes_tool	FBto0000166	FBrf0241897		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228664_cas	tool_uses	promoter trap	FBrf0241897		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228665_cas	encodes_tool	FBto0000135	FBrf0241897		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228665_cas	tool_uses	promoter trap	FBrf0241897		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228666_cas	encodes_tool	FBto0000146	FBrf0241897		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228666_cas	tool_uses	promoter trap	FBrf0241897		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228683_cas	carries_tool	FBto0000349	FBrf0234343		TOOL DATA from: FBal0389900
+FBti0228683_cas	carries_tool	FBto0000356	FBrf0234343		TOOL DATA from: FBal0389900
+FBti0228684_cas	carries_tool	FBto0000349	FBrf0234343		TOOL DATA from: FBal0389901
+FBti0228684_cas	carries_tool	FBto0000356	FBrf0234343		TOOL DATA from: FBal0389901
+FBti0228685_cas	carries_tool	FBto0000349	FBrf0234343		TOOL DATA from: FBal0389902
+FBti0228685_cas	tagged_with	FBto0000093	FBrf0234343		TOOL DATA from: FBal0389902
+FBti0228688_cas	tagged_with	FBto0000335	FBrf0235662		TOOL DATA from: FBal0389905
+FBti0228689_cas	tagged_with	FBto0000027	FBrf0235662		TOOL DATA from: FBal0389906
+FBti0228690_cas	carries_tool	FBto0000318	FBrf0256197		TOOL DATA from: FBal0389927
+FBti0228692_cas	tagged_with	FBto0000031	FBrf0256151		TOOL DATA from: FBal0390246
+FBti0228696_cas	carries_tool	FBto0000349	FBrf0256120		TOOL DATA from: FBal0390251
+FBti0228696_cas	tagged_with	FBto0000118	FBrf0256120		TOOL DATA from: FBal0390251
+FBti0228708_cas	encodes_tool	FBto0000135	FBrf0256409		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228708_cas	tool_uses	promoter trap	FBrf0256409		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228709_cas	tagged_with	FBto0000093	FBrf0255232		TOOL DATA from: FBal0390290
+FBti0228709_cas	tagged_with	FBto0000118	FBrf0255232		TOOL DATA from: FBal0390290
+FBti0228710_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390308
+FBti0228710_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390308
+FBti0228711_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390309
+FBti0228711_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390309
+FBti0228712_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390310
+FBti0228712_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390310
+FBti0228713_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390311
+FBti0228713_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390311
+FBti0228714_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390312
+FBti0228714_cas	tagged_with	FBto0000335	FBrf0256010		TOOL DATA from: FBal0390312
+FBti0228715_cas	carries_tool	FBto0000356	FBrf0256010		TOOL DATA from: FBal0390313
+FBti0228716_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390314
+FBti0228716_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390314
+FBti0228717_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390315
+FBti0228717_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390315
+FBti0228718_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390316
+FBti0228718_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390316
+FBti0228719_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390317
+FBti0228719_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390317
+FBti0228720_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390318
+FBti0228720_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390318
+FBti0228721_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390319
+FBti0228721_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390319
+FBti0228722_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390320
+FBti0228722_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390320
+FBti0228723_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390321
+FBti0228723_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390321
+FBti0228724_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390322
+FBti0228724_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390322
+FBti0228725_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390323
+FBti0228725_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390323
+FBti0228726_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390324
+FBti0228726_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390324
+FBti0228727_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390325
+FBti0228727_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390325
+FBti0228728_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390326
+FBti0228728_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390326
+FBti0228729_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390327
+FBti0228729_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390327
+FBti0228730_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390328
+FBti0228730_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390328
+FBti0228731_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390329
+FBti0228731_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390329
+FBti0228732_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390330
+FBti0228732_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390330
+FBti0228733_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390331
+FBti0228733_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390331
+FBti0228734_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390332
+FBti0228734_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390332
+FBti0228735_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390333
+FBti0228735_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390333
+FBti0228736_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390334
+FBti0228736_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390334
+FBti0228737_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390335
+FBti0228737_cas	tagged_with	FBto0000335	FBrf0256010		TOOL DATA from: FBal0390335
+FBti0228738_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390336
+FBti0228738_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390336
+FBti0228739_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390337
+FBti0228739_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390337
+FBti0228740_cas	carries_tool	FBto0000356	FBrf0256010		TOOL DATA from: FBal0390338
+FBti0228741_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390339
+FBti0228741_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390339
+FBti0228742_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390340
+FBti0228742_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390340
+FBti0228743_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390341
+FBti0228743_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390341
+FBti0228744_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390342
+FBti0228744_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390342
+FBti0228745_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390343
+FBti0228745_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390343
+FBti0228746_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390344
+FBti0228746_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390344
+FBti0228747_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390345
+FBti0228747_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390345
+FBti0228748_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390346
+FBti0228748_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390346
+FBti0228749_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390347
+FBti0228749_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390347
+FBti0228750_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390348
+FBti0228750_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390348
+FBti0228751_cas	carries_tool	FBto0000349	FBrf0256010		TOOL DATA from: FBal0390349
+FBti0228751_cas	tagged_with	FBto0000031	FBrf0256010		TOOL DATA from: FBal0390349
+FBti0228813_cas	carries_tool	FBto0000349	FBrf0237361		TOOL DATA from: FBal0390403
+FBti0228813_cas	carries_tool	FBto0000356	FBrf0237361		TOOL DATA from: FBal0390403
+FBti0228814_cas	carries_tool	FBto0000349	FBrf0237361		TOOL DATA from: FBal0390404
+FBti0228814_cas	carries_tool	FBto0000356	FBrf0237361		TOOL DATA from: FBal0390404
+FBti0228820_cas	carries_tool	FBto0000356	FBrf0239596		TOOL DATA from: FBal0390412
+FBti0228821_cas	encodes_tool	FBto0000027	FBrf0239596		TOOL DATA from: FBtp0160138, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228821_cas	tool_uses	gene trap	FBrf0239596		TOOL DATA from: FBtp0160138, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228822_cas	encodes_tool	FBto0000135	FBrf0239596		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228822_cas	tool_uses	gene trap	FBrf0239596		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228823_cas	carries_tool	FBto0000356	FBrf0239596		TOOL DATA from: FBal0390415
+FBti0228936_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390698
+FBti0228937_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390699
+FBti0228938_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390700
+FBti0228939_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390701
+FBti0228940_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390702
+FBti0228941_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390681
+FBti0228941_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390681
+FBti0228942_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390707
+FBti0228942_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390707
+FBti0228943_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390709
+FBti0228943_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390709
+FBti0228944_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390710
+FBti0228944_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390710
+FBti0228945_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390712
+FBti0228945_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390712
+FBti0228947_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390713
+FBti0228947_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390713
+FBti0228948_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390714
+FBti0228948_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390714
+FBti0228949_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390715
+FBti0228949_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390715
+FBti0228950_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390717
+FBti0228950_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390717
+FBti0228951_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390719
+FBti0228951_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390719
+FBti0228952_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390720
+FBti0228952_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390720
+FBti0228953_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390721
+FBti0228953_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390721
+FBti0228954_cas	encodes_tool	FBto0000135	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228954_cas	tool_uses	promoter trap	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228954_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390682
+FBti0228954_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390722
+FBti0228955_cas	encodes_tool	FBto0000135	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228955_cas	tool_uses	promoter trap	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228955_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390708
+FBti0228955_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390723
+FBti0228956_cas	encodes_tool	FBto0000135	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228956_cas	tool_uses	promoter trap	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228956_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390718
+FBti0228956_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390724
+FBti0228957_cas	encodes_tool	FBto0000135	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228957_cas	tool_uses	promoter trap	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228957_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390716
+FBti0228957_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390725
+FBti0228958_cas	encodes_tool	FBto0000135	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228958_cas	tool_uses	promoter trap	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228958_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390711
+FBti0228958_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390726
+FBti0228959_cas	encodes_tool	FBto0000135	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228959_cas	tool_uses	promoter trap	FBrf0245192		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0228959_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390727
+FBti0228960_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390730
+FBti0228960_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390730
+FBti0228968_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390684
+FBti0228969_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390685
+FBti0228969_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390690
+FBti0228970_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390686
+FBti0228970_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390692
+FBti0228971_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390687
+FBti0228971_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390696
+FBti0228972_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390688
+FBti0228972_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390697
+FBti0228973_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390689
+FBti0228974_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390691
+FBti0228974_cas	carries_tool	FBto0000356	FBrf0245192		TOOL DATA from: FBal0390691
+FBti0228978_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390678
+FBti0228978_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390706
+FBti0228979_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390675
+FBti0228979_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390703
+FBti0228980_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390676
+FBti0228980_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390704
+FBti0228981_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390677
+FBti0228981_cas	carries_tool	FBto0000349	FBrf0245192		TOOL DATA from: FBal0390705
+FBti0228984_cas	tagged_with	FBto0000031	FBrf0255068		TOOL DATA from: FBal0390733
+FBti0228985_cas	tagged_with	FBto0000031	FBrf0255068		TOOL DATA from: FBal0390734
+FBti0228986_cas	tagged_with	FBto0000031	FBrf0255068		TOOL DATA from: FBal0390735
+FBti0229124_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390893
+FBti0229124_cas	carries_tool	FBto0000356	FBrf0254393		TOOL DATA from: FBal0390893
+FBti0229125_cas	encodes_tool	FBto0000135	FBrf0254393		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229125_cas	tool_uses	promoter trap	FBrf0254393		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229125_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390894
+FBti0229125_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390895
+FBti0229126_cas	encodes_tool	FBto0000135	FBrf0254393		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229126_cas	tool_uses	promoter trap	FBrf0254393		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229126_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390896
+FBti0229126_cas	carries_tool	FBto0000349	FBrf0254393		TOOL DATA from: FBal0390898
+FBti0229163_cas	tagged_with	FBto0000077	FBrf0256130		TOOL DATA from: FBal0390932
+FBti0229173_cas	carries_tool	FBto0000349	FBrf0256457		TOOL DATA from: FBal0390949
+FBti0229173_cas	tagged_with	FBto0000372	FBrf0256457		TOOL DATA from: FBal0390949
+FBti0229281_cas	tagged_with	FBto0000063	FBrf0256322		TOOL DATA from: FBal0391075
+FBti0229282_cas	tagged_with	FBto0000014	FBrf0256322		TOOL DATA from: FBal0391076
+FBti0229283_cas	carries_tool	FBto0000349	FBrf0255170		TOOL DATA from: FBal0391085
+FBti0229283_cas	tagged_with	FBto0000077	FBrf0255170		TOOL DATA from: FBal0391085
+FBti0229304_cas	tagged_with	FBto0000088	FBrf0256636		TOOL DATA from: FBal0391108
+FBti0229311_cas	tagged_with	FBto0000031	FBrf0242317		TOOL DATA from: FBal0391114
+FBti0229311_cas	tagged_with	FBto0000886	FBrf0242317		TOOL DATA from: FBal0391114
+FBti0229335_cas	carries_tool	FBto0000318	FBrf0256307		TOOL DATA from: FBal0391133
+FBti0229335_cas	carries_tool	FBto0000356	FBrf0256307		TOOL DATA from: FBal0391133
+FBti0229336_cas	carries_tool	FBto0000318	FBrf0256307		TOOL DATA from: FBal0391136
+FBti0229337_cas	carries_tool	FBto0000318	FBrf0256307		TOOL DATA from: FBal0391137
+FBti0229338_cas				FTA: unable to add tool information from FBal0391134 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0229338_cas				FTA: unable to add tool information from FBal0391135 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0229339_cas	encodes_tool	FBto0000155	FBrf0256492		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229339_cas	tool_uses	promoter trap	FBrf0256492		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229339_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391138
+FBti0229339_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391144
+FBti0229340_cas	encodes_tool	FBto0000155	FBrf0256492		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229340_cas	tool_uses	promoter trap	FBrf0256492		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229340_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391139
+FBti0229340_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391145
+FBti0229341_cas	encodes_tool	FBto0000155	FBrf0256492		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229341_cas	tool_uses	promoter trap	FBrf0256492		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229341_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391140
+FBti0229341_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391148
+FBti0229342_cas	encodes_tool	FBto0000155	FBrf0256492		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229342_cas	tool_uses	promoter trap	FBrf0256492		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229342_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391141
+FBti0229342_cas	carries_tool	FBto0000349	FBrf0256492		TOOL DATA from: FBal0391149
+FBti0229348_cas	tagged_with	FBto0000028	FBrf0256570		TOOL DATA from: FBal0391153
+FBti0229477_cas	tagged_with	FBto0000076	FBrf0256335		TOOL DATA from: FBal0391408
+FBti0229478_cas	tagged_with	FBto0000076	FBrf0256335		TOOL DATA from: FBal0391409
+FBti0229479_cas	tagged_with	FBto0000076	FBrf0256335		TOOL DATA from: FBal0391410
+FBti0229480_cas	tagged_with	FBto0000076	FBrf0256335		TOOL DATA from: FBal0391411
+FBti0229481_cas	tagged_with	FBto0000027	FBrf0256335		TOOL DATA from: FBal0391412
+FBti0229502_cas	encodes_tool	FBto0000150	FBrf0247105		TOOL DATA from: FBtp0146569, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229502_cas	tool_uses	promoter trap	FBrf0247105		TOOL DATA from: FBtp0146569, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229521_cas	tagged_with	FBto0000081	FBrf0256345		TOOL DATA from: FBal0391472
+FBti0229522_cas	tagged_with	FBto0000077	FBrf0256345		TOOL DATA from: FBal0391473
+FBti0229523_cas	tagged_with	FBto0000081	FBrf0256345		TOOL DATA from: FBal0391474
+FBti0229524_cas	tagged_with	FBto0000077	FBrf0256345		TOOL DATA from: FBal0391475
+FBti0229524_cas	tagged_with	FBto0000081	FBrf0256345		TOOL DATA from: FBal0391475
+FBti0229549_cas	carries_tool	FBto0000349	FBrf0256531		TOOL DATA from: FBal0391506
+FBti0229550_cas	carries_tool	FBto0000349	FBrf0256531		TOOL DATA from: FBal0391507
+FBti0229576_cas	carries_tool	FBto0000318	FBrf0239922		TOOL DATA from: FBal0391564
+FBti0229576_cas	carries_tool	FBto0000896	FBrf0239922		TOOL DATA from: FBal0391564
+FBti0229577_cas	carries_tool	FBto0000318	FBrf0239922		TOOL DATA from: FBal0391565
+FBti0229578_cas	encodes_tool	FBto0000159	FBrf0239922		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229578_cas	tool_uses	promoter trap	FBrf0239922		TOOL DATA from: FBtp0099209, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229578_cas	carries_tool	FBto0000318	FBrf0239922		TOOL DATA from: FBal0391566
+FBti0229578_cas	carries_tool	FBto0000318	FBrf0239922		TOOL DATA from: FBal0391567
+FBti0229579_cas	carries_tool	FBto0000349	FBrf0239922		TOOL DATA from: FBal0391568
+FBti0229579_cas	carries_tool	FBto0000356	FBrf0239922		TOOL DATA from: FBal0391568
+FBti0229580_cas	carries_tool	FBto0000349	FBrf0239922		TOOL DATA from: FBal0391569
+FBti0229581_cas	encodes_tool	FBto0000135	FBrf0239922		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229581_cas	tool_uses	promoter trap	FBrf0239922		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229581_cas	carries_tool	FBto0000349	FBrf0239922		TOOL DATA from: FBal0391570
+FBti0229581_cas	carries_tool	FBto0000349	FBrf0239922		TOOL DATA from: FBal0391571
+FBti0229595_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229595_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229595_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229595_cas	tagged_with	FBto0000159	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229595_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391599
+FBti0229596_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391600
+FBti0229596_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391600
+FBti0229596_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391600
+FBti0229597_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391601
+FBti0229597_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391601
+FBti0229597_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391601
+FBti0229598_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229598_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229598_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229598_cas	tagged_with	FBto0000159	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229598_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391602
+FBti0229599_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391603
+FBti0229599_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391603
+FBti0229599_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391603
+FBti0229600_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391604
+FBti0229600_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391604
+FBti0229600_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391604
+FBti0229601_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229601_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229601_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229601_cas	tagged_with	FBto0000159	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229601_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391605
+FBti0229602_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391606
+FBti0229602_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391606
+FBti0229602_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391606
+FBti0229603_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391607
+FBti0229603_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391607
+FBti0229603_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391607
+FBti0229604_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229604_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229604_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229604_cas	tagged_with	FBto0000135	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229604_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391608
+FBti0229605_cas	carries_tool	FBto0000349	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229605_cas	tagged_with	FBto0000077	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229605_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229605_cas	tagged_with	FBto0000168	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229605_cas	tool_uses	genetically encoded sensor	FBrf0256127		TOOL DATA from: FBal0391609
+FBti0229606_cas	tagged_with	FBto0000048	FBrf0261549		TOOL DATA from: FBal0391611
+FBti0229606_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0391611
+FBti0229607_cas	tagged_with	FBto0000093	FBrf0256127|FBrf0261549		TOOL DATA from: FBal0391612
+FBti0229609_cas	encodes_tool	FBto0000135	FBrf0256127		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229609_cas	tool_uses	promoter trap	FBrf0256127		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229609_cas				FTA: unable to add tool information from FBal0391610 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0229610_cas	encodes_tool	FBto0000159	FBrf0256127		TOOL DATA from: FBtp0160841, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229610_cas	tool_uses	promoter trap	FBrf0256127		TOOL DATA from: FBtp0160841, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229610_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391610
+FBti0229610_cas	tagged_with	FBto0000093	FBrf0256127		TOOL DATA from: FBal0391614
+FBti0229612_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391623
+FBti0229613_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391624
+FBti0229613_cas	tagged_with	FBto0000025	FBrf0256675		TOOL DATA from: FBal0391624
+FBti0229614_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391625
+FBti0229614_cas	tagged_with	FBto0000025	FBrf0256675		TOOL DATA from: FBal0391625
+FBti0229615_cas	encodes_tool	FBto0000308	FBrf0256675		TOOL DATA from: FBtp0099203, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229615_cas	tool_uses	promoter trap	FBrf0256675		TOOL DATA from: FBtp0099203, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229616_cas	tagged_with	FBto0000070	FBrf0256675		TOOL DATA from: FBal0391627
+FBti0229617_cas	tagged_with	FBto0000069	FBrf0256675		TOOL DATA from: FBal0391628
+FBti0229618_cas	encodes_tool	FBto0000166	FBrf0256675		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229618_cas	tool_uses	promoter trap	FBrf0256675		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229619_cas	encodes_tool	FBto0000146	FBrf0256675		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229619_cas	tool_uses	promoter trap	FBrf0256675		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229620_cas	tagged_with	FBto0000018	FBrf0256675		TOOL DATA from: FBal0391633
+FBti0229621_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391634
+FBti0229621_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391634
+FBti0229622_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391635
+FBti0229622_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391635
+FBti0229623_cas	tagged_with	FBto0000018	FBrf0256675		TOOL DATA from: FBal0391636
+FBti0229624_cas	carries_tool	FBto0000356	FBrf0256675		TOOL DATA from: FBal0391637
+FBti0229625_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391638
+FBti0229625_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391638
+FBti0229626_cas	carries_tool	FBto0000318	FBrf0256675		TOOL DATA from: FBal0391639
+FBti0229626_cas	tagged_with	FBto0000027	FBrf0256675		TOOL DATA from: FBal0391639
+FBti0229627_cas	tagged_with	FBto0000070	FBrf0256675		TOOL DATA from: FBal0391642
+FBti0229636_cas	carries_tool	FBto0000356	FBrf0256741		TOOL DATA from: FBal0391651
+FBti0229641_cas				FTA: unable to add tool information from FBal0391659 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0229646_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229646_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229646_cas	tagged_with	FBto0000092	FBrf0256541		TOOL DATA from: FBal0391661
+FBti0229647_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229647_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229647_cas	carries_tool	FBto0000135	FBrf0256541		TOOL DATA from: FBal0391662
+FBti0229648_cas	encodes_tool	FBto0000135	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229648_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229648_cas	tagged_with	FBto0000077	FBrf0256541		TOOL DATA from: FBal0391668
+FBti0229649_cas	encodes_tool	FBto0000168	FBrf0105495		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229649_cas	tool_uses	promoter trap	FBrf0105495		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229649_cas	tagged_with	FBto0000077	FBrf0256541		TOOL DATA from: FBal0391669
+FBti0229896_cas	encodes_tool	FBto0000135	FBrf0256600		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229896_cas	tool_uses	promoter trap	FBrf0256600		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229896_cas	carries_tool	FBto0000349	FBrf0256600		TOOL DATA from: FBal0391881
+FBti0229896_cas	carries_tool	FBto0000349	FBrf0256600		TOOL DATA from: FBal0391883
+FBti0229897_cas	carries_tool	FBto0000349	FBrf0256600		TOOL DATA from: FBal0391882
+FBti0229897_cas	tagged_with	FBto0000077	FBrf0256600		TOOL DATA from: FBal0391882
+FBti0229898_cas	carries_tool	FBto0000318	FBrf0256821		TOOL DATA from: FBal0391901
+FBti0229899_cas	carries_tool	FBto0000318	FBrf0256821		TOOL DATA from: FBal0391902
+FBti0229899_cas	tagged_with	FBto0000093	FBrf0256821		TOOL DATA from: FBal0391902
+FBti0229902_cas	encodes_tool	FBto0000159	FBrf0256663		TOOL DATA from: FBtp0160841, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229902_cas	tool_uses	promoter trap	FBrf0256663		TOOL DATA from: FBtp0160841, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229902_cas	tagged_with	FBto0000093	FBrf0256663		TOOL DATA from: FBal0391927
+FBti0229902_cas	tagged_with	FBto0000899	FBrf0256663		TOOL DATA from: FBal0391927
+FBti0229903_cas	tagged_with	FBto0000126	FBrf0256663		TOOL DATA from: FBal0391932
+FBti0229916_cas	encodes_tool	FBto0000308	FBrf0256539		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229916_cas	tool_uses	promoter trap	FBrf0256539		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229916_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391939
+FBti0229916_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391952
+FBti0229917_cas	encodes_tool	FBto0000308	FBrf0256539		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229917_cas	tool_uses	promoter trap	FBrf0256539		TOOL DATA from: FBtp0140111, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229917_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391940
+FBti0229917_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391953
+FBti0229918_cas	encodes_tool	FBto0000168	FBrf0256539		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229918_cas	tool_uses	promoter trap	FBrf0256539		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229918_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391951
+FBti0229918_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391956
+FBti0229919_cas	encodes_tool	FBto0000168	FBrf0256539		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229919_cas	tool_uses	promoter trap	FBrf0256539		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229919_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391954
+FBti0229919_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391957
+FBti0229920_cas	encodes_tool	FBto0000168	FBrf0256539		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229920_cas	tool_uses	promoter trap	FBrf0256539		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229920_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391955
+FBti0229920_cas	carries_tool	FBto0000349	FBrf0256539		TOOL DATA from: FBal0391958
+FBti0229987_cas	encodes_tool	FBto0000168	FBrf0256619		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229987_cas	tool_uses	promoter trap	FBrf0256619		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229988_cas	encodes_tool	FBto0000168	FBrf0256619		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0229988_cas	tool_uses	promoter trap	FBrf0256619		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230144_cas	carries_tool	FBto0000349	FBrf0256867		TOOL DATA from: FBal0392341
+FBti0230304_cas	tagged_with	FBto0000099	FBrf0257330		TOOL DATA from: FBal0392526
+FBti0230305_cas	tagged_with	FBto0000118	FBrf0257331		TOOL DATA from: FBal0392527
+FBti0230317_cas	tagged_with	FBto0000044	FBrf0257396		TOOL DATA from: FBal0392544
+FBti0230324_cas	carries_tool	FBto0000349	FBrf0257404		TOOL DATA from: FBal0392558
+FBti0230324_cas	tagged_with	FBto0000027	FBrf0257404		TOOL DATA from: FBal0392558
+FBti0230325_cas	tagged_with	FBto0000093	FBrf0257405		TOOL DATA from: FBal0392559
+FBti0230356_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230356_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230357_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230357_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230358_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230358_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230359_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230359_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230360_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230360_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230361_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230361_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230362_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230362_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230363_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230363_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230364_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230364_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230365_cas	encodes_tool	FBto0000907	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230365_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230366_cas	encodes_tool	FBto0000908	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230366_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230367_cas	encodes_tool	FBto0000908	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230367_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230368_cas	encodes_tool	FBto0000908	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230368_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230369_cas	encodes_tool	FBto0000908	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230369_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230370_cas	encodes_tool	FBto0000908	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230370_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230371_cas	encodes_tool	FBto0000908	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230371_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230372_cas	encodes_tool	FBto0000908	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230372_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230373_cas	encodes_tool	FBto0000908	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230373_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230374_cas	encodes_tool	FBto0000908	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230374_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230375_cas	encodes_tool	FBto0000146	FBrf0256689		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230375_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230376_cas	encodes_tool	FBto0000146	FBrf0256689		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230376_cas	tool_uses	promoter trap	FBrf0256689		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230453_cas	carries_tool	FBto0000356	FBrf0257237		TOOL DATA from: FBal0392815
+FBti0230462_cas	encodes_tool	FBto0000135	FBrf0257345		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230462_cas	tool_uses	promoter trap	FBrf0257345		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230462_cas	carries_tool	FBto0000349	FBrf0257345		TOOL DATA from: FBal0392824
+FBti0230462_cas	carries_tool	FBto0000375	FBrf0257345		TOOL DATA from: FBal0392824
+FBti0230462_cas	carries_tool	FBto0000349	FBrf0257345		TOOL DATA from: FBal0392826
+FBti0230462_cas	carries_tool	FBto0000375	FBrf0257345		TOOL DATA from: FBal0392826
+FBti0230503_cas	encodes_tool	FBto0000153	FBrf0257357		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230503_cas	tool_uses	promoter trap	FBrf0257357		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230507_cas	tagged_with	FBto0000063	FBrf0257271		TOOL DATA from: FBal0392877
+FBti0230508_cas	tagged_with	FBto0000522	FBrf0257271		TOOL DATA from: FBal0392878
+FBti0230516_cas	tagged_with	FBto0000093	FBrf0257196		TOOL DATA from: FBal0392889
+FBti0230517_cas	tagged_with	FBto0000027	FBrf0257196		TOOL DATA from: FBal0392890
+FBti0230518_cas	tagged_with	FBto0000027	FBrf0257196		TOOL DATA from: FBal0392891
+FBti0230523_cas	tagged_with	FBto0000083	FBrf0256925		TOOL DATA from: FBal0392898
+FBti0230523_cas	tagged_with	FBto0000118	FBrf0256925		TOOL DATA from: FBal0392898
+FBti0230524_cas	tagged_with	FBto0000083	FBrf0256925		TOOL DATA from: FBal0392899
+FBti0230524_cas	tagged_with	FBto0000118	FBrf0256925		TOOL DATA from: FBal0392899
+FBti0230525_cas	tagged_with	FBto0000083	FBrf0256925		TOOL DATA from: FBal0392900
+FBti0230525_cas	tagged_with	FBto0000118	FBrf0256925		TOOL DATA from: FBal0392900
+FBti0230536_cas	encodes_tool	FBto0000135	FBrf0256703		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230536_cas	tool_uses	promoter trap	FBrf0256703		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230537_cas	tagged_with	FBto0000027	FBrf0257433		TOOL DATA from: FBal0392917
+FBti0230552_cas	carries_tool	FBto0000349	FBrf0257275		TOOL DATA from: FBal0392937
+FBti0230552_cas	tagged_with	FBto0000118	FBrf0257275		TOOL DATA from: FBal0392937
+FBti0230553_cas	encodes_tool	FBto0000135	FBrf0257456		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230553_cas	tool_uses	promoter trap	FBrf0257456		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0230570_cas	carries_tool	FBto0000349	FBrf0256895		TOOL DATA from: FBal0392963
+FBti0230570_cas	tagged_with	FBto0000031	FBrf0256895		TOOL DATA from: FBal0392963
+FBti0230579_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392984
+FBti0230579_cas	carries_tool	FBto0000356	FBrf0257506		TOOL DATA from: FBal0392984
+FBti0230580_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392985
+FBti0230580_cas	carries_tool	FBto0000356	FBrf0257506		TOOL DATA from: FBal0392985
+FBti0230581_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392986
+FBti0230582_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392987
+FBti0230582_cas	tagged_with	FBto0000093	FBrf0257506		TOOL DATA from: FBal0392987
+FBti0230583_cas	carries_tool	FBto0000349	FBrf0257506		TOOL DATA from: FBal0392988
+FBti0230583_cas	tagged_with	FBto0000077	FBrf0257506		TOOL DATA from: FBal0392988
+FBti0230629_cas	tagged_with	FBto0000027	FBrf0257295		TOOL DATA from: FBal0393037
+FBti0230630_cas	tagged_with	FBto0000335	FBrf0257295		TOOL DATA from: FBal0393044
+FBti0230631_cas	tagged_with	FBto0000335	FBrf0257295		TOOL DATA from: FBal0393047
+FBti0230733_cas	tagged_with	FBto0000076	FBrf0257587		TOOL DATA from: FBal0393171
+FBti0230733_cas	tagged_with	FBto0000093	FBrf0257587		TOOL DATA from: FBal0393171
+FBti0230734_cas	tagged_with	FBto0000076	FBrf0257587		TOOL DATA from: FBal0393173
+FBti0230734_cas	tagged_with	FBto0000093	FBrf0257587		TOOL DATA from: FBal0393173
+FBti0230735_cas	tagged_with	FBto0000076	FBrf0257587		TOOL DATA from: FBal0393174
+FBti0230735_cas	tagged_with	FBto0000093	FBrf0257587		TOOL DATA from: FBal0393174
+FBti0231865_cas	carries_tool	FBto0000349	FBrf0257538		TOOL DATA from: FBal0394281
+FBti0231865_cas	tagged_with	FBto0000031	FBrf0257538		TOOL DATA from: FBal0394281
+FBti0231868_cas	carries_tool	FBto0000349	FBrf0257837		TOOL DATA from: FBal0394286
+FBti0231868_cas	tagged_with	FBto0000027	FBrf0257837		TOOL DATA from: FBal0394286
+FBti0231869_cas	carries_tool	FBto0000349	FBrf0257837		TOOL DATA from: FBal0394287
+FBti0231869_cas	tagged_with	FBto0000118	FBrf0257837		TOOL DATA from: FBal0394287
+FBti0234537_cas	tagged_with	FBto0000077	FBrf0257829		TOOL DATA from: FBal0396468
+FBti0234601_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234601_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234602_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234602_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234603_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234603_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234604_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234604_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234605_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234605_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234606_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234606_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234607_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234607_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234608_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234608_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234609_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234609_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234610_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234610_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234611_cas	encodes_tool	FBto0000146	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234611_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234625_cas	tagged_with	FBto0000031	FBrf0258084		TOOL DATA from: FBal0396685
+FBti0234628_cas	carries_tool	FBto0000356	FBrf0257759		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234628_cas	tool_uses	docking element	FBrf0257759		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234628_cas	carries_tool	FBto0000356	FBrf0257759		TOOL DATA from: FBal0396688
+FBti0234630_cas	tagged_with	FBto0000077	FBrf0257759		TOOL DATA from: FBal0396690
+FBti0234632_cas	tagged_with	FBto0000063	FBrf0257759		TOOL DATA from: FBal0396692
+FBti0234633_cas	carries_tool	FBto0000356	FBrf0257759		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234633_cas	tool_uses	docking element	FBrf0257759		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234633_cas	carries_tool	FBto0000356	FBrf0257759		TOOL DATA from: FBal0396697
+FBti0234642_cas	encodes_tool	FBto0000031	FBrf0257726		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234642_cas	tool_uses	promoter trap	FBrf0257726		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234642_cas	tagged_with	FBto0000031	FBrf0257726		TOOL DATA from: FBal0396719
+FBti0234648_cas	carries_tool	FBto0000356	FBrf0257868		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234648_cas	tool_uses	docking element	FBrf0257868		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234648_cas				FTA: unable to add tool information from FBal0396730 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0234649_cas	carries_tool	FBto0000356	FBrf0257868		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234649_cas	tool_uses	docking element	FBrf0257868		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234649_cas				FTA: unable to add tool information from FBal0396737 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0234650_cas	carries_tool	FBto0000318	FBrf0257868		TOOL DATA from: FBal0396738
+FBti0234651_cas	carries_tool	FBto0000318	FBrf0257868		TOOL DATA from: FBal0396739
+FBti0234651_cas	tagged_with	FBto0000076	FBrf0257868		TOOL DATA from: FBal0396739
+FBti0234652_cas	carries_tool	FBto0000318	FBrf0257868		TOOL DATA from: FBal0396747
+FBti0234652_cas	tagged_with	FBto0000077	FBrf0257868		TOOL DATA from: FBal0396747
+FBti0234653_cas	carries_tool	FBto0000356	FBrf0257868		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234653_cas	tool_uses	docking element	FBrf0257868		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234666_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234666_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234667_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234667_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234668_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234668_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234669_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234669_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234670_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234670_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234671_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234671_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234672_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234672_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234673_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234673_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234674_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234674_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234675_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234675_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234676_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234676_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234677_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234677_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234678_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234678_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234679_cas	encodes_tool	FBto0000184	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234679_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234680_cas	encodes_tool	FBto0000144	FBrf0257150		TOOL DATA from: FBtp0165199, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234680_cas	tool_uses	promoter trap	FBrf0257150		TOOL DATA from: FBtp0165199, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234927_cas	tagged_with	FBto0000118	FBrf0257896		TOOL DATA from: FBal0397055
+FBti0234928_cas	tagged_with	FBto0000077	FBrf0257600		TOOL DATA from: FBal0397057
+FBti0234932_cas	encodes_tool	FBto0000166	FBrf0257935		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234932_cas	tool_uses	promoter trap	FBrf0257935		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0234932_cas	carries_tool	FBto0000349	FBrf0257935		TOOL DATA from: FBal0397065
+FBti0234932_cas	carries_tool	FBto0000349	FBrf0257935		TOOL DATA from: FBal0397066
+FBti0234947_cas	tagged_with	FBto0000102	FBrf0257635		TOOL DATA from: FBal0397127
+FBti0234961_cas	tagged_with	FBto0000027	FBrf0257501		TOOL DATA from: FBal0397136
+FBti0234962_cas	tagged_with	FBto0000027	FBrf0257501		TOOL DATA from: FBal0397137
+FBti0234974_cas				FTA: unable to add tool information from FBal0397152 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0234986_cas	carries_tool	FBto0000349	FBrf0257530		TOOL DATA from: FBal0397159
+FBti0234986_cas	tagged_with	FBto0000027	FBrf0257530		TOOL DATA from: FBal0397159
+FBti0235034_cas	tagged_with	FBto0000027	FBrf0257901		TOOL DATA from: FBal0397182
+FBti0235035_cas	encodes_tool	FBto0000027	FBrf0257901		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0235035_cas	tool_uses	promoter trap	FBrf0257901		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0235072_cas	carries_tool	FBto0000349	FBrf0257451		TOOL DATA from: FBal0397215
+FBti0235073_cas	carries_tool	FBto0000318	FBrf0257451		TOOL DATA from: FBtp0165470, used single pub_curie from FBti->FBtp producedby f_r
+FBti0235162_cas	carries_tool	FBto0000318	FBrf0257867		TOOL DATA from: FBal0397365
+FBti0235162_cas	tagged_with	FBto0000027	FBrf0257867		TOOL DATA from: FBal0397365
+FBti0235163_cas	tagged_with	FBto0000093	FBrf0257735		TOOL DATA from: FBal0397376
+FBti0235164_cas	tagged_with	FBto0000093	FBrf0257735		TOOL DATA from: FBal0397377
+FBti0235165_cas	tagged_with	FBto0000093	FBrf0257735		TOOL DATA from: FBal0397384
+FBti0235172_cas	tagged_with	FBto0000031	FBrf0257765		TOOL DATA from: FBal0397397
+FBti0235172_cas	tagged_with	FBto0000077	FBrf0257765		TOOL DATA from: FBal0397397
+FBti0235195_cas	tagged_with	FBto0000031	FBrf0258079		TOOL DATA from: FBal0397427
+FBti0235205_cas	tagged_with	FBto0000077	FBrf0258142		TOOL DATA from: FBal0397452
+FBti0235206_cas	tagged_with	FBto0000077	FBrf0258142		TOOL DATA from: FBal0397453
+FBti0235207_cas	tagged_with	FBto0000077	FBrf0258142		TOOL DATA from: FBal0397454
+FBti0235208_cas	tagged_with	FBto0000077	FBrf0258142		TOOL DATA from: FBal0397455
+FBti0235211_cas	carries_tool	FBto0000349	FBrf0257791		TOOL DATA from: FBal0397465
+FBti0235211_cas	carries_tool	FBto0000356	FBrf0257791		TOOL DATA from: FBal0397465
+FBti0235212_cas				FTA: unable to add tool information from FBal0397466 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235225_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397502
+FBti0235225_cas	carries_tool	FBto0000356	FBrf0258102		TOOL DATA from: FBal0397502
+FBti0235226_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397503
+FBti0235226_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397503
+FBti0235227_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397504
+FBti0235227_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397504
+FBti0235228_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397505
+FBti0235229_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397506
+FBti0235229_cas	tagged_with	FBto0000118	FBrf0258102		TOOL DATA from: FBal0397506
+FBti0235230_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397507
+FBti0235230_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397507
+FBti0235230_cas	tagged_with	FBto0000118	FBrf0258102		TOOL DATA from: FBal0397507
+FBti0235231_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397508
+FBti0235231_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397508
+FBti0235232_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397509
+FBti0235232_cas	tagged_with	FBto0000063	FBrf0258102		TOOL DATA from: FBal0397509
+FBti0235233_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397510
+FBti0235233_cas	tagged_with	FBto0000070	FBrf0258102		TOOL DATA from: FBal0397510
+FBti0235234_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397511
+FBti0235234_cas	tagged_with	FBto0000070	FBrf0258102		TOOL DATA from: FBal0397511
+FBti0235234_cas	tagged_with	FBto0000118	FBrf0258102		TOOL DATA from: FBal0397511
+FBti0235235_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397512
+FBti0235235_cas	tagged_with	FBto0000117	FBrf0258102		TOOL DATA from: FBal0397512
+FBti0235235_cas	tagged_with	FBto0000638	FBrf0258102		TOOL DATA from: FBal0397512
+FBti0235236_cas	carries_tool	FBto0000349	FBrf0258102		TOOL DATA from: FBal0397513
+FBti0235236_cas	tagged_with	FBto0000117	FBrf0258102		TOOL DATA from: FBal0397513
+FBti0235236_cas	tagged_with	FBto0000118	FBrf0258102		TOOL DATA from: FBal0397513
+FBti0235322_cas	tagged_with	FBto0000077	FBrf0258148		TOOL DATA from: FBal0397658
+FBti0235323_cas	tagged_with	FBto0000076	FBrf0258148		TOOL DATA from: FBal0397659
+FBti0235323_cas	tagged_with	FBto0000077	FBrf0258148		TOOL DATA from: FBal0397659
+FBti0235324_cas	tagged_with	FBto0000076	FBrf0258148		TOOL DATA from: FBal0397660
+FBti0235324_cas	tagged_with	FBto0000077	FBrf0258148		TOOL DATA from: FBal0397660
+FBti0235401_cas				FTA: unable to add tool information from FBal0397815 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235402_cas				FTA: unable to add tool information from FBal0397816 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235403_cas				FTA: unable to add tool information from FBal0397817 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235404_cas				FTA: unable to add tool information from FBal0397818 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0235411_cas	encodes_tool	FBto0000027	FBrf0258196		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0235411_cas	tool_uses	promoter trap	FBrf0258196		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0235459_cas	encodes_tool	FBto0000135	FBrf0258487		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0235459_cas	tool_uses	promoter trap	FBrf0258487		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0235470_cas	carries_tool	FBto0000349	FBrf0258355		TOOL DATA from: FBal0398033
+FBti0236724_cas	carries_tool	FBto0000349	FBrf0258418		TOOL DATA from: FBal0398824
+FBti0236742_cas	tagged_with	FBto0000063	FBrf0257086		TOOL DATA from: FBal0398860
+FBti0236743_cas				FTA: unable to add tool information from FBal0398861 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236744_cas				FTA: unable to add tool information from FBal0398862 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236745_cas				FTA: unable to add tool information from FBal0398863 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236746_cas				FTA: unable to add tool information from FBal0398864 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236747_cas				FTA: unable to add tool information from FBal0398865 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236748_cas				FTA: unable to add tool information from FBal0398866 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236753_cas	carries_tool	FBto0000349	FBrf0258340		TOOL DATA from: FBal0398877
+FBti0236753_cas	carries_tool	FBto0000356	FBrf0258340		TOOL DATA from: FBal0398877
+FBti0236754_cas	tagged_with	FBto0000027	FBrf0258450		TOOL DATA from: FBal0398878
+FBti0236755_cas				FTA: unable to add tool information from FBal0398879 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236756_cas	carries_tool	FBto0000349	FBrf0258392		TOOL DATA from: FBal0398883
+FBti0236757_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398884
+FBti0236757_cas	carries_tool	FBto0000356	FBrf0258594		TOOL DATA from: FBal0398884
+FBti0236758_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398885
+FBti0236759_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398886
+FBti0236760_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398887
+FBti0236761_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398888
+FBti0236762_cas	carries_tool	FBto0000349	FBrf0258594		TOOL DATA from: FBal0398889
+FBti0236763_cas				FTA: unable to add tool information from FBal0398890 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236764_cas				FTA: unable to add tool information from FBal0398891 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236765_cas	tagged_with	FBto0000389	FBrf0257573		TOOL DATA from: FBal0398894
+FBti0236765_cas	tagged_with	FBto0000785	FBrf0257573		TOOL DATA from: FBal0398894
+FBti0236773_cas	tagged_with	FBto0000922	FBrf0258431		TOOL DATA from: FBal0398908
+FBti0236779_cas				FTA: unable to add tool information from FBal0398930 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0236796_cas	tagged_with	FBto0000076	FBrf0257972		TOOL DATA from: FBal0398944
+FBti0236846_cas	tagged_with	FBto0000048	FBrf0258633		TOOL DATA from: FBal0399054
+FBti0236847_cas	encodes_tool	FBto0000135	FBrf0258633		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0236847_cas	tool_uses	promoter trap	FBrf0258633		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0236850_cas	carries_tool	FBto0000349	FBrf0258633		TOOL DATA from: FBal0399058
+FBti0236850_cas	tagged_with	FBto0000077	FBrf0258633		TOOL DATA from: FBal0399058
+FBti0236850_cas	tagged_with	FBto0000093	FBrf0258633		TOOL DATA from: FBal0399058
+FBti0236856_cas	tagged_with	FBto0000027	FBrf0258683		TOOL DATA from: FBal0399068
+FBti0236857_cas	tagged_with	FBto0000027	FBrf0258683		TOOL DATA from: FBal0399069
+FBti0236863_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399087
+FBti0236863_cas	carries_tool	FBto0000356	FBrf0258384		TOOL DATA from: FBal0399087
+FBti0236864_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399088
+FBti0236864_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399088
+FBti0236865_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399089
+FBti0236865_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399089
+FBti0236865_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399089
+FBti0236866_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399090
+FBti0236866_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399090
+FBti0236866_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399090
+FBti0236867_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399091
+FBti0236867_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399091
+FBti0236867_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399091
+FBti0236868_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399092
+FBti0236868_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399092
+FBti0236868_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399092
+FBti0236869_cas	carries_tool	FBto0000318	FBrf0258384		TOOL DATA from: FBal0399093
+FBti0236869_cas	carries_tool	FBto0000349	FBrf0258384		TOOL DATA from: FBal0399093
+FBti0236869_cas	tagged_with	FBto0000027	FBrf0258384		TOOL DATA from: FBal0399093
+FBti0236873_cas	carries_tool	FBto0000356	FBrf0258505		TOOL DATA from: FBal0399103
+FBti0236874_cas	encodes_tool	FBto0000135	FBrf0258468		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0236874_cas	tool_uses	promoter trap	FBrf0258468		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0236874_cas	carries_tool	FBto0000349	FBrf0258468		TOOL DATA from: FBal0399106
+FBti0236874_cas	tagged_with	FBto0000079	FBrf0258468		TOOL DATA from: FBal0399106
+FBti0236874_cas	carries_tool	FBto0000349	FBrf0258468		TOOL DATA from: FBal0399115
+FBti0236874_cas	tagged_with	FBto0000079	FBrf0258468		TOOL DATA from: FBal0399115
+FBti0236875_cas	encodes_tool	FBto0000135	FBrf0258468		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0236875_cas	tool_uses	gene trap	FBrf0258468		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0236875_cas	carries_tool	FBto0000318	FBrf0258468		TOOL DATA from: FBal0399107
+FBti0236875_cas	carries_tool	FBto0000349	FBrf0258468		TOOL DATA from: FBal0399107
+FBti0236876_cas	encodes_tool	FBto0000135	FBrf0258468		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0236876_cas	tool_uses	gene trap	FBrf0258468		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0236876_cas	carries_tool	FBto0000318	FBrf0258468		TOOL DATA from: FBal0399108
+FBti0236876_cas	carries_tool	FBto0000349	FBrf0258468		TOOL DATA from: FBal0399108
+FBti0236885_cas	tagged_with	FBto0000031	FBrf0257653		TOOL DATA from: FBal0399129
+FBti0236895_cas	carries_tool	FBto0000349	FBrf0249106		TOOL DATA from: FBal0399154
+FBti0236895_cas	tagged_with	FBto0000118	FBrf0249106		TOOL DATA from: FBal0399154
+FBti0236896_cas	tagged_with	FBto0000063	FBrf0249106		TOOL DATA from: FBal0399157
+FBti0236897_cas	tagged_with	FBto0000063	FBrf0249106		TOOL DATA from: FBal0399158
+FBti0236898_cas	tagged_with	FBto0000063	FBrf0249106		TOOL DATA from: FBal0399159
+FBti0236926_cas	tagged_with	FBto0000102	FBrf0258581		TOOL DATA from: FBal0399187
+FBti0236959_cas	tagged_with	FBto0000076	FBrf0256909		TOOL DATA from: FBal0399249
+FBti0236972_cas	carries_tool	FBto0000349	FBrf0258590		TOOL DATA from: FBal0399292
+FBti0236979_cas	carries_tool	FBto0000349	FBrf0258192		TOOL DATA from: FBal0399319
+FBti0236980_cas	carries_tool	FBto0000349	FBrf0258192		TOOL DATA from: FBal0399320
+FBti0236981_cas	carries_tool	FBto0000349	FBrf0257529		TOOL DATA from: FBal0399322
+FBti0236981_cas	carries_tool	FBto0000356	FBrf0257529		TOOL DATA from: FBal0399322
+FBti0236992_cas	tagged_with	FBto0000126	FBrf0253702		TOOL DATA from: FBal0399375
+FBti0236998_cas	tagged_with	FBto0000927	FBrf0258443		TOOL DATA from: FBal0399386
+FBti0236999_cas	carries_tool	FBto0000349	FBrf0258443		TOOL DATA from: FBal0399387
+FBti0236999_cas	carries_tool	FBto0000356	FBrf0258443		TOOL DATA from: FBal0399387
+FBti0236999_cas	tagged_with	FBto0000102	FBrf0258443		TOOL DATA from: FBal0399387
+FBti0236999_cas	tagged_with	FBto0000927	FBrf0258443		TOOL DATA from: FBal0399387
+FBti0237013_cas	carries_tool	FBto0000349	FBrf0257674		TOOL DATA from: FBal0399409
+FBti0237013_cas	tagged_with	FBto0000389	FBrf0257674		TOOL DATA from: FBal0399409
+FBti0237014_cas	carries_tool	FBto0000349	FBrf0257674		TOOL DATA from: FBal0399410
+FBti0237014_cas	tagged_with	FBto0000389	FBrf0257674		TOOL DATA from: FBal0399410
+FBti0237015_cas	tagged_with	FBto0000118	FBrf0257535		TOOL DATA from: FBal0399421
+FBti0237016_cas	tagged_with	FBto0000063	FBrf0257535		TOOL DATA from: FBal0399424
+FBti0237026_cas	tagged_with	FBto0000031	FBrf0257425		TOOL DATA from: FBal0399441
+FBti0237027_cas	tagged_with	FBto0000118	FBrf0258777		TOOL DATA from: FBal0399451
+FBti0237028_cas	tagged_with	FBto0000118	FBrf0258777		TOOL DATA from: FBal0399452
+FBti0237035_cas				FTA: unable to add tool information from FBal0399483 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0237036_cas	carries_tool	FBto0000349	FBrf0258639		TOOL DATA from: FBal0399484
+FBti0237036_cas	carries_tool	FBto0000349	FBrf0258639		TOOL DATA from: FBal0399491
+FBti0237036_cas	tagged_with	FBto0000077	FBrf0258639		TOOL DATA from: FBal0399491
+FBti0237037_cas	tagged_with	FBto0000104	FBrf0258639		TOOL DATA from: FBal0399485
+FBti0237038_cas	tagged_with	FBto0000104	FBrf0258639		TOOL DATA from: FBal0399486
+FBti0237039_cas	tagged_with	FBto0000077	FBrf0258639		TOOL DATA from: FBal0399487
+FBti0237040_cas	tagged_with	FBto0000077	FBrf0258639		TOOL DATA from: FBal0399488
+FBti0237040_cas	tagged_with	FBto0000081	FBrf0258639		TOOL DATA from: FBal0399488
+FBti0237041_cas				FTA: unable to add tool information from FBal0399489 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0237042_cas	carries_tool	FBto0000349	FBrf0258639		TOOL DATA from: FBal0399490
+FBti0237042_cas	tagged_with	FBto0000077	FBrf0258639		TOOL DATA from: FBal0399490
+FBti0237043_cas	encodes_tool	FBto0000135	FBrf0258639		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0237043_cas	tool_uses	promoter trap	FBrf0258639		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0237044_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399496
+FBti0237044_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399496
+FBti0237045_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399500
+FBti0237045_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399500
+FBti0237046_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399504
+FBti0237046_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399504
+FBti0237047_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399508
+FBti0237047_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399508
+FBti0237048_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399512
+FBti0237048_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399512
+FBti0237049_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399516
+FBti0237049_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399516
+FBti0237050_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399520
+FBti0237050_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399520
+FBti0237051_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399524
+FBti0237051_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399524
+FBti0237052_cas	tagged_with	FBto0000027	FBrf0258634		TOOL DATA from: FBal0399528
+FBti0237052_cas	tagged_with	FBto0000076	FBrf0258634		TOOL DATA from: FBal0399528
+FBti0237053_cas	tagged_with	FBto0000516	FBrf0258634		TOOL DATA from: FBal0399529
+FBti0237130_cas	tagged_with	FBto0000063	FBrf0258821		TOOL DATA from: FBal0399611
+FBti0237161_cas	tagged_with	FBto0000036	FBrf0257294		TOOL DATA from: FBal0399646
+FBti0237161_cas	tagged_with	FBto0000645	FBrf0257294		TOOL DATA from: FBal0399646
+FBti0237162_cas	tagged_with	FBto0000036	FBrf0257294		TOOL DATA from: FBal0399647
+FBti0237162_cas	tagged_with	FBto0000307	FBrf0257294		TOOL DATA from: FBal0399647
+FBti0237312_cas	tagged_with	FBto0000063	FBrf0258745		TOOL DATA from: FBal0399878
+FBti0237313_cas	tagged_with	FBto0000063	FBrf0258745		TOOL DATA from: FBal0399879
+FBti0237323_cas	carries_tool	FBto0000349	FBrf0258849		TOOL DATA from: FBal0399912
+FBti0237323_cas	carries_tool	FBto0000356	FBrf0258849		TOOL DATA from: FBal0399912
+FBti0237391_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400006
+FBti0237391_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400006
+FBti0237391_cas	tagged_with	FBto0000077	FBrf0259117		TOOL DATA from: FBal0400006
+FBti0237392_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400007
+FBti0237392_cas	tagged_with	FBto0000077	FBrf0259117		TOOL DATA from: FBal0400007
+FBti0237393_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400008
+FBti0237393_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400008
+FBti0237393_cas	tagged_with	FBto0000077	FBrf0259117		TOOL DATA from: FBal0400008
+FBti0237394_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400009
+FBti0237394_cas	tagged_with	FBto0000077	FBrf0259117		TOOL DATA from: FBal0400009
+FBti0237395_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400010
+FBti0237395_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400010
+FBti0237395_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400010
+FBti0237396_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400011
+FBti0237396_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400011
+FBti0237397_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400012
+FBti0237397_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400012
+FBti0237397_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400012
+FBti0237398_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400013
+FBti0237398_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400013
+FBti0237399_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400015
+FBti0237399_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400015
+FBti0237399_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400015
+FBti0237400_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400016
+FBti0237400_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400016
+FBti0237401_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400017
+FBti0237401_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400017
+FBti0237401_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400017
+FBti0237402_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400018
+FBti0237402_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400018
+FBti0237403_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400019
+FBti0237403_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400019
+FBti0237403_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400019
+FBti0237404_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400020
+FBti0237404_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400020
+FBti0237405_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400021
+FBti0237405_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400021
+FBti0237405_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400021
+FBti0237406_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400022
+FBti0237406_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400022
+FBti0237407_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400023
+FBti0237407_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400023
+FBti0237407_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400023
+FBti0237408_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400024
+FBti0237408_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400024
+FBti0237409_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400025
+FBti0237409_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400025
+FBti0237409_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400025
+FBti0237410_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400026
+FBti0237410_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400026
+FBti0237411_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400027
+FBti0237411_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400027
+FBti0237411_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400027
+FBti0237412_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400028
+FBti0237412_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400028
+FBti0237413_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400029
+FBti0237413_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400029
+FBti0237413_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400029
+FBti0237414_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400030
+FBti0237414_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400030
+FBti0237415_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400031
+FBti0237415_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400031
+FBti0237415_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400031
+FBti0237416_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400032
+FBti0237416_cas	tagged_with	FBto0000081	FBrf0259117		TOOL DATA from: FBal0400032
+FBti0237417_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400033
+FBti0237417_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400033
+FBti0237417_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400033
+FBti0237418_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400034
+FBti0237418_cas	tagged_with	FBto0000093	FBrf0259117		TOOL DATA from: FBal0400034
+FBti0237419_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400035
+FBti0237419_cas	carries_tool	FBto0000349	FBrf0259117		TOOL DATA from: FBal0400035
+FBti0237419_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400035
+FBti0237420_cas	carries_tool	FBto0000323	FBrf0259117		TOOL DATA from: FBal0400036
+FBti0237420_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400036
+FBti0237421_cas	tagged_with	FBto0000936	FBrf0259117		TOOL DATA from: FBal0400041
+FBti0237494_cas	encodes_tool	FBto0000135	FBrf0259036		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0237494_cas	tool_uses	promoter trap	FBrf0259036		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0237495_cas	tagged_with	FBto0000118	FBrf0259036		TOOL DATA from: FBal0400151
+FBti0237496_cas	tagged_with	FBto0000031	FBrf0259036		TOOL DATA from: FBal0400152
+FBti0237497_cas	carries_tool	FBto0000349	FBrf0257534		TOOL DATA from: FBal0400162
+FBti0237497_cas	carries_tool	FBto0000356	FBrf0257534		TOOL DATA from: FBal0400162
+FBti0237498_cas	carries_tool	FBto0000349	FBrf0257534		TOOL DATA from: FBal0400163
+FBti0237498_cas	tagged_with	FBto0000126	FBrf0257534		TOOL DATA from: FBal0400163
+FBti0237507_cas	carries_tool	FBto0000356	FBrf0258889		TOOL DATA from: FBal0400166
+FBti0237508_cas				FTA: unable to add tool information from FBal0391660 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0237523_cas	encodes_tool	FBto0000135	FBrf0259008		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0237523_cas	tool_uses	promoter trap	FBrf0259008		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0237526_cas	carries_tool	FBto0000349	FBrf0258866		TOOL DATA from: FBal0400193
+FBti0237526_cas	carries_tool	FBto0000356	FBrf0258866		TOOL DATA from: FBal0400193
+FBti0237527_cas	carries_tool	FBto0000349	FBrf0258866		TOOL DATA from: FBal0400194
+FBti0237528_cas	tagged_with	FBto0000027	FBrf0258866		TOOL DATA from: FBal0400195
+FBti0237529_cas	tagged_with	FBto0000936	FBrf0258866		TOOL DATA from: FBal0400196
+FBti0237538_cas	tagged_with	FBto0000031	FBrf0258741		TOOL DATA from: FBal0400202
+FBti0237539_cas	carries_tool	FBto0000318	FBrf0258741		TOOL DATA from: FBal0400203
+FBti0237539_cas	tagged_with	FBto0000901	FBrf0258741		TOOL DATA from: FBal0400203
+FBti0237540_cas	carries_tool	FBto0000318	FBrf0258741		TOOL DATA from: FBal0400204
+FBti0237540_cas	tagged_with	FBto0000601	FBrf0258741		TOOL DATA from: FBal0400204
+FBti0237731_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400406
+FBti0237732_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400407
+FBti0237732_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400407
+FBti0237733_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400421
+FBti0237734_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400422
+FBti0237734_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400422
+FBti0237735_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400430
+FBti0237736_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400431
+FBti0237736_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400431
+FBti0237737_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400432
+FBti0237738_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400433
+FBti0237738_cas	tagged_with	FBto0000118	FBrf0258900		TOOL DATA from: FBal0400433
+FBti0237739_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400437
+FBti0237740_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400438
+FBti0237740_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400438
+FBti0237741_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400439
+FBti0237742_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400440
+FBti0237742_cas	tagged_with	FBto0000031	FBrf0258900		TOOL DATA from: FBal0400440
+FBti0237743_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400441
+FBti0237744_cas	carries_tool	FBto0000318	FBrf0258900		TOOL DATA from: FBal0400442
+FBti0237744_cas	tagged_with	FBto0000118	FBrf0258900		TOOL DATA from: FBal0400442
+FBti0237769_cas	tagged_with	FBto0000031	FBrf0259000		TOOL DATA from: FBal0400497
+FBti0237769_cas	tagged_with	FBto0000076	FBrf0259000		TOOL DATA from: FBal0400497
+FBti0237769_cas	tagged_with	FBto0000403	FBrf0259000		TOOL DATA from: FBal0400497
+FBti0237770_cas	tagged_with	FBto0000076	FBrf0259000		TOOL DATA from: FBal0400505
+FBti0237770_cas	tagged_with	FBto0000118	FBrf0259000		TOOL DATA from: FBal0400505
+FBti0237770_cas	tagged_with	FBto0000403	FBrf0259000		TOOL DATA from: FBal0400505
+FBti0237771_cas	tagged_with	FBto0000031	FBrf0259000		TOOL DATA from: FBal0400506
+FBti0237771_cas	tagged_with	FBto0000076	FBrf0259000		TOOL DATA from: FBal0400506
+FBti0237771_cas	tagged_with	FBto0000403	FBrf0259000		TOOL DATA from: FBal0400506
+FBti0237789_cas	carries_tool	FBto0000349	FBrf0259307		TOOL DATA from: FBal0400548
+FBti0237789_cas	carries_tool	FBto0000356	FBrf0259307		TOOL DATA from: FBal0400548
+FBti0237790_cas	carries_tool	FBto0000349	FBrf0259307		TOOL DATA from: FBal0400549
+FBti0237790_cas	carries_tool	FBto0000356	FBrf0259307		TOOL DATA from: FBal0400549
+FBti0237800_cas	carries_tool	FBto0000349	FBrf0258976		TOOL DATA from: FBal0400583
+FBti0237800_cas	carries_tool	FBto0000356	FBrf0258976		TOOL DATA from: FBal0400583
+FBti0237801_cas	carries_tool	FBto0000349	FBrf0258976		TOOL DATA from: FBal0400584
+FBti0237801_cas	carries_tool	FBto0000356	FBrf0258976		TOOL DATA from: FBal0400584
+FBti0237802_cas	carries_tool	FBto0000349	FBrf0258976		TOOL DATA from: FBal0400581
+FBti0237802_cas	carries_tool	FBto0000356	FBrf0258976		TOOL DATA from: FBal0400581
+FBti0237803_cas	carries_tool	FBto0000349	FBrf0258976		TOOL DATA from: FBal0400582
+FBti0237803_cas	carries_tool	FBto0000356	FBrf0258976		TOOL DATA from: FBal0400582
+FBti0237804_cas	carries_tool	FBto0000349	FBrf0257308		TOOL DATA from: FBal0400604
+FBti0237804_cas	carries_tool	FBto0000356	FBrf0257308		TOOL DATA from: FBal0400604
+FBti0237811_cas	tagged_with	FBto0000622	FBrf0257429		TOOL DATA from: FBal0400616
+FBti0237812_cas	tagged_with	FBto0000622	FBrf0257429		TOOL DATA from: FBal0400617
+FBti0237842_cas	tagged_with	FBto0000031	FBrf0259207		TOOL DATA from: FBal0400701
+FBti0237844_cas	carries_tool	FBto0000349	FBrf0259101		TOOL DATA from: FBal0400717
+FBti0237844_cas	tagged_with	FBto0000031	FBrf0259101		TOOL DATA from: FBal0400717
+FBti0237849_cas	carries_tool	FBto0000349	FBrf0259048		TOOL DATA from: FBal0400722
+FBti0237849_cas	tagged_with	FBto0000063	FBrf0259048		TOOL DATA from: FBal0400722
+FBti0238052_cas	tagged_with	FBto0000031	FBrf0230588		TOOL DATA from: FBal0401053
+FBti0238063_cas	tagged_with	FBto0000118	FBrf0259138		TOOL DATA from: FBal0401075
+FBti0238077_cas	encodes_tool	FBto0000135	FBrf0259116		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238077_cas	tool_uses	promoter trap	FBrf0259116		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238083_cas	encodes_tool	FBto0000155	FBrf0259097		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238083_cas	tool_uses	promoter trap	FBrf0259097		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238084_cas	encodes_tool	FBto0000166	FBrf0259097		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238084_cas	tool_uses	promoter trap	FBrf0259097		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238085_cas	encodes_tool	FBto0000146	FBrf0259097		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238085_cas	tool_uses	promoter trap	FBrf0259097		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238103_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401180
+FBti0238103_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401180
+FBti0238104_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401181
+FBti0238104_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401181
+FBti0238105_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401182
+FBti0238105_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401182
+FBti0238106_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401183
+FBti0238106_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401183
+FBti0238107_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401184
+FBti0238107_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401184
+FBti0238108_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401185
+FBti0238108_cas	tagged_with	FBto0000077	FBrf0259157		TOOL DATA from: FBal0401185
+FBti0238109_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401186
+FBti0238109_cas	carries_tool	FBto0000349	FBrf0259157		TOOL DATA from: FBal0401187
+FBti0238389_cas	carries_tool	FBto0000349	FBrf0259229		TOOL DATA from: FBal0401679
+FBti0238389_cas	tagged_with	FBto0000118	FBrf0259229		TOOL DATA from: FBal0401679
+FBti0238390_cas	carries_tool	FBto0000349	FBrf0259229		TOOL DATA from: FBal0401680
+FBti0238390_cas	tagged_with	FBto0000030	FBrf0259229		TOOL DATA from: FBal0401680
+FBti0238396_cas	encodes_tool	FBto0000135	FBrf0259330		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238396_cas	tool_uses	promoter trap	FBrf0259330		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238400_cas	tagged_with	FBto0000077	FBrf0252098		TOOL DATA from: FBal0401731
+FBti0238401_cas	tagged_with	FBto0000027	FBrf0259266		TOOL DATA from: FBal0401752
+FBti0238401_cas	tagged_with	FBto0000076	FBrf0259266		TOOL DATA from: FBal0401752
+FBti0238402_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238402_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238402_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401794
+FBti0238402_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401868
+FBti0238403_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238403_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238403_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401795
+FBti0238403_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401872
+FBti0238404_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238404_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238404_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401796
+FBti0238404_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401876
+FBti0238405_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238405_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238405_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401797
+FBti0238405_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401878
+FBti0238406_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238406_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238406_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401798
+FBti0238406_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401882
+FBti0238407_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238407_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238407_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401799
+FBti0238407_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401887
+FBti0238408_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238408_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238408_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401800
+FBti0238408_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401891
+FBti0238409_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238409_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238409_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401801
+FBti0238409_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401895
+FBti0238410_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238410_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238410_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401802
+FBti0238410_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401898
+FBti0238411_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238411_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238411_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401803
+FBti0238411_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401900
+FBti0238412_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238412_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238412_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401804
+FBti0238412_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401903
+FBti0238413_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238413_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238413_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401805
+FBti0238413_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401907
+FBti0238414_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238414_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238414_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401806
+FBti0238414_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401911
+FBti0238415_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238415_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238415_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401807
+FBti0238415_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401915
+FBti0238416_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238416_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238416_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401808
+FBti0238416_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401921
+FBti0238417_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238417_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238417_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401809
+FBti0238417_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401925
+FBti0238418_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238418_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238418_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401810
+FBti0238418_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401929
+FBti0238419_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238419_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238419_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401811
+FBti0238419_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401869
+FBti0238420_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238420_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238420_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401812
+FBti0238420_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401879
+FBti0238421_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238421_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238421_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401813
+FBti0238421_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401883
+FBti0238422_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238422_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238422_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401814
+FBti0238422_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401888
+FBti0238423_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238423_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238423_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401815
+FBti0238423_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401892
+FBti0238424_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238424_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238424_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401816
+FBti0238424_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401896
+FBti0238425_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238425_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238425_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401817
+FBti0238425_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401901
+FBti0238426_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238426_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238426_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401818
+FBti0238426_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401904
+FBti0238427_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238427_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238427_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401819
+FBti0238427_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401908
+FBti0238428_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238428_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238428_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401820
+FBti0238428_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401912
+FBti0238429_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238429_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238429_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401821
+FBti0238429_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401916
+FBti0238430_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238430_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238430_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401822
+FBti0238430_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401922
+FBti0238431_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238431_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238431_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401823
+FBti0238431_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401926
+FBti0238432_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238432_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238432_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401824
+FBti0238432_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401930
+FBti0238433_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0168557, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238433_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0168557, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238433_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0168557, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238433_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401825
+FBti0238433_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401825
+FBti0238433_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401825
+FBti0238433_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401865
+FBti0238433_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401865
+FBti0238433_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401865
+FBti0238433_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401933
+FBti0238433_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401933
+FBti0238433_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401933
+FBti0238434_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238434_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238434_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401826
+FBti0238434_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401826
+FBti0238434_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401826
+FBti0238434_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401935
+FBti0238434_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401935
+FBti0238434_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401935
+FBti0238435_cas	encodes_tool	FBto0000153	FBrf0259179		TOOL DATA from: FBtp0168557, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238435_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0168557, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238435_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0168557, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238435_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401827
+FBti0238435_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401827
+FBti0238435_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401827
+FBti0238435_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401867
+FBti0238435_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401867
+FBti0238435_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401867
+FBti0238435_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401936
+FBti0238435_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401936
+FBti0238435_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401936
+FBti0238436_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238436_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238436_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401829
+FBti0238436_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401870
+FBti0238437_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238437_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238437_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401830
+FBti0238437_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401873
+FBti0238438_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238438_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238438_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401831
+FBti0238438_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401874
+FBti0238439_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238439_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238439_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401832
+FBti0238439_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401877
+FBti0238440_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238440_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238440_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401833
+FBti0238440_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401880
+FBti0238441_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238441_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238441_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401834
+FBti0238441_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401884
+FBti0238442_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238442_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238442_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401835
+FBti0238442_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401889
+FBti0238443_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238443_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238443_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401836
+FBti0238443_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401893
+FBti0238444_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238444_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238444_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401837
+FBti0238444_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401897
+FBti0238445_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238445_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238445_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401838
+FBti0238445_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401899
+FBti0238446_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238446_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238446_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401839
+FBti0238446_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401902
+FBti0238447_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238447_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238447_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401840
+FBti0238447_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401905
+FBti0238448_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238448_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238448_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401841
+FBti0238448_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401909
+FBti0238449_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238449_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238449_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401842
+FBti0238449_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401913
+FBti0238450_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238450_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238450_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401843
+FBti0238450_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401917
+FBti0238451_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238451_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238451_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401844
+FBti0238451_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401919
+FBti0238452_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238452_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238452_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401845
+FBti0238452_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401923
+FBti0238453_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238453_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238453_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401846
+FBti0238453_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401927
+FBti0238454_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238454_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238454_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401847
+FBti0238454_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401931
+FBti0238455_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238455_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238455_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401848
+FBti0238455_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401871
+FBti0238456_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238456_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238456_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401849
+FBti0238456_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401875
+FBti0238457_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238457_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238457_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401850
+FBti0238457_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401885
+FBti0238458_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238458_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238458_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401851
+FBti0238458_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401890
+FBti0238459_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238459_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238459_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401852
+FBti0238459_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401894
+FBti0238460_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238460_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238460_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401853
+FBti0238460_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401906
+FBti0238461_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238461_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238461_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401854
+FBti0238461_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401910
+FBti0238462_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238462_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238462_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401855
+FBti0238462_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401914
+FBti0238463_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238463_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238463_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401856
+FBti0238463_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401918
+FBti0238464_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238464_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238464_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401857
+FBti0238464_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401920
+FBti0238465_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238465_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238465_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401858
+FBti0238465_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401924
+FBti0238466_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238466_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238466_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401859
+FBti0238466_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401928
+FBti0238467_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238467_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238467_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401860
+FBti0238467_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401932
+FBti0238468_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238468_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238468_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401861
+FBti0238468_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401881
+FBti0238469_cas	encodes_tool	FBto0000168	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238469_cas	tool_uses	promoter trap	FBrf0259179		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238469_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401866
+FBti0238469_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401866
+FBti0238469_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401866
+FBti0238469_cas	carries_tool	FBto0000318	FBrf0259179		TOOL DATA from: FBal0401934
+FBti0238469_cas	carries_tool	FBto0000345	FBrf0259179		TOOL DATA from: FBal0401934
+FBti0238469_cas	carries_tool	FBto0000349	FBrf0259179		TOOL DATA from: FBal0401934
+FBti0238504_cas	encodes_tool	FBto0000135	FBrf0259095		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238504_cas	tool_uses	promoter trap	FBrf0259095		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238544_cas	carries_tool	FBto0000349	FBrf0259433		TOOL DATA from: FBal0402027
+FBti0238681_cas				FTA: unable to add tool information from FBal0402217 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0238683_cas	encodes_tool	FBto0000135	FBrf0259335		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238683_cas	tool_uses	promoter trap	FBrf0259335		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238683_cas	carries_tool	FBto0000349	FBrf0259335		TOOL DATA from: FBal0402220
+FBti0238683_cas	carries_tool	FBto0000349	FBrf0259335		TOOL DATA from: FBal0402221
+FBti0238705_cas	tagged_with	FBto0000522	FBrf0259610		TOOL DATA from: FBal0402246
+FBti0238708_cas	encodes_tool	FBto0000135	FBrf0259468		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238708_cas	tool_uses	promoter trap	FBrf0259468		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238708_cas	carries_tool	FBto0000349	FBrf0259468		TOOL DATA from: FBal0402248
+FBti0238708_cas	carries_tool	FBto0000349	FBrf0259468		TOOL DATA from: FBal0402249
+FBti0238715_cas	encodes_tool	FBto0000135	FBrf0259420		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238715_cas	tool_uses	promoter trap	FBrf0259420		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238735_cas	encodes_tool	FBto0000135	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238735_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238736_cas	encodes_tool	FBto0000135	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238736_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238737_cas	encodes_tool	FBto0000166	FBrf0249466		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238737_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238738_cas	encodes_tool	FBto0000135	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238738_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238739_cas	encodes_tool	FBto0000135	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238739_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238740_cas	encodes_tool	FBto0000135	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238740_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238741_cas	encodes_tool	FBto0000135	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238741_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238742_cas	encodes_tool	FBto0000158	FBrf0249466		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238742_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238743_cas	encodes_tool	FBto0000166	FBrf0249466		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238743_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238744_cas	encodes_tool	FBto0000135	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238744_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238745_cas	encodes_tool	FBto0000135	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238745_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238746_cas	encodes_tool	FBto0000135	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238746_cas	tool_uses	promoter trap	FBrf0249466		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238748_cas	tagged_with	FBto0000077	FBrf0259354		TOOL DATA from: FBal0402304
+FBti0238758_cas				FTA: unable to add tool information from FBal0385572 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0238767_cas	carries_tool	FBto0000349	FBrf0259550		TOOL DATA from: FBal0402337
+FBti0238767_cas	carries_tool	FBto0000356	FBrf0259550		TOOL DATA from: FBal0402337
+FBti0238767_cas	carries_tool	FBto0000349	FBrf0259550		TOOL DATA from: FBal0402338
+FBti0238767_cas	carries_tool	FBto0000356	FBrf0259550		TOOL DATA from: FBal0402338
+FBti0238768_cas	tagged_with	FBto0000063	FBrf0259445		TOOL DATA from: FBal0402346
+FBti0238770_cas	tagged_with	FBto0000031	FBrf0259669		TOOL DATA from: FBal0402363
+FBti0238771_cas	tagged_with	FBto0000031	FBrf0259669		TOOL DATA from: FBal0402364
+FBti0238793_cas	tagged_with	FBto0000063	FBrf0259481		TOOL DATA from: FBal0402405
+FBti0238794_cas	tagged_with	FBto0000063	FBrf0259481		TOOL DATA from: FBal0402408
+FBti0238795_cas	tagged_with	FBto0000039	FBrf0259481		TOOL DATA from: FBal0402410
+FBti0238795_cas	tagged_with	FBto0000389	FBrf0259481		TOOL DATA from: FBal0402410
+FBti0238866_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238866_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238866_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402484
+FBti0238866_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402484
+FBti0238866_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402820
+FBti0238866_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402820
+FBti0238867_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238867_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238867_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402486
+FBti0238867_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402486
+FBti0238867_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402821
+FBti0238867_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402821
+FBti0238868_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238868_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238868_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402488
+FBti0238868_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402488
+FBti0238868_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402822
+FBti0238868_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402822
+FBti0238869_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238869_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238869_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402493
+FBti0238869_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402493
+FBti0238869_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402823
+FBti0238869_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402823
+FBti0238870_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238870_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238870_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402496
+FBti0238870_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402496
+FBti0238870_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402824
+FBti0238870_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402824
+FBti0238871_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238871_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238871_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402498
+FBti0238871_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402498
+FBti0238871_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402825
+FBti0238871_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402825
+FBti0238872_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238872_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238872_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402500
+FBti0238872_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402500
+FBti0238872_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402826
+FBti0238872_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402826
+FBti0238873_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238873_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238873_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402502
+FBti0238873_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402502
+FBti0238873_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402827
+FBti0238873_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402827
+FBti0238874_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238874_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238874_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402504
+FBti0238874_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402504
+FBti0238874_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402828
+FBti0238874_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402828
+FBti0238875_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238875_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238875_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402506
+FBti0238875_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402506
+FBti0238875_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402829
+FBti0238875_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402829
+FBti0238876_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238876_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238876_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402508
+FBti0238876_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402508
+FBti0238876_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402830
+FBti0238876_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402830
+FBti0238877_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238877_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238877_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402510
+FBti0238877_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402510
+FBti0238877_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402831
+FBti0238877_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402831
+FBti0238878_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238878_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238878_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402512
+FBti0238878_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402512
+FBti0238878_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402832
+FBti0238878_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402832
+FBti0238879_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238879_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238879_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402514
+FBti0238879_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402514
+FBti0238879_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402833
+FBti0238879_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402833
+FBti0238880_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238880_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238880_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402516
+FBti0238880_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402516
+FBti0238880_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402834
+FBti0238880_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402834
+FBti0238881_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238881_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238881_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402518
+FBti0238881_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402518
+FBti0238881_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402835
+FBti0238881_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402835
+FBti0238882_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238882_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238882_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402520
+FBti0238882_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402520
+FBti0238882_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402836
+FBti0238882_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402836
+FBti0238883_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238883_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238883_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402523
+FBti0238883_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402523
+FBti0238883_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402837
+FBti0238883_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402837
+FBti0238884_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238884_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238884_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402525
+FBti0238884_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402525
+FBti0238884_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402838
+FBti0238884_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402838
+FBti0238885_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238885_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238885_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402527
+FBti0238885_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402527
+FBti0238885_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402839
+FBti0238885_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402839
+FBti0238886_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238886_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238886_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402529
+FBti0238886_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402529
+FBti0238886_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402840
+FBti0238886_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402840
+FBti0238887_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238887_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238887_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402534
+FBti0238887_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402534
+FBti0238887_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402841
+FBti0238887_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402841
+FBti0238888_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238888_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238888_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402536
+FBti0238888_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402536
+FBti0238888_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402842
+FBti0238888_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402842
+FBti0238889_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238889_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238889_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402540
+FBti0238889_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402540
+FBti0238889_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402843
+FBti0238889_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402843
+FBti0238890_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238890_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238890_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402542
+FBti0238890_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402542
+FBti0238890_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402844
+FBti0238890_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402844
+FBti0238891_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238891_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238891_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402544
+FBti0238891_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402544
+FBti0238891_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402845
+FBti0238891_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402845
+FBti0238892_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238892_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238892_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402547
+FBti0238892_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402547
+FBti0238892_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402846
+FBti0238892_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402846
+FBti0238893_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238893_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238893_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402549
+FBti0238893_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402549
+FBti0238893_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402847
+FBti0238893_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402847
+FBti0238894_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238894_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238894_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402551
+FBti0238894_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402551
+FBti0238894_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402848
+FBti0238894_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402848
+FBti0238895_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238895_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238895_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402553
+FBti0238895_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402553
+FBti0238895_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402849
+FBti0238895_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402849
+FBti0238896_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238896_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238896_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402555
+FBti0238896_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402555
+FBti0238896_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402850
+FBti0238896_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402850
+FBti0238897_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238897_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238897_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402558
+FBti0238897_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402558
+FBti0238897_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402851
+FBti0238897_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402851
+FBti0238898_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238898_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238898_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402560
+FBti0238898_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402560
+FBti0238898_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402852
+FBti0238898_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402852
+FBti0238899_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238899_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238899_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402562
+FBti0238899_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402562
+FBti0238899_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402853
+FBti0238899_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402853
+FBti0238900_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238900_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238900_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402566
+FBti0238900_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402566
+FBti0238900_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402854
+FBti0238900_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402854
+FBti0238901_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238901_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238901_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402568
+FBti0238901_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402568
+FBti0238901_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402855
+FBti0238901_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402855
+FBti0238902_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238902_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238902_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402571
+FBti0238902_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402571
+FBti0238902_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402856
+FBti0238902_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402856
+FBti0238903_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238903_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238903_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402573
+FBti0238903_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402573
+FBti0238903_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402857
+FBti0238903_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402857
+FBti0238904_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238904_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238904_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402575
+FBti0238904_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402575
+FBti0238904_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402858
+FBti0238904_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402858
+FBti0238905_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238905_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238905_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402578
+FBti0238905_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402578
+FBti0238905_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402859
+FBti0238905_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402859
+FBti0238906_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238906_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238906_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402580
+FBti0238906_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402580
+FBti0238906_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402860
+FBti0238906_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402860
+FBti0238907_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238907_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238907_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402582
+FBti0238907_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402582
+FBti0238907_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402861
+FBti0238907_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402861
+FBti0238908_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238908_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238908_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402584
+FBti0238908_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402584
+FBti0238908_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402862
+FBti0238908_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402862
+FBti0238909_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238909_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238909_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402586
+FBti0238909_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402586
+FBti0238909_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402863
+FBti0238909_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402863
+FBti0238910_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238910_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238910_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402588
+FBti0238910_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402588
+FBti0238910_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402864
+FBti0238910_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402864
+FBti0238911_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238911_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238911_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402591
+FBti0238911_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402591
+FBti0238911_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402865
+FBti0238911_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402865
+FBti0238912_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238912_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238912_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402593
+FBti0238912_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402593
+FBti0238912_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402866
+FBti0238912_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402866
+FBti0238913_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238913_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238913_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402599
+FBti0238913_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402599
+FBti0238913_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402867
+FBti0238913_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402867
+FBti0238914_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238914_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238914_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402601
+FBti0238914_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402601
+FBti0238914_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402868
+FBti0238914_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402868
+FBti0238915_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238915_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238915_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402603
+FBti0238915_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402603
+FBti0238915_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402869
+FBti0238915_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402869
+FBti0238916_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238916_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238916_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402607
+FBti0238916_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402607
+FBti0238916_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402870
+FBti0238916_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402870
+FBti0238917_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238917_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238917_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402611
+FBti0238917_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402611
+FBti0238917_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402871
+FBti0238917_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402871
+FBti0238918_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238918_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238918_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402613
+FBti0238918_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402613
+FBti0238918_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402872
+FBti0238918_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402872
+FBti0238919_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238919_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238919_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402615
+FBti0238919_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402615
+FBti0238919_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402873
+FBti0238919_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402873
+FBti0238920_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238920_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238920_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402619
+FBti0238920_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402619
+FBti0238920_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402874
+FBti0238920_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402874
+FBti0238921_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238921_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238921_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402621
+FBti0238921_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402621
+FBti0238921_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402875
+FBti0238921_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402875
+FBti0238922_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238922_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238922_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402623
+FBti0238922_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402623
+FBti0238922_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402876
+FBti0238922_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402876
+FBti0238923_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238923_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238923_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402625
+FBti0238923_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402625
+FBti0238923_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402877
+FBti0238923_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402877
+FBti0238924_cas	encodes_tool	FBto0000166	FBrf0259397		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238924_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238924_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402626
+FBti0238924_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402953
+FBti0238925_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238925_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238925_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402628
+FBti0238925_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402628
+FBti0238925_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402878
+FBti0238925_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402878
+FBti0238926_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238926_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238926_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402633
+FBti0238926_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402633
+FBti0238926_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402879
+FBti0238926_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402879
+FBti0238927_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238927_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238927_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402635
+FBti0238927_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402635
+FBti0238927_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402880
+FBti0238927_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402880
+FBti0238928_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238928_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238928_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402637
+FBti0238928_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402637
+FBti0238928_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402881
+FBti0238928_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402881
+FBti0238929_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238929_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238929_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402639
+FBti0238929_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402639
+FBti0238929_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402882
+FBti0238929_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402882
+FBti0238930_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238930_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238930_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402641
+FBti0238930_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402641
+FBti0238930_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402883
+FBti0238930_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402883
+FBti0238931_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238931_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238931_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402643
+FBti0238931_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402643
+FBti0238931_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402884
+FBti0238931_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402884
+FBti0238932_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238932_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238932_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402645
+FBti0238932_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402645
+FBti0238932_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402885
+FBti0238932_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402885
+FBti0238933_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238933_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238933_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402649
+FBti0238933_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402649
+FBti0238933_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402886
+FBti0238933_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402886
+FBti0238934_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238934_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238934_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402656
+FBti0238934_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402656
+FBti0238934_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402887
+FBti0238934_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402887
+FBti0238935_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238935_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238935_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402659
+FBti0238935_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402659
+FBti0238935_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402888
+FBti0238935_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402888
+FBti0238936_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238936_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238936_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402662
+FBti0238936_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402662
+FBti0238936_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402889
+FBti0238936_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402889
+FBti0238937_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238937_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238937_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402664
+FBti0238937_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402664
+FBti0238937_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402890
+FBti0238937_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402890
+FBti0238938_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238938_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238938_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402666
+FBti0238938_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402666
+FBti0238938_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402891
+FBti0238938_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402891
+FBti0238939_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238939_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238939_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402668
+FBti0238939_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402668
+FBti0238939_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402892
+FBti0238939_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402892
+FBti0238940_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238940_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238940_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402673
+FBti0238940_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402673
+FBti0238940_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402893
+FBti0238940_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402893
+FBti0238941_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238941_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238941_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402676
+FBti0238941_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402676
+FBti0238941_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402894
+FBti0238941_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402894
+FBti0238942_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238942_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238942_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402679
+FBti0238942_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402679
+FBti0238942_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402895
+FBti0238942_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402895
+FBti0238943_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238943_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238943_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402683
+FBti0238943_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402683
+FBti0238943_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402896
+FBti0238943_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402896
+FBti0238944_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238944_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238944_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402685
+FBti0238944_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402685
+FBti0238944_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402897
+FBti0238944_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402897
+FBti0238945_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238945_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238945_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402687
+FBti0238945_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402687
+FBti0238945_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402898
+FBti0238945_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402898
+FBti0238946_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238946_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238946_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402690
+FBti0238946_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402690
+FBti0238946_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402899
+FBti0238946_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402899
+FBti0238947_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238947_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238947_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402692
+FBti0238947_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402692
+FBti0238947_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402900
+FBti0238947_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402900
+FBti0238948_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238948_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238948_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402696
+FBti0238948_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402696
+FBti0238948_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402901
+FBti0238948_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402901
+FBti0238949_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238949_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238949_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402698
+FBti0238949_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402698
+FBti0238949_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402902
+FBti0238949_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402902
+FBti0238950_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238950_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238950_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402700
+FBti0238950_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402700
+FBti0238950_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402903
+FBti0238950_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402903
+FBti0238951_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238951_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238951_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402703
+FBti0238951_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402703
+FBti0238951_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402904
+FBti0238951_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402904
+FBti0238952_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238952_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238952_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402707
+FBti0238952_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402707
+FBti0238952_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402905
+FBti0238952_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402905
+FBti0238953_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238953_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238953_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402710
+FBti0238953_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402710
+FBti0238953_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402906
+FBti0238953_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402906
+FBti0238954_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238954_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238954_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402712
+FBti0238954_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402712
+FBti0238954_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402907
+FBti0238954_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402907
+FBti0238955_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238955_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238955_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402716
+FBti0238955_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402716
+FBti0238955_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402908
+FBti0238955_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402908
+FBti0238956_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238956_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238956_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402722
+FBti0238956_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402722
+FBti0238956_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402909
+FBti0238956_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402909
+FBti0238957_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238957_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238957_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402724
+FBti0238957_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402724
+FBti0238957_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402910
+FBti0238957_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402910
+FBti0238958_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238958_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238958_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402727
+FBti0238958_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402727
+FBti0238958_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402911
+FBti0238958_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402911
+FBti0238959_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238959_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238959_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402729
+FBti0238959_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402729
+FBti0238959_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402912
+FBti0238959_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402912
+FBti0238960_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238960_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238960_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402731
+FBti0238960_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402731
+FBti0238960_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402913
+FBti0238960_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402913
+FBti0238961_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238961_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238961_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402735
+FBti0238961_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402735
+FBti0238961_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402914
+FBti0238961_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402914
+FBti0238962_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238962_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238962_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402737
+FBti0238962_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402737
+FBti0238962_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402915
+FBti0238962_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402915
+FBti0238963_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238963_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238963_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402740
+FBti0238963_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402740
+FBti0238963_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402916
+FBti0238963_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402916
+FBti0238964_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238964_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238964_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402742
+FBti0238964_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402742
+FBti0238964_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402917
+FBti0238964_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402917
+FBti0238965_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238965_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238965_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402744
+FBti0238965_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402744
+FBti0238965_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402918
+FBti0238965_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402918
+FBti0238966_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238966_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238966_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402746
+FBti0238966_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402746
+FBti0238966_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402919
+FBti0238966_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402919
+FBti0238967_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238967_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238967_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402749
+FBti0238967_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402749
+FBti0238967_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402920
+FBti0238967_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402920
+FBti0238968_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238968_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238968_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402752
+FBti0238968_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402752
+FBti0238968_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402921
+FBti0238968_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402921
+FBti0238969_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238969_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238969_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402755
+FBti0238969_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402755
+FBti0238969_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402922
+FBti0238969_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402922
+FBti0238970_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238970_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238970_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402759
+FBti0238970_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402759
+FBti0238970_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402923
+FBti0238970_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402923
+FBti0238971_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238971_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238971_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402761
+FBti0238971_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402761
+FBti0238971_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402924
+FBti0238971_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402924
+FBti0238972_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238972_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238972_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402763
+FBti0238972_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402763
+FBti0238972_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402925
+FBti0238972_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402925
+FBti0238973_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238973_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238973_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402765
+FBti0238973_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402765
+FBti0238973_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402926
+FBti0238973_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402926
+FBti0238974_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238974_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238974_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402768
+FBti0238974_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402768
+FBti0238974_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402927
+FBti0238974_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402927
+FBti0238975_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238975_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238975_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402771
+FBti0238975_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402771
+FBti0238975_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402928
+FBti0238975_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402928
+FBti0238976_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238976_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238976_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402774
+FBti0238976_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402774
+FBti0238976_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402929
+FBti0238976_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402929
+FBti0238977_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238977_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238977_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402777
+FBti0238977_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402777
+FBti0238977_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402930
+FBti0238977_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402930
+FBti0238978_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238978_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238978_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402779
+FBti0238978_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402779
+FBti0238978_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402931
+FBti0238978_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402931
+FBti0238979_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238979_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238979_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402781
+FBti0238979_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402781
+FBti0238979_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402932
+FBti0238979_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402932
+FBti0238980_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238980_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238980_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402784
+FBti0238980_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402784
+FBti0238980_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402933
+FBti0238980_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402933
+FBti0238981_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238981_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238981_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402786
+FBti0238981_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402786
+FBti0238981_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402934
+FBti0238981_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402934
+FBti0238982_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238982_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238982_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402790
+FBti0238982_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402790
+FBti0238982_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402935
+FBti0238982_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402935
+FBti0238983_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238983_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238983_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402792
+FBti0238983_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402792
+FBti0238983_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402936
+FBti0238983_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402936
+FBti0238984_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238984_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238984_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402796
+FBti0238984_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402796
+FBti0238984_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402937
+FBti0238984_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402937
+FBti0238985_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238985_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238985_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402798
+FBti0238985_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402798
+FBti0238985_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402938
+FBti0238985_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402938
+FBti0238986_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238986_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238986_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402800
+FBti0238986_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402800
+FBti0238986_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402939
+FBti0238986_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402939
+FBti0238987_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238987_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238987_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402803
+FBti0238987_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402803
+FBti0238987_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402940
+FBti0238987_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402940
+FBti0238988_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238988_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238988_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402805
+FBti0238988_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402805
+FBti0238988_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402941
+FBti0238988_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402941
+FBti0238989_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238989_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238989_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402807
+FBti0238989_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402807
+FBti0238989_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402942
+FBti0238989_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402942
+FBti0238990_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238990_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238990_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402809
+FBti0238990_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402809
+FBti0238990_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402943
+FBti0238990_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402943
+FBti0238991_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238991_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238991_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402811
+FBti0238991_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402811
+FBti0238991_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402944
+FBti0238991_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402944
+FBti0238992_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238992_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238992_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402813
+FBti0238992_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402813
+FBti0238992_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402945
+FBti0238992_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402945
+FBti0238993_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238993_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238993_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402815
+FBti0238993_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402815
+FBti0238993_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402946
+FBti0238993_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402946
+FBti0238994_cas	encodes_tool	FBto0000027	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238994_cas	tool_uses	promoter trap	FBrf0259397		TOOL DATA from: FBtp0143820, used single pub_curie from FBti->FBtp producedby f_r
+FBti0238994_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402819
+FBti0238994_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402819
+FBti0238994_cas	carries_tool	FBto0000318	FBrf0259397		TOOL DATA from: FBal0402947
+FBti0238994_cas	carries_tool	FBto0000349	FBrf0259397		TOOL DATA from: FBal0402947
+FBti0239341_cas	encodes_tool	FBto0000153	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239341_cas	tool_uses	promoter trap	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239341_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403122
+FBti0239341_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403125
+FBti0239342_cas	encodes_tool	FBto0000153	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239342_cas	tool_uses	promoter trap	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239342_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403123
+FBti0239342_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403126
+FBti0239343_cas	encodes_tool	FBto0000153	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239343_cas	tool_uses	promoter trap	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239343_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403124
+FBti0239343_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403127
+FBti0239344_cas	encodes_tool	FBto0000153	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239344_cas	tool_uses	promoter trap	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239344_cas	carries_tool	FBto0000318	FBrf0259812		TOOL DATA from: FBal0403128
+FBti0239344_cas	carries_tool	FBto0000345	FBrf0259812		TOOL DATA from: FBal0403128
+FBti0239344_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403128
+FBti0239344_cas	carries_tool	FBto0000318	FBrf0259812		TOOL DATA from: FBal0403130
+FBti0239344_cas	carries_tool	FBto0000345	FBrf0259812		TOOL DATA from: FBal0403130
+FBti0239344_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403130
+FBti0239345_cas	encodes_tool	FBto0000153	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239345_cas	tool_uses	promoter trap	FBrf0259812		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239345_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403129
+FBti0239345_cas	carries_tool	FBto0000349	FBrf0259812		TOOL DATA from: FBal0403131
+FBti0239355_cas	carries_tool	FBto0000318	FBrf0259520		TOOL DATA from: FBal0403150
+FBti0239355_cas	tagged_with	FBto0000076	FBrf0259520		TOOL DATA from: FBal0403150
+FBti0239356_cas	encodes_tool	FBto0000140	FBrf0250180		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239356_cas	tool_uses	promoter trap	FBrf0250180		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239356_cas	carries_tool	FBto0000349	FBrf0250180		TOOL DATA from: FBal0403171
+FBti0239356_cas	carries_tool	FBto0000349	FBrf0250180		TOOL DATA from: FBal0403172
+FBti0239364_cas	tagged_with	FBto0000077	FBrf0259319		TOOL DATA from: FBal0403255
+FBti0239440_cas	tagged_with	FBto0000077	FBrf0243163		TOOL DATA from: FBal0403392
+FBti0239441_cas	tagged_with	FBto0000014	FBrf0243937		TOOL DATA from: FBal0403393
+FBti0239442_cas	tagged_with	FBto0000014	FBrf0243937		TOOL DATA from: FBal0403394
+FBti0239443_cas	tagged_with	FBto0000014	FBrf0243937		TOOL DATA from: FBal0403395
+FBti0239444_cas	tagged_with	FBto0000118	FBrf0243937		TOOL DATA from: FBal0403396
+FBti0239484_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239484_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239485_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239485_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239486_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239486_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239487_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239487_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239488_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239488_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239489_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239489_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239490_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239490_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239491_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239491_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239492_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239492_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239493_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239493_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239494_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239494_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239495_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239495_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239496_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239496_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239497_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239497_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239498_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239498_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239499_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239499_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239500_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239500_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239501_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239501_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239502_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239502_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239503_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239503_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239504_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239504_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239505_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239505_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239506_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239506_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239507_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239507_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239508_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239508_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239509_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239509_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239510_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239510_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239511_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239511_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239512_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239512_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239513_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239513_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239514_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239514_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239515_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239515_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239516_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239516_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239517_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239517_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239518_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239518_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239519_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239519_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239520_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239520_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239521_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239521_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239522_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239522_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239523_cas	encodes_tool	FBto0000146	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239523_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239524_cas	encodes_tool	FBto0000166	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239524_cas	tool_uses	promoter trap	FBrf0259910		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239528_cas	tagged_with	FBto0000076	FBrf0259912		TOOL DATA from: FBal0403640
+FBti0239529_cas	carries_tool	FBto0000349	FBrf0253579		TOOL DATA from: FBal0403641
+FBti0239529_cas	carries_tool	FBto0000356	FBrf0253579		TOOL DATA from: FBal0403641
+FBti0239530_cas				FTA: unable to add tool information from FBal0403642 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403645 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239530_cas				FTA: unable to add tool information from FBal0403647 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239531_cas				FTA: unable to add tool information from FBal0403643 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239532_cas				FTA: unable to add tool information from FBal0403644 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239532_cas				FTA: unable to add tool information from FBal0403653 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239533_cas				FTA: unable to add tool information from FBal0403645 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239534_cas				FTA: unable to add tool information from FBal0403646 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239535_cas				FTA: unable to add tool information from FBal0403647 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239536_cas	carries_tool	FBto0000349	FBrf0253579		TOOL DATA from: FBal0403649
+FBti0239536_cas	carries_tool	FBto0000356	FBrf0253579		TOOL DATA from: FBal0403649
+FBti0239537_cas				FTA: unable to add tool information from FBal0403650 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403651 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403652 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403653 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403654 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403655 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239537_cas				FTA: unable to add tool information from FBal0403656 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239538_cas				FTA: unable to add tool information from FBal0403651 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239539_cas				FTA: unable to add tool information from FBal0403652 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239540_cas				FTA: unable to add tool information from FBal0403654 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239541_cas				FTA: unable to add tool information from FBal0403655 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239542_cas				FTA: unable to add tool information from FBal0403656 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239543_cas				FTA: unable to add tool information from FBal0403657 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239544_cas				FTA: unable to add tool information from FBal0403658 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403661 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403662 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403663 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403664 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239545_cas				FTA: unable to add tool information from FBal0403665 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239546_cas				FTA: unable to add tool information from FBal0403662 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239547_cas				FTA: unable to add tool information from FBal0403663 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239548_cas				FTA: unable to add tool information from FBal0403664 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239549_cas				FTA: unable to add tool information from FBal0403665 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239555_cas	tagged_with	FBto0000077	FBrf0259596		TOOL DATA from: FBal0403667
+FBti0239564_cas	carries_tool	FBto0000349	FBrf0259569		TOOL DATA from: FBal0403677
+FBti0239565_cas	carries_tool	FBto0000349	FBrf0259569		TOOL DATA from: FBal0403678
+FBti0239566_cas	carries_tool	FBto0000349	FBrf0259569		TOOL DATA from: FBal0403679
+FBti0239567_cas	carries_tool	FBto0000349	FBrf0234540		TOOL DATA from: FBal0403753
+FBti0239567_cas	tagged_with	FBto0000389	FBrf0234540		TOOL DATA from: FBal0403753
+FBti0239611_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403808
+FBti0239611_cas	carries_tool	FBto0000356	FBrf0239437		TOOL DATA from: FBal0403808
+FBti0239612_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403809
+FBti0239613_cas	carries_tool	FBto0000318	FBrf0239437		TOOL DATA from: FBal0403810
+FBti0239613_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403810
+FBti0239613_cas	tagged_with	FBto0000009	FBrf0239437		TOOL DATA from: FBal0403810
+FBti0239614_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403811
+FBti0239614_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403814
+FBti0239615_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403812
+FBti0239616_cas	carries_tool	FBto0000349	FBrf0239437		TOOL DATA from: FBal0403813
+FBti0239633_cas	carries_tool	FBto0000356	FBrf0239945		TOOL DATA from: FBal0403834
+FBti0239634_cas	tagged_with	FBto0000039	FBrf0239945		TOOL DATA from: FBal0403835
+FBti0239634_cas	tagged_with	FBto0000389	FBrf0239945		TOOL DATA from: FBal0403835
+FBti0239683_cas	carries_tool	FBto0000349	FBrf0255958		TOOL DATA from: FBal0404045
+FBti0239684_cas	carries_tool	FBto0000349	FBrf0255958		TOOL DATA from: FBal0404046
+FBti0239685_cas	carries_tool	FBto0000349	FBrf0258248		TOOL DATA from: FBal0404073
+FBti0239685_cas	carries_tool	FBto0000356	FBrf0258248		TOOL DATA from: FBal0404073
+FBti0239781_cas	encodes_tool	FBto0000168	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239781_cas	tool_uses	promoter trap	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239781_cas	tagged_with	FBto0000318	FBrf0260008		TOOL DATA from: FBal0404409
+FBti0239781_cas	tagged_with	FBto0000345	FBrf0260008		TOOL DATA from: FBal0404409
+FBti0239781_cas	tagged_with	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404409
+FBti0239781_cas	tagged_with	FBto0000318	FBrf0260008		TOOL DATA from: FBal0404412
+FBti0239781_cas	tagged_with	FBto0000345	FBrf0260008		TOOL DATA from: FBal0404412
+FBti0239781_cas	tagged_with	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404412
+FBti0239782_cas	encodes_tool	FBto0000168	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239782_cas	tool_uses	promoter trap	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239782_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404410
+FBti0239782_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404413
+FBti0239783_cas	encodes_tool	FBto0000168	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239783_cas	tool_uses	promoter trap	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239783_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404411
+FBti0239783_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404414
+FBti0239784_cas	encodes_tool	FBto0000168	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239784_cas	tool_uses	promoter trap	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239784_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404415
+FBti0239784_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404417
+FBti0239785_cas	encodes_tool	FBto0000168	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239785_cas	tool_uses	promoter trap	FBrf0260008		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239785_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404416
+FBti0239785_cas	carries_tool	FBto0000349	FBrf0260008		TOOL DATA from: FBal0404418
+FBti0239786_cas	carries_tool	FBto0000356	FBrf0259727		TOOL DATA from: FBal0404420
+FBti0239787_cas	tagged_with	FBto0000585	FBrf0259727		TOOL DATA from: FBal0404421
+FBti0239788_cas	tagged_with	FBto0000585	FBrf0259727		TOOL DATA from: FBal0404424
+FBti0239789_cas	tagged_with	FBto0000585	FBrf0259727		TOOL DATA from: FBal0404423
+FBti0239790_cas	tagged_with	FBto0000031	FBrf0259713		TOOL DATA from: FBal0404425
+FBti0239791_cas				FTA: unable to add tool information from FBal0404426 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239792_cas	carries_tool	FBto0000349	FBrf0259693		TOOL DATA from: FBal0404427
+FBti0239792_cas	carries_tool	FBto0000356	FBrf0259693		TOOL DATA from: FBal0404427
+FBti0239793_cas				FTA: unable to add tool information from FBal0404428 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239794_cas				FTA: unable to add tool information from FBal0404429 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239795_cas				FTA: unable to add tool information from FBal0404430 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239835_cas	carries_tool	FBto0000318	FBrf0248654		TOOL DATA from: FBtp0165470, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239843_cas	encodes_tool	FBto0000155	FBrf0259889		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239843_cas	tool_uses	promoter trap	FBrf0259889		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239844_cas	tagged_with	FBto0000077	FBrf0259771		TOOL DATA from: FBal0404527
+FBti0239845_cas	carries_tool	FBto0000349	FBrf0259747		TOOL DATA from: FBal0404529
+FBti0239845_cas	tagged_with	FBto0000077	FBrf0259747		TOOL DATA from: FBal0404529
+FBti0239863_cas	carries_tool	FBto0000349	FBrf0259998		TOOL DATA from: FBal0404579
+FBti0239863_cas	carries_tool	FBto0000356	FBrf0259998		TOOL DATA from: FBal0404579
+FBti0239863_cas	tagged_with	FBto0000121	FBrf0259998		TOOL DATA from: FBal0404579
+FBti0239868_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404585
+FBti0239869_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404586
+FBti0239870_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404587
+FBti0239871_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404588
+FBti0239872_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404589
+FBti0239873_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404590
+FBti0239874_cas	tagged_with	FBto0000046	FBrf0259956		TOOL DATA from: FBal0404591
+FBti0239875_cas	tagged_with	FBto0000076	FBrf0259853		TOOL DATA from: FBal0404596
+FBti0239877_cas				FTA: unable to add tool information from FBal0404594 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239877_cas				FTA: unable to add tool information from FBal0404595 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0239878_cas	tagged_with	FBto0000027	FBrf0259950		TOOL DATA from: FBal0404599
+FBti0239880_cas	carries_tool	FBto0000349	FBrf0259943		TOOL DATA from: FBal0404618
+FBti0239880_cas	carries_tool	FBto0000356	FBrf0259943		TOOL DATA from: FBal0404618
+FBti0239881_cas	carries_tool	FBto0000349	FBrf0259943		TOOL DATA from: FBal0404619
+FBti0239881_cas	carries_tool	FBto0000356	FBrf0259943		TOOL DATA from: FBal0404619
+FBti0239962_cas	encodes_tool	FBto0000166	FBrf0258826		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239962_cas	tool_uses	promoter trap	FBrf0258826		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239963_cas	encodes_tool	FBto0000166	FBrf0258826		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239963_cas	tool_uses	promoter trap	FBrf0258826		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0239964_cas				FTA: unable to add tool information from FBal0404833 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0240012_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404878
+FBti0240012_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404878
+FBti0240012_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404878
+FBti0240013_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404879
+FBti0240013_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404879
+FBti0240014_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404880
+FBti0240014_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404880
+FBti0240014_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404880
+FBti0240015_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404881
+FBti0240015_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404881
+FBti0240016_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404882
+FBti0240016_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404882
+FBti0240016_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404882
+FBti0240017_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404883
+FBti0240017_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404883
+FBti0240018_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404884
+FBti0240018_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404884
+FBti0240018_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404884
+FBti0240019_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404885
+FBti0240019_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404885
+FBti0240020_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404886
+FBti0240020_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404886
+FBti0240020_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404886
+FBti0240021_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404887
+FBti0240021_cas	tagged_with	FBto0000936	FBrf0260194		TOOL DATA from: FBal0404887
+FBti0240022_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404888
+FBti0240022_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404888
+FBti0240022_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404888
+FBti0240023_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404889
+FBti0240023_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404889
+FBti0240024_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404890
+FBti0240024_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404890
+FBti0240024_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404890
+FBti0240025_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404891
+FBti0240025_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404891
+FBti0240026_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404892
+FBti0240026_cas	carries_tool	FBto0000349	FBrf0260194		TOOL DATA from: FBal0404892
+FBti0240026_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404892
+FBti0240027_cas	carries_tool	FBto0000323	FBrf0260194		TOOL DATA from: FBal0404893
+FBti0240027_cas	tagged_with	FBto0000093	FBrf0260194		TOOL DATA from: FBal0404893
+FBti0240110_cas	tagged_with	FBto0000063	FBrf0260068		TOOL DATA from: FBal0405043
+FBti0240126_cas	tagged_with	FBto0000638	FBrf0260205		TOOL DATA from: FBal0405061
+FBti0240131_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405068
+FBti0240132_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405069
+FBti0240133_cas	tagged_with	FBto0000541	FBrf0260212		TOOL DATA from: FBal0405070
+FBti0240134_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405071
+FBti0240135_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405072
+FBti0240136_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405073
+FBti0240137_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405074
+FBti0240138_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405075
+FBti0240139_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405076
+FBti0240140_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405077
+FBti0240141_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405078
+FBti0240142_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405079
+FBti0240143_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405080
+FBti0240144_cas	tagged_with	FBto0000126	FBrf0260212		TOOL DATA from: FBal0405081
+FBti0240145_cas	tagged_with	FBto0000522	FBrf0260212		TOOL DATA from: FBal0405082
+FBti0240146_cas	tagged_with	FBto0000057	FBrf0260212		TOOL DATA from: FBal0405083
+FBti0240170_cas				FTA: unable to add tool information from FBal0405123 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0240170_cas				FTA: unable to add tool information from FBal0405124 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0240171_cas	tagged_with	FBto0000031	FBrf0260123		TOOL DATA from: FBal0405125
+FBti0240172_cas	tagged_with	FBto0000076	FBrf0260014		TOOL DATA from: FBal0405128
+FBti0240172_cas	tagged_with	FBto0000077	FBrf0260014		TOOL DATA from: FBal0405128
+FBti0244400_cas				FTA: unable to add tool information from FBal0405203 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0244402_cas	tagged_with	FBto0000936	FBrf0260098		TOOL DATA from: FBal0405217
+FBti0244403_cas	tagged_with	FBto0000936	FBrf0260098		TOOL DATA from: FBal0405218
+FBti0244419_cas	encodes_tool	FBto0000135	FBrf0260208		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244419_cas	tool_uses	promoter trap	FBrf0260208		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244420_cas	encodes_tool	FBto0000135	FBrf0260208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244420_cas	tool_uses	promoter trap	FBrf0260208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244421_cas	encodes_tool	FBto0000135	FBrf0260208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244421_cas	tool_uses	promoter trap	FBrf0260208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244422_cas	encodes_tool	FBto0000135	FBrf0260208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244422_cas	tool_uses	promoter trap	FBrf0260208		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244423_cas	encodes_tool	FBto0000155	FBrf0260208		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244423_cas	tool_uses	promoter trap	FBrf0260208		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0244425_cas	carries_tool	FBto0000318	FBrf0260208		TOOL DATA from: FBal0405244
+FBti0244426_cas	carries_tool	FBto0000318	FBrf0260208		TOOL DATA from: FBal0405245
+FBti0244431_cas	carries_tool	FBto0000318	FBrf0260208		TOOL DATA from: FBal0405250
+FBti0244433_cas	carries_tool	FBto0000349	FBrf0260208		TOOL DATA from: FBal0405252
+FBti0244433_cas	carries_tool	FBto0000356	FBrf0260208		TOOL DATA from: FBal0405252
+FBti0244442_cas	tagged_with	FBto0000076	FBrf0260166		TOOL DATA from: FBal0405273
+FBti0244442_cas	tagged_with	FBto0000077	FBrf0260166		TOOL DATA from: FBal0405273
+FBti0244443_cas	tagged_with	FBto0000076	FBrf0260166		TOOL DATA from: FBal0405274
+FBti0244443_cas	tagged_with	FBto0000077	FBrf0260166		TOOL DATA from: FBal0405274
+FBti0244448_cas	tagged_with	FBto0000027	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244448_cas	tagged_with	FBto0000076	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244448_cas	tagged_with	FBto0000088	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244448_cas	tagged_with	FBto0000287	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244448_cas	tagged_with	FBto0000341	FBrf0260139		TOOL DATA from: FBal0405290
+FBti0244453_cas	tagged_with	FBto0000077	FBrf0258187		TOOL DATA from: FBal0405295
+FBti0244454_cas	tagged_with	FBto0000077	FBrf0258187		TOOL DATA from: FBal0405296
+FBti0247797_cas	tagged_with	FBto0000623	FBrf0257180		TOOL DATA from: FBal0405375
+FBti0247804_cas	carries_tool	FBto0000349	FBrf0257043		TOOL DATA from: FBal0405382
+FBti0247805_cas	carries_tool	FBto0000349	FBrf0257043		TOOL DATA from: FBal0405383
+FBti0247806_cas	encodes_tool	FBto0000143	FBrf0260325		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247806_cas	tool_uses	promoter trap	FBrf0260325		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247806_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405386
+FBti0247806_cas	carries_tool	FBto0000356	FBrf0260325		TOOL DATA from: FBal0405386
+FBti0247806_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405392
+FBti0247806_cas	carries_tool	FBto0000356	FBrf0260325		TOOL DATA from: FBal0405392
+FBti0247807_cas	encodes_tool	FBto0000143	FBrf0260325		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247807_cas	tool_uses	promoter trap	FBrf0260325		TOOL DATA from: FBtp0132059, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247807_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405387
+FBti0247807_cas	carries_tool	FBto0000356	FBrf0260325		TOOL DATA from: FBal0405387
+FBti0247807_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405398
+FBti0247807_cas	carries_tool	FBto0000356	FBrf0260325		TOOL DATA from: FBal0405398
+FBti0247808_cas	tagged_with	FBto0000031	FBrf0260325		TOOL DATA from: FBal0405393
+FBti0247809_cas	carries_tool	FBto0000349	FBrf0260325		TOOL DATA from: FBal0405397
+FBti0247810_cas	tagged_with	FBto0000031	FBrf0260325		TOOL DATA from: FBal0405399
+FBti0247829_cas	carries_tool	FBto0000356	FBrf0260193		TOOL DATA from: FBal0405407
+FBti0247843_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247843_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247843_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405421
+FBti0247843_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405430
+FBti0247844_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247844_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247844_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405422
+FBti0247844_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405431
+FBti0247845_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247845_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247845_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405423
+FBti0247845_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405432
+FBti0247846_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247846_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247846_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405424
+FBti0247846_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405433
+FBti0247847_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247847_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247847_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405425
+FBti0247847_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405434
+FBti0247848_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247848_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247848_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405426
+FBti0247848_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405435
+FBti0247849_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247849_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247849_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405427
+FBti0247849_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405436
+FBti0247850_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247850_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247850_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405428
+FBti0247850_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405437
+FBti0247851_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247851_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247851_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405429
+FBti0247851_cas	carries_tool	FBto0000349	FBrf0260470		TOOL DATA from: FBal0405441
+FBti0247852_cas				FTA: unable to add tool information from FBal0405440 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0247853_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247853_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247854_cas	encodes_tool	FBto0000155	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247854_cas	tool_uses	promoter trap	FBrf0260470		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0247864_cas	tagged_with	FBto0000516	FBrf0260345		TOOL DATA from: FBal0405479
+FBti0248000_cas	carries_tool	FBto0000356	FBrf0260492		TOOL DATA from: FBal0405672
+FBti0248001_cas	tagged_with	FBto0000077	FBrf0260492		TOOL DATA from: FBal0405673
+FBti0248002_cas	tagged_with	FBto0000077	FBrf0260492		TOOL DATA from: FBal0405674
+FBti0248003_cas	tagged_with	FBto0000077	FBrf0260492		TOOL DATA from: FBal0405675
+FBti0248015_cas	carries_tool	FBto0000318	FBrf0260379		TOOL DATA from: FBal0405688
+FBti0248015_cas	carries_tool	FBto0000904	FBrf0260379		TOOL DATA from: FBal0405688
+FBti0248016_cas	encodes_tool	FBto0000907	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248016_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161476, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248017_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248017_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248018_cas	encodes_tool	FBto0000908	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248018_cas	tool_uses	promoter trap	FBrf0259909		TOOL DATA from: FBtp0161477, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248027_cas	carries_tool	FBto0000318	FBrf0260479		TOOL DATA from: FBal0405713
+FBti0248028_cas	carries_tool	FBto0000318	FBrf0260479		TOOL DATA from: FBal0405714
+FBti0248034_cas	tagged_with	FBto0000070	FBrf0260317		TOOL DATA from: FBal0405733
+FBti0248037_cas	carries_tool	FBto0000318	FBrf0260549		TOOL DATA from: FBal0405768
+FBti0248038_cas	encodes_tool	FBto0000135	FBrf0260414		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248038_cas	tool_uses	promoter trap	FBrf0260414		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248039_cas	encodes_tool	FBto0000155	FBrf0260414		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248039_cas	tool_uses	promoter trap	FBrf0260414		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248041_cas	tagged_with	FBto0000093	FBrf0260397		TOOL DATA from: FBal0405782
+FBti0248041_cas	tagged_with	FBto0000403	FBrf0260397		TOOL DATA from: FBal0405782
+FBti0248058_cas	encodes_tool	FBto0000146	FBrf0260396		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248058_cas	tool_uses	promoter trap	FBrf0260396		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248058_cas	carries_tool	FBto0000318	FBrf0260396		TOOL DATA from: FBal0405842
+FBti0248058_cas	carries_tool	FBto0000356	FBrf0260396		TOOL DATA from: FBal0405842
+FBti0248058_cas	carries_tool	FBto0000318	FBrf0260396		TOOL DATA from: FBal0405845
+FBti0248058_cas	carries_tool	FBto0000356	FBrf0260396		TOOL DATA from: FBal0405845
+FBti0248059_cas	encodes_tool	FBto0000135	FBrf0260396		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248059_cas	tool_uses	promoter trap	FBrf0260396		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248072_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405886
+FBti0248073_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405887
+FBti0248074_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405888
+FBti0248075_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405889
+FBti0248076_cas	tagged_with	FBto0000076	FBrf0260621		TOOL DATA from: FBal0405890
+FBti0248077_cas	tagged_with	FBto0000104	FBrf0260621		TOOL DATA from: FBal0405891
+FBti0248078_cas				FTA: unable to add tool information from FBal0405892 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248113_cas	tagged_with	FBto0000077	FBrf0260221		TOOL DATA from: FBal0405984
+FBti0248114_cas	tagged_with	FBto0000077	FBrf0260221		TOOL DATA from: FBal0405987
+FBti0248123_cas				FTA: unable to add tool information from FBal0406034 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248124_cas				FTA: unable to add tool information from FBal0406035 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248125_cas				FTA: unable to add tool information from FBal0406036 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248137_cas	carries_tool	FBto0000031	FBrf0243812		TOOL DATA from: FBal0406048
+FBti0248138_cas	encodes_tool	FBto0000031	FBrf0243812		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248138_cas	tool_uses	promoter trap	FBrf0243812		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248159_cas	tagged_with	FBto0000077	FBrf0260629		TOOL DATA from: FBal0406072
+FBti0248159_cas	tagged_with	FBto0000083	FBrf0260629		TOOL DATA from: FBal0406072
+FBti0248160_cas	tagged_with	FBto0000093	FBrf0260484		TOOL DATA from: FBal0406074
+FBti0248161_cas	tagged_with	FBto0000093	FBrf0260484		TOOL DATA from: FBal0406075
+FBti0248162_cas	tagged_with	FBto0000093	FBrf0260484		TOOL DATA from: FBal0406076
+FBti0248163_cas	tagged_with	FBto0000121	FBrf0260484		TOOL DATA from: FBal0406077
+FBti0248164_cas	tagged_with	FBto0000522	FBrf0260484		TOOL DATA from: FBal0406078
+FBti0248186_cas	tagged_with	FBto0000027	FBrf0260703		TOOL DATA from: FBal0406106
+FBti0248187_cas				FTA: unable to add tool information from FBal0406116 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248197_cas				FTA: unable to add tool information from FBal0406129 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248198_cas				FTA: unable to add tool information from FBal0406130 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248199_cas	tagged_with	FBto0001007	FBrf0260195		TOOL DATA from: FBal0406131
+FBti0248200_cas	tagged_with	FBto0001007	FBrf0260195		TOOL DATA from: FBal0406132
+FBti0248201_cas	tagged_with	FBto0001007	FBrf0260195		TOOL DATA from: FBal0406133
+FBti0248202_cas	tagged_with	FBto0001007	FBrf0260195		TOOL DATA from: FBal0406134
+FBti0248205_cas				FTA: unable to add tool information from FBal0406137 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248206_cas				FTA: unable to add tool information from FBal0406138 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248207_cas				FTA: unable to add tool information from FBal0406139 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248208_cas				FTA: unable to add tool information from FBal0406140 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248209_cas				FTA: unable to add tool information from FBal0406141 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248211_cas	encodes_tool	FBto0000135	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248211_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248212_cas	encodes_tool	FBto0000135	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248212_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248213_cas	encodes_tool	FBto0000777	FBrf0259738		TOOL DATA from: FBtp0171321, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248213_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0171321, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248214_cas	encodes_tool	FBto0000777	FBrf0259738		TOOL DATA from: FBtp0171321, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248214_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0171321, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248220_cas	encodes_tool	FBto0000135	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248220_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248221_cas	encodes_tool	FBto0000146	FBrf0259738		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248221_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248222_cas	encodes_tool	FBto0000135	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248222_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248223_cas	encodes_tool	FBto0000135	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248223_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248224_cas	encodes_tool	FBto0000135	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248224_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248225_cas	encodes_tool	FBto0000161	FBrf0259738		TOOL DATA from: FBtp0171320, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248225_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0171320, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248226_cas	encodes_tool	FBto0000161	FBrf0259738		TOOL DATA from: FBtp0171320, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248226_cas	tool_uses	promoter trap	FBrf0259738		TOOL DATA from: FBtp0171320, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248247_cas	tagged_with	FBto0000102	FBrf0256977		TOOL DATA from: FBal0406220
+FBti0248261_cas	tagged_with	FBto0000076	FBrf0260259		TOOL DATA from: FBal0406249
+FBti0248261_cas	tagged_with	FBto0000077	FBrf0260259		TOOL DATA from: FBal0406249
+FBti0248262_cas	tagged_with	FBto0000076	FBrf0260259		TOOL DATA from: FBal0406250
+FBti0248262_cas	tagged_with	FBto0000077	FBrf0260259		TOOL DATA from: FBal0406250
+FBti0248263_cas	tagged_with	FBto0000077	FBrf0260618		TOOL DATA from: FBal0406273
+FBti0248263_cas	tagged_with	FBto0000936	FBrf0260618		TOOL DATA from: FBal0406273
+FBti0248264_cas	tagged_with	FBto0000077	FBrf0260618		TOOL DATA from: FBal0406275
+FBti0248264_cas	tagged_with	FBto0000936	FBrf0260618		TOOL DATA from: FBal0406275
+FBti0248266_cas	tagged_with	FBto0000063	FBrf0260618		TOOL DATA from: FBal0406277
+FBti0248267_cas	carries_tool	FBto0000349	FBrf0260618		TOOL DATA from: FBal0406278
+FBti0248269_cas	tagged_with	FBto0000118	FBrf0260618		TOOL DATA from: FBal0406280
+FBti0248271_cas	tagged_with	FBto0000063	FBrf0260618		TOOL DATA from: FBal0406282
+FBti0248273_cas	tagged_with	FBto0000063	FBrf0260618		TOOL DATA from: FBal0406284
+FBti0248291_cas	encodes_tool	FBto0000385	FBrf0260700		TOOL DATA from: FBtp0171399, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248291_cas	tool_uses	promoter trap	FBrf0260700		TOOL DATA from: FBtp0171399, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248319_cas				FTA: unable to add tool information from FBal0406444 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248320_cas	tagged_with	FBto0000093	FBrf0260878		TOOL DATA from: FBal0406445
+FBti0248326_cas	carries_tool	FBto0000349	FBrf0260416		TOOL DATA from: FBal0406462
+FBti0248327_cas	tagged_with	FBto0000031	FBrf0260738		TOOL DATA from: FBal0406481
+FBti0248328_cas	tagged_with	FBto0000031	FBrf0260738		TOOL DATA from: FBal0406482
+FBti0248350_cas	tagged_with	FBto0000070	FBrf0261147		TOOL DATA from: FBal0406527
+FBti0248350_cas	tagged_with	FBto0000077	FBrf0261147		TOOL DATA from: FBal0406527
+FBti0248351_cas	tagged_with	FBto0000031	FBrf0260924		TOOL DATA from: FBal0406535
+FBti0248352_cas	carries_tool	FBto0000349	FBrf0260937		TOOL DATA from: FBal0406544
+FBti0248352_cas	tagged_with	FBto0000063	FBrf0260937		TOOL DATA from: FBal0406544
+FBti0248355_cas				FTA: unable to add tool information from FBal0406556 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248356_cas				FTA: unable to add tool information from FBal0406559 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248358_cas				FTA: unable to add tool information from FBal0406581 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248359_cas				FTA: unable to add tool information from FBal0406582 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248419_cas	carries_tool	FBto0000349	FBrf0260910		TOOL DATA from: FBal0406708
+FBti0248419_cas	tagged_with	FBto0000118	FBrf0260910		TOOL DATA from: FBal0406708
+FBti0248422_cas	carries_tool	FBto0000349	FBrf0260993		TOOL DATA from: FBal0406715
+FBti0248422_cas	carries_tool	FBto0000356	FBrf0260993		TOOL DATA from: FBal0406715
+FBti0248423_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406716
+FBti0248425_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406718
+FBti0248426_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406719
+FBti0248427_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406720
+FBti0248428_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406721
+FBti0248429_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406722
+FBti0248430_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406723
+FBti0248431_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406724
+FBti0248432_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406725
+FBti0248433_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406726
+FBti0248434_cas	tagged_with	FBto0000093	FBrf0260993		TOOL DATA from: FBal0406727
+FBti0248445_cas	encodes_tool	FBto0000155	FBrf0261397		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248445_cas	tool_uses	promoter trap	FBrf0261397		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248456_cas				FTA: unable to add tool information from FBal0406752 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248480_cas	tagged_with	FBto0000027	FBrf0261242		TOOL DATA from: FBal0406766
+FBti0248515_cas	encodes_tool	FBto0000135	FBrf0261245		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248515_cas	tool_uses	promoter trap	FBrf0261245		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248515_cas	carries_tool	FBto0000349	FBrf0261245		TOOL DATA from: FBal0406845
+FBti0248515_cas	carries_tool	FBto0000349	FBrf0261245		TOOL DATA from: FBal0406846
+FBti0248524_cas	encodes_tool	FBto0000153	FBrf0260984		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248524_cas	tool_uses	promoter trap	FBrf0260984		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248524_cas	carries_tool	FBto0000349	FBrf0260984		TOOL DATA from: FBal0406892
+FBti0248524_cas	tagged_with	FBto0000093	FBrf0260984		TOOL DATA from: FBal0406892
+FBti0248524_cas	carries_tool	FBto0000349	FBrf0260984		TOOL DATA from: FBal0406894
+FBti0248524_cas	tagged_with	FBto0000093	FBrf0260984		TOOL DATA from: FBal0406894
+FBti0248525_cas	encodes_tool	FBto0000153	FBrf0260984		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248525_cas	tool_uses	promoter trap	FBrf0260984		TOOL DATA from: FBtp0140110, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248525_cas	carries_tool	FBto0000349	FBrf0260984		TOOL DATA from: FBal0406893
+FBti0248525_cas	tagged_with	FBto0000093	FBrf0260984		TOOL DATA from: FBal0406893
+FBti0248525_cas	carries_tool	FBto0000349	FBrf0260984		TOOL DATA from: FBal0406895
+FBti0248525_cas	tagged_with	FBto0000093	FBrf0260984		TOOL DATA from: FBal0406895
+FBti0248526_cas	tagged_with	FBto0000077	FBrf0261201		TOOL DATA from: FBal0406908
+FBti0248527_cas	carries_tool	FBto0000349	FBrf0261422		TOOL DATA from: FBal0406935
+FBti0248527_cas	tagged_with	FBto0000031	FBrf0261422		TOOL DATA from: FBal0406935
+FBti0248528_cas	carries_tool	FBto0000349	FBrf0261422		TOOL DATA from: FBal0406936
+FBti0248528_cas	carries_tool	FBto0000356	FBrf0261422		TOOL DATA from: FBal0406936
+FBti0248529_cas	carries_tool	FBto0000349	FBrf0261422		TOOL DATA from: FBal0406938
+FBti0248529_cas	tagged_with	FBto0000093	FBrf0261422		TOOL DATA from: FBal0406938
+FBti0248535_cas	tagged_with	FBto0000118	FBrf0261231		TOOL DATA from: FBal0406995
+FBti0248536_cas	tagged_with	FBto0000027	FBrf0261231		TOOL DATA from: FBal0406996
+FBti0248537_cas				FTA: unable to add tool information from FBal0407004 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0248538_cas	tagged_with	FBto0000027	FBrf0261312		TOOL DATA from: FBal0407018
+FBti0248539_cas	carries_tool	FBto0000323	FBrf0261312		TOOL DATA from: FBal0407020
+FBti0248539_cas	tagged_with	FBto0000936	FBrf0261312		TOOL DATA from: FBal0407020
+FBti0248540_cas	carries_tool	FBto0000323	FBrf0261312		TOOL DATA from: FBal0407021
+FBti0248540_cas	tagged_with	FBto0000936	FBrf0261312		TOOL DATA from: FBal0407021
+FBti0248542_cas	carries_tool	FBto0000349	FBrf0261483		TOOL DATA from: FBal0407025
+FBti0248543_cas	carries_tool	FBto0000349	FBrf0261483		TOOL DATA from: FBal0407027
+FBti0248544_cas	carries_tool	FBto0000349	FBrf0261483		TOOL DATA from: FBal0407028
+FBti0248545_cas	carries_tool	FBto0000349	FBrf0261483		TOOL DATA from: FBal0407029
+FBti0248546_cas	tagged_with	FBto0000063	FBrf0261536		TOOL DATA from: FBal0407034
+FBti0248585_cas	tagged_with	FBto0000093	FBrf0261351		TOOL DATA from: FBal0407101
+FBti0248604_cas	tagged_with	FBto0000063	FBrf0261515		TOOL DATA from: FBal0407132
+FBti0248605_cas	tagged_with	FBto0000063	FBrf0261515		TOOL DATA from: FBal0407133
+FBti0248653_cas	tagged_with	FBto0000031	FBrf0261159		TOOL DATA from: FBal0407194
+FBti0248654_cas	tagged_with	FBto0000031	FBrf0261159		TOOL DATA from: FBal0407195
+FBti0248655_cas	tagged_with	FBto0000031	FBrf0261159		TOOL DATA from: FBal0407196
+FBti0248656_cas	tagged_with	FBto0000031	FBrf0261159		TOOL DATA from: FBal0407197
+FBti0248663_cas	tagged_with	FBto0000077	FBrf0261647		TOOL DATA from: FBal0407221
+FBti0248663_cas	tagged_with	FBto0000601	FBrf0261647		TOOL DATA from: FBal0407221
+FBti0248664_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407231
+FBti0248664_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407231
+FBti0248665_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407232
+FBti0248665_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407232
+FBti0248666_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407233
+FBti0248666_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407233
+FBti0248667_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407234
+FBti0248667_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407234
+FBti0248668_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407235
+FBti0248668_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407235
+FBti0248669_cas	tagged_with	FBto0000070	FBrf0260943		TOOL DATA from: FBal0407236
+FBti0248669_cas	tagged_with	FBto0000077	FBrf0260943		TOOL DATA from: FBal0407236
+FBti0248691_cas	encodes_tool	FBto0000146	FBrf0261542		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248691_cas	tool_uses	promoter trap	FBrf0261542		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248692_cas	encodes_tool	FBto0000166	FBrf0261542		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248692_cas	tool_uses	promoter trap	FBrf0261542		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248723_cas	carries_tool	FBto0000318	FBrf0261580		TOOL DATA from: FBal0407315
+FBti0248723_cas	tagged_with	FBto0000027	FBrf0261580		TOOL DATA from: FBal0407315
+FBti0248738_cas	carries_tool	FBto0000349	FBrf0261567		TOOL DATA from: FBal0407321
+FBti0248739_cas	encodes_tool	FBto0000166	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248739_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248739_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407338
+FBti0248739_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407359
+FBti0248740_cas	encodes_tool	FBto0000166	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248740_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248740_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407339
+FBti0248740_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407361
+FBti0248741_cas	encodes_tool	FBto0000166	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248741_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248741_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407340
+FBti0248741_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407373
+FBti0248742_cas	encodes_tool	FBto0000166	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248742_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248742_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407341
+FBti0248742_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407374
+FBti0248743_cas	encodes_tool	FBto0000166	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248743_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248743_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407342
+FBti0248743_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407365
+FBti0248744_cas	encodes_tool	FBto0000166	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248744_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248744_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407343
+FBti0248744_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407367
+FBti0248745_cas	encodes_tool	FBto0000166	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248745_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248745_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407344
+FBti0248745_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407369
+FBti0248746_cas	encodes_tool	FBto0000166	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248746_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248746_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407345
+FBti0248746_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407363
+FBti0248747_cas	encodes_tool	FBto0000166	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248747_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248747_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407346
+FBti0248747_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407371
+FBti0248748_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248748_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248748_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407347
+FBti0248748_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407358
+FBti0248749_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248749_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248749_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407348
+FBti0248749_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407372
+FBti0248750_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248750_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248750_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407349
+FBti0248750_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407360
+FBti0248751_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248751_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248751_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407350
+FBti0248751_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407362
+FBti0248752_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248752_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248752_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407351
+FBti0248752_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407364
+FBti0248753_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248753_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248753_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407352
+FBti0248753_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407375
+FBti0248754_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248754_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248754_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407353
+FBti0248754_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407366
+FBti0248755_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248755_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248755_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407354
+FBti0248755_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407368
+FBti0248756_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248756_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248756_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407355
+FBti0248756_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407376
+FBti0248757_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248757_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248757_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407356
+FBti0248757_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407377
+FBti0248758_cas	encodes_tool	FBto0000146	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248758_cas	tool_uses	promoter trap	FBrf0261575		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248758_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407357
+FBti0248758_cas	carries_tool	FBto0000349	FBrf0261575		TOOL DATA from: FBal0407370
+FBti0248814_cas	carries_tool	FBto0000349	FBrf0244833		TOOL DATA from: FBal0407507
+FBti0248851_cas	encodes_tool	FBto0000135	FBrf0261576		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248851_cas	tool_uses	promoter trap	FBrf0261576		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0248852_cas	carries_tool	FBto0000318	FBrf0261576		TOOL DATA from: FBal0407558
+FBti0248853_cas	carries_tool	FBto0000318	FBrf0261576		TOOL DATA from: FBal0407559
+FBti0248854_cas	carries_tool	FBto0000318	FBrf0261576		TOOL DATA from: FBal0407560
+FBti0248855_cas	carries_tool	FBto0000318	FBrf0261576		TOOL DATA from: FBal0407561
+FBti0248856_cas	tagged_with	FBto0000076	FBrf0261576		TOOL DATA from: FBal0407562
+FBti0248856_cas	tagged_with	FBto0000077	FBrf0261576		TOOL DATA from: FBal0407562
+FBti0248857_cas	tagged_with	FBto0000076	FBrf0261576		TOOL DATA from: FBal0407563
+FBti0248857_cas	tagged_with	FBto0000077	FBrf0261576		TOOL DATA from: FBal0407563
+FBti0248858_cas	tagged_with	FBto0000063	FBrf0261576		TOOL DATA from: FBal0407564
+FBti0248859_cas	tagged_with	FBto0000076	FBrf0261576		TOOL DATA from: FBal0407565
+FBti0248859_cas	tagged_with	FBto0000077	FBrf0261576		TOOL DATA from: FBal0407565
+FBti0249051_cas	tagged_with	FBto0000126	FBrf0261233		TOOL DATA from: FBal0407734
+FBti0249051_cas	tagged_with	FBto0000522	FBrf0261233		TOOL DATA from: FBal0407734
+FBti0249052_cas	carries_tool	FBto0000318	FBrf0261233		TOOL DATA from: FBal0407735
+FBti0249052_cas	tagged_with	FBto0000126	FBrf0261233		TOOL DATA from: FBal0407735
+FBti0249053_cas	tagged_with	FBto0000126	FBrf0261233		TOOL DATA from: FBal0407736
+FBti0249066_cas	tagged_with	FBto0000077	FBrf0260494		TOOL DATA from: FBal0407745
+FBti0249068_cas	encodes_tool	FBto0000135	FBrf0261632		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0249068_cas	tool_uses	promoter trap	FBrf0261632		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0249068_cas	carries_tool	FBto0000349	FBrf0261632		TOOL DATA from: FBal0407748
+FBti0249069_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407758
+FBti0249070_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407759
+FBti0249071_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407760
+FBti0249072_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407761
+FBti0249073_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407762
+FBti0249074_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407763
+FBti0249075_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407764
+FBti0249076_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407765
+FBti0249077_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407766
+FBti0249078_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407767
+FBti0249079_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407768
+FBti0249080_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407769
+FBti0249081_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407770
+FBti0249082_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407771
+FBti0249083_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407772
+FBti0249084_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407773
+FBti0249085_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407774
+FBti0249086_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407775
+FBti0249087_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407776
+FBti0249088_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407777
+FBti0249089_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407778
+FBti0249090_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407779
+FBti0249091_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407780
+FBti0249092_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407781
+FBti0249093_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407782
+FBti0249094_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407783
+FBti0249095_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407784
+FBti0249096_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407785
+FBti0249097_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407786
+FBti0249098_cas	tagged_with	FBto0000077	FBrf0261823		TOOL DATA from: FBal0407787
+FBti0249099_cas	tagged_with	FBto0000869	FBrf0261627		TOOL DATA from: FBal0407791
+FBti0249100_cas	tagged_with	FBto0000869	FBrf0261627		TOOL DATA from: FBal0407792
+FBti0249101_cas	tagged_with	FBto0000063	FBrf0261627		TOOL DATA from: FBal0407793
+FBti0249102_cas	tagged_with	FBto0000063	FBrf0261627		TOOL DATA from: FBal0407794
+FBti0249103_cas	tagged_with	FBto0000063	FBrf0261627		TOOL DATA from: FBal0407795
+FBti0249104_cas	tagged_with	FBto0000063	FBrf0261627		TOOL DATA from: FBal0407796
+FBti0249106_cas	tagged_with	FBto0000118	FBrf0261523		TOOL DATA from: FBal0407816
+FBti0249128_cas	tagged_with	FBto0000126	FBrf0261873		TOOL DATA from: FBal0407880
+FBti0249129_cas	carries_tool	FBto0000318	FBrf0261873		TOOL DATA from: FBal0407881
+FBti0249129_cas	carries_tool	FBto0000318	FBrf0261873		TOOL DATA from: FBal0407882
+FBti0249129_cas	tagged_with	FBto0000226	FBrf0261873		TOOL DATA from: FBal0407882
+FBti0249137_cas	carries_tool	FBto0000318	FBrf0261442		TOOL DATA from: FBal0407886
+FBti0249137_cas	tagged_with	FBto0000031	FBrf0261442		TOOL DATA from: FBal0407886
+FBti0249137_cas	tagged_with	FBto0000079	FBrf0261442		TOOL DATA from: FBal0407886
+FBti0249137_cas	tagged_with	FBto0000242	FBrf0261442		TOOL DATA from: FBal0407886
+FBti0249138_cas	carries_tool	FBto0000318	FBrf0261442		TOOL DATA from: FBal0407887
+FBti0249138_cas	tagged_with	FBto0000031	FBrf0261442		TOOL DATA from: FBal0407887
+FBti0249138_cas	tagged_with	FBto0000079	FBrf0261442		TOOL DATA from: FBal0407887
+FBti0249138_cas	tagged_with	FBto0000242	FBrf0261442		TOOL DATA from: FBal0407887
+FBti0249139_cas	carries_tool	FBto0000318	FBrf0261442		TOOL DATA from: FBal0407888
+FBti0249139_cas	tagged_with	FBto0000031	FBrf0261442		TOOL DATA from: FBal0407888
+FBti0249139_cas	tagged_with	FBto0000079	FBrf0261442		TOOL DATA from: FBal0407888
+FBti0249139_cas	tagged_with	FBto0000242	FBrf0261442		TOOL DATA from: FBal0407888
+FBti0249140_cas	tagged_with	FBto0000076	FBrf0261766		TOOL DATA from: FBal0407889
+FBti0249140_cas	tagged_with	FBto0000077	FBrf0261766		TOOL DATA from: FBal0407889
+FBti0249141_cas	tagged_with	FBto0000076	FBrf0261766		TOOL DATA from: FBal0407893
+FBti0249142_cas	tagged_with	FBto0000076	FBrf0261766		TOOL DATA from: FBal0407895
+FBti0249142_cas	tagged_with	FBto0000077	FBrf0261766		TOOL DATA from: FBal0407895
+FBti0249143_cas	tagged_with	FBto0000076	FBrf0261766		TOOL DATA from: FBal0407896
+FBti0249143_cas	tagged_with	FBto0000077	FBrf0261766		TOOL DATA from: FBal0407896
+FBti0249144_cas	tagged_with	FBto0000077	FBrf0261950		TOOL DATA from: FBal0407897
+FBti0249148_cas	carries_tool	FBto0000318	FBrf0261824		TOOL DATA from: FBal0407911
+FBti0249149_cas	carries_tool	FBto0000318	FBrf0261824		TOOL DATA from: FBal0407912
+FBti0249149_cas	tagged_with	FBto0000426	FBrf0261824		TOOL DATA from: FBal0407912
+FBti0249150_cas	carries_tool	FBto0000318	FBrf0261824		TOOL DATA from: FBal0407913
+FBti0249150_cas	tagged_with	FBto0000426	FBrf0261824		TOOL DATA from: FBal0407913
+FBti0249151_cas	carries_tool	FBto0000318	FBrf0261824		TOOL DATA from: FBal0407914
+FBti0249152_cas	tagged_with	FBto0000375	FBrf0261824		TOOL DATA from: FBal0407915
+FBti0249156_cas	tagged_with	FBto0000077	FBrf0261717		TOOL DATA from: FBal0407950
+FBti0249169_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407963
+FBti0249169_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407963
+FBti0249170_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407964
+FBti0249170_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407964
+FBti0249171_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407965
+FBti0249171_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407965
+FBti0249172_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407966
+FBti0249172_cas	tagged_with	FBto0000093	FBrf0260932		TOOL DATA from: FBal0407966
+FBti0249173_cas				FTA: unable to add tool information from FBal0407967 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249174_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407968
+FBti0249174_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407968
+FBti0249175_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407969
+FBti0249175_cas	tagged_with	FBto0000027	FBrf0260932		TOOL DATA from: FBal0407969
+FBti0249175_cas	tagged_with	FBto0000076	FBrf0260932		TOOL DATA from: FBal0407969
+FBti0249175_cas	tagged_with	FBto0000092	FBrf0260932		TOOL DATA from: FBal0407969
+FBti0249176_cas				FTA: unable to add tool information from FBal0407970 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249177_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407971
+FBti0249177_cas	tagged_with	FBto0000027	FBrf0260932		TOOL DATA from: FBal0407971
+FBti0249177_cas	tagged_with	FBto0000076	FBrf0260932		TOOL DATA from: FBal0407971
+FBti0249177_cas	tagged_with	FBto0000092	FBrf0260932		TOOL DATA from: FBal0407971
+FBti0249178_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407972
+FBti0249178_cas	tagged_with	FBto0000093	FBrf0260932		TOOL DATA from: FBal0407972
+FBti0249179_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407973
+FBti0249179_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407973
+FBti0249179_cas	tagged_with	FBto0001030	FBrf0260932		TOOL DATA from: FBal0407973
+FBti0249180_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407974
+FBti0249180_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407974
+FBti0249181_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407975
+FBti0249181_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407975
+FBti0249182_cas				FTA: unable to add tool information from FBal0407976 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249183_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407977
+FBti0249183_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407977
+FBti0249184_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407978
+FBti0249184_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407978
+FBti0249185_cas				FTA: unable to add tool information from FBal0407979 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249186_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407980
+FBti0249186_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407980
+FBti0249187_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407981
+FBti0249187_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407981
+FBti0249188_cas				FTA: unable to add tool information from FBal0407982 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249189_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407983
+FBti0249189_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407983
+FBti0249190_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407984
+FBti0249190_cas	tagged_with	FBto0000009	FBrf0260932		TOOL DATA from: FBal0407984
+FBti0249191_cas				FTA: unable to add tool information from FBal0407985 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249192_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407986
+FBti0249192_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407986
+FBti0249193_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407987
+FBti0249193_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407987
+FBti0249194_cas				FTA: unable to add tool information from FBal0407988 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249195_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407989
+FBti0249195_cas	tagged_with	FBto0000027	FBrf0260932		TOOL DATA from: FBal0407989
+FBti0249195_cas	tagged_with	FBto0000076	FBrf0260932		TOOL DATA from: FBal0407989
+FBti0249195_cas	tagged_with	FBto0000092	FBrf0260932		TOOL DATA from: FBal0407989
+FBti0249196_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407990
+FBti0249196_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407990
+FBti0249197_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407991
+FBti0249197_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407991
+FBti0249198_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407992
+FBti0249199_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407993
+FBti0249200_cas				FTA: unable to add tool information from FBal0407994 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249201_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407995
+FBti0249201_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0407995
+FBti0249202_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407996
+FBti0249202_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407996
+FBti0249203_cas				FTA: unable to add tool information from FBal0407997 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249204_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0407998
+FBti0249204_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0407998
+FBti0249205_cas				FTA: unable to add tool information from FBal0407999 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249206_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0408000
+FBti0249206_cas	tagged_with	FBto0000027	FBrf0260932		TOOL DATA from: FBal0408000
+FBti0249206_cas	tagged_with	FBto0000076	FBrf0260932		TOOL DATA from: FBal0408000
+FBti0249206_cas	tagged_with	FBto0000092	FBrf0260932		TOOL DATA from: FBal0408000
+FBti0249207_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0408001
+FBti0249207_cas	tagged_with	FBto0000104	FBrf0260932		TOOL DATA from: FBal0408001
+FBti0249208_cas	carries_tool	FBto0000349	FBrf0260932		TOOL DATA from: FBal0408002
+FBti0249208_cas	tagged_with	FBto0000077	FBrf0260932		TOOL DATA from: FBal0408002
+FBti0249209_cas	carries_tool	FBto0000349	FBrf0242827		TOOL DATA from: FBal0407962
+FBti0249209_cas	tagged_with	FBto0000077	FBrf0232782|FBrf0242827		TOOL DATA from: FBal0407962
+FBti0249213_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408008
+FBti0249214_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408009
+FBti0249215_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408013
+FBti0249217_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408012
+FBti0249218_cas	tagged_with	FBto0000077	FBrf0261843		TOOL DATA from: FBal0408014
+FBti0249252_cas	tagged_with	FBto0000063	FBrf0261967		TOOL DATA from: FBal0408076
+FBti0249281_cas	tagged_with	FBto0000048	FBrf0261549		TOOL DATA from: FBal0408145
+FBti0249281_cas	tagged_with	FBto0000076	FBrf0261549		TOOL DATA from: FBal0408145
+FBti0249281_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408145
+FBti0249282_cas	tagged_with	FBto0000048	FBrf0261549		TOOL DATA from: FBal0408146
+FBti0249282_cas	tagged_with	FBto0000076	FBrf0261549		TOOL DATA from: FBal0408146
+FBti0249282_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408146
+FBti0249283_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408147
+FBti0249284_cas	tagged_with	FBto0000048	FBrf0261549		TOOL DATA from: FBal0408148
+FBti0249284_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408148
+FBti0249285_cas	tagged_with	FBto0000093	FBrf0261549		TOOL DATA from: FBal0408149
+FBti0249285_cas	tagged_with	FBto0000208	FBrf0261549		TOOL DATA from: FBal0408149
+FBti0249317_cas	tagged_with	FBto0000118	FBrf0262127		TOOL DATA from: FBal0408222
+FBti0249318_cas				FTA: unable to add tool information from FBal0408238 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249319_cas				FTA: unable to add tool information from FBal0408261 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249321_cas				FTA: unable to add tool information from FBal0408274 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0249334_cas	encodes_tool	FBto0000168	FBrf0261898		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0249334_cas	tool_uses	promoter trap	FBrf0261898		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0249334_cas	tagged_with	FBto0000081	FBrf0261898		TOOL DATA from: FBal0408294
+FBti0249334_cas	tagged_with	FBto0000899	FBrf0261898		TOOL DATA from: FBal0408294
+FBti0249361_cas	tagged_with	FBto0000076	FBrf0262050		TOOL DATA from: FBal0408339
+FBti0249361_cas	tagged_with	FBto0000077	FBrf0262050		TOOL DATA from: FBal0408339
+FBti0249362_cas	carries_tool	FBto0000349	FBrf0262100		TOOL DATA from: FBal0408341
+FBti0249363_cas	tagged_with	FBto0000077	FBrf0262100		TOOL DATA from: FBal0408343
+FBti0249364_cas	tagged_with	FBto0000077	FBrf0262100		TOOL DATA from: FBal0408344
+FBti0419130_cas	tagged_with	FBto0000077	FBrf0261730		TOOL DATA from: FBal0408455
+FBti0419131_cas	tagged_with	FBto0000118	FBrf0261730		TOOL DATA from: FBal0408456
+FBti0419132_cas	tagged_with	FBto0000077	FBrf0261730		TOOL DATA from: FBal0408457
+FBti0419133_cas	tagged_with	FBto0000077	FBrf0261730		TOOL DATA from: FBal0408458
+FBti0419134_cas	tagged_with	FBto0000077	FBrf0261730		TOOL DATA from: FBal0408459
+FBti0419135_cas	tagged_with	FBto0000027	FBrf0261730		TOOL DATA from: FBal0408460
+FBti0419198_cas	tagged_with	FBto0000063	FBrf0262484		TOOL DATA from: FBal0408573
+FBti0419210_cas	carries_tool	FBto0000349	FBrf0262293		TOOL DATA from: FBal0408582
+FBti0419210_cas	carries_tool	FBto0000356	FBrf0262293		TOOL DATA from: FBal0408582
+FBti0419211_cas	tagged_with	FBto0000027	FBrf0262293		TOOL DATA from: FBal0408584
+FBti0419214_cas	tagged_with	FBto0000031	FBrf0262159		TOOL DATA from: FBal0408586
+FBti0419215_cas	tagged_with	FBto0000076	FBrf0262159		TOOL DATA from: FBal0408587
+FBti0419216_cas	tagged_with	FBto0000623	FBrf0262485		TOOL DATA from: FBal0408588
+FBti0419386_cas	tagged_with	FBto0000093	FBrf0262206		TOOL DATA from: FBal0408648
+FBti0419386_cas	tagged_with	FBto0000118	FBrf0262206		TOOL DATA from: FBal0408648
+FBti0419402_cas	tagged_with	FBto0000099	FBrf0262110		TOOL DATA from: FBal0408712
+FBti0419404_cas	carries_tool	FBto0000356	FBrf0262154		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419404_cas	tool_uses	docking element	FBrf0262154		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419558_cas	tagged_with	FBto0000076	FBrf0262201		TOOL DATA from: FBal0408788
+FBti0419564_cas	carries_tool	FBto0000356	FBrf0262209		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419564_cas	tool_uses	docking element	FBrf0262209		TOOL DATA from: FBtp0129389, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419570_cas	tagged_with	FBto0000027	FBrf0262242		TOOL DATA from: FBal0408817
+FBti0419699_cas	carries_tool	FBto0000349	FBrf0262205		TOOL DATA from: FBal0408874
+FBti0419701_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408887
+FBti0419705_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408894
+FBti0419708_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408899
+FBti0419712_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408906
+FBti0419715_cas	carries_tool	FBto0000356	FBrf0262044		TOOL DATA from: FBal0408909
+FBti0419761_cas	tagged_with	FBto0000789	FBrf0260923		TOOL DATA from: FBal0409000
+FBti0419762_cas	tagged_with	FBto0000118	FBrf0260923		TOOL DATA from: FBal0409001
+FBti0419762_cas	tagged_with	FBto0000789	FBrf0260923		TOOL DATA from: FBal0409001
+FBti0419763_cas	tagged_with	FBto0000389	FBrf0260923		TOOL DATA from: FBal0409004
+FBti0419764_cas	tagged_with	FBto0000389	FBrf0260923		TOOL DATA from: FBal0409005
+FBti0419776_cas	encodes_tool	FBto0000027	FBrf0262294		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419776_cas	tool_uses	promoter trap	FBrf0262294		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419776_cas	carries_tool	FBto0000349	FBrf0262294		TOOL DATA from: FBal0409020
+FBti0419777_cas	encodes_tool	FBto0000027	FBrf0262294		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419777_cas	tool_uses	promoter trap	FBrf0262294		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419777_cas	carries_tool	FBto0000349	FBrf0262294		TOOL DATA from: FBal0409021
+FBti0419778_cas	encodes_tool	FBto0000140	FBrf0262294		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419778_cas	tool_uses	promoter trap	FBrf0262294		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419778_cas	carries_tool	FBto0000349	FBrf0262294		TOOL DATA from: FBal0409022
+FBti0419779_cas	encodes_tool	FBto0000140	FBrf0262294		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419779_cas	tool_uses	promoter trap	FBrf0262294		TOOL DATA from: FBtp0128008, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419779_cas	carries_tool	FBto0000349	FBrf0262294		TOOL DATA from: FBal0409023
+FBti0419790_cas	tagged_with	FBto0000027	FBrf0260765		TOOL DATA from: FBal0409046
+FBti0419791_cas	tagged_with	FBto0000027	FBrf0260765		TOOL DATA from: FBal0409047
+FBti0419792_cas	tagged_with	FBto0000027	FBrf0260765		TOOL DATA from: FBal0409048
+FBti0419793_cas	tagged_with	FBto0000027	FBrf0260765		TOOL DATA from: FBal0409049
+FBti0419794_cas	carries_tool	FBto0000356	FBrf0260765		TOOL DATA from: FBal0409050
+FBti0419795_cas	tagged_with	FBto0000077	FBrf0260765		TOOL DATA from: FBal0409051
+FBti0419796_cas	tagged_with	FBto0000077	FBrf0260765		TOOL DATA from: FBal0409052
+FBti0419797_cas	tagged_with	FBto0000077	FBrf0260765		TOOL DATA from: FBal0409053
+FBti0419798_cas	tagged_with	FBto0000077	FBrf0260765		TOOL DATA from: FBal0409054
+FBti0419808_cas	encodes_tool	FBto0000146	FBrf0262684		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419808_cas	tool_uses	promoter trap	FBrf0262684		TOOL DATA from: FBtp0116623, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419809_cas	encodes_tool	FBto0000166	FBrf0262684		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419809_cas	tool_uses	promoter trap	FBrf0262684		TOOL DATA from: FBtp0141341, used single pub_curie from FBti->FBtp producedby f_r
+FBti0419817_cas	tagged_with	FBto0000077	FBrf0262360		TOOL DATA from: FBal0409072
+FBti0419817_cas	tagged_with	FBto0000081	FBrf0262360		TOOL DATA from: FBal0409072
+FBti0419817_cas	tagged_with	FBto0000239	FBrf0262360		TOOL DATA from: FBal0409072
+FBti0419817_cas	tagged_with	FBto0000341	FBrf0262360		TOOL DATA from: FBal0409072
+FBti0419818_cas	tagged_with	FBto0000077	FBrf0262360		TOOL DATA from: FBal0409073
+FBti0419818_cas	tagged_with	FBto0000888	FBrf0262360		TOOL DATA from: FBal0409073
+FBti0419819_cas	tagged_with	FBto0000126	FBrf0262360		TOOL DATA from: FBal0409074
+FBti0419820_cas	tagged_with	FBto0000077	FBrf0262360		TOOL DATA from: FBal0409077
+FBti0419917_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409087
+FBti0419917_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409087
+FBti0419918_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409088
+FBti0419918_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409088
+FBti0419919_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409089
+FBti0419919_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409089
+FBti0419920_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409090
+FBti0419920_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409090
+FBti0419921_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409091
+FBti0419921_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409091
+FBti0419922_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409092
+FBti0419922_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409092
+FBti0419923_cas	carries_tool	FBto0000349	FBrf0244711		TOOL DATA from: FBal0409093
+FBti0419923_cas	carries_tool	FBto0000356	FBrf0244711		TOOL DATA from: FBal0409093
+FBti0420009_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409210
+FBti0420009_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409210
+FBti0420010_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409212
+FBti0420010_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409212
+FBti0420011_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409213
+FBti0420011_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409213
+FBti0420012_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409214
+FBti0420012_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409214
+FBti0420013_cas	tagged_with	FBto0000076	FBrf0263781		TOOL DATA from: FBal0409215
+FBti0420013_cas	tagged_with	FBto0000088	FBrf0263781		TOOL DATA from: FBal0409215
+FBti0420014_cas	tagged_with	FBto0000093	FBrf0262689		TOOL DATA from: FBal0409218
+FBti0420014_cas	tagged_with	FBto0000589	FBrf0262689		TOOL DATA from: FBal0409218
+FBti0420015_cas	encodes_tool	FBto0000135	FBrf0262689		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420015_cas	tool_uses	promoter trap	FBrf0262689		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420015_cas	carries_tool	FBto0000345	FBrf0262689		TOOL DATA from: FBal0409216
+FBti0420015_cas	carries_tool	FBto0000349	FBrf0262689		TOOL DATA from: FBal0409216
+FBti0420015_cas	carries_tool	FBto0000356	FBrf0262689		TOOL DATA from: FBal0409216
+FBti0420015_cas	carries_tool	FBto0000345	FBrf0262689		TOOL DATA from: FBal0409217
+FBti0420015_cas	carries_tool	FBto0000349	FBrf0262689		TOOL DATA from: FBal0409217
+FBti0420015_cas	carries_tool	FBto0000356	FBrf0262689		TOOL DATA from: FBal0409217
+FBti0420020_cas	tagged_with	FBto0000076	FBrf0262750		TOOL DATA from: FBal0409223
+FBti0420022_cas				FTA: unable to add tool information from FBal0409225 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0420022_cas				FTA: unable to add tool information from FBal0409227 (failed 'is_represented_at_alliance_as' cross-check)	
+FBti0420058_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420058_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420059_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420059_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420060_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420060_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420061_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420061_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420062_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420062_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420063_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420063_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420064_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420064_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420065_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420065_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420066_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420066_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420067_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420067_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420068_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420068_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420069_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420069_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420070_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420070_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420071_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420071_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420072_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420072_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420073_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420073_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420074_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420074_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420075_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420075_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420076_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420076_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420076_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409269
+FBti0420076_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409299
+FBti0420077_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420077_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420078_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420078_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420078_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409271
+FBti0420078_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409301
+FBti0420079_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420079_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420080_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420080_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420080_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409273
+FBti0420080_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409303
+FBti0420081_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420081_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420082_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420082_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420082_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409275
+FBti0420082_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409305
+FBti0420083_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420083_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420084_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420084_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420084_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409277
+FBti0420084_cas	carries_tool	FBto0000349	FBrf0262526		TOOL DATA from: FBal0409297
+FBti0420085_cas	encodes_tool	FBto0000168	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420085_cas	tool_uses	promoter trap	FBrf0262526		TOOL DATA from: FBtp0147466, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420090_cas	tagged_with	FBto0000031	FBrf0262719		TOOL DATA from: FBal0409320
+FBti0420091_cas	tagged_with	FBto0000582	FBrf0262719		TOOL DATA from: FBal0409321
+FBti0420093_cas	carries_tool	FBto0000356	FBrf0262719		TOOL DATA from: FBal0409323
+FBti0420122_cas	tagged_with	FBto0000389	FBrf0262715		TOOL DATA from: FBal0409342
+FBti0420123_cas	tagged_with	FBto0000389	FBrf0262715		TOOL DATA from: FBal0409343
+FBti0420124_cas	encodes_tool	FBto0000310	FBrf0262715		TOOL DATA from: FBtp0173663, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420124_cas	tool_uses	promoter trap	FBrf0262715		TOOL DATA from: FBtp0173663, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420138_cas	carries_tool	FBto0000326	FBrf0262580		TOOL DATA from: FBal0409361
+FBti0420139_cas	carries_tool	FBto0000326	FBrf0262580		TOOL DATA from: FBal0409362
+FBti0420139_cas	tagged_with	FBto0000093	FBrf0262580		TOOL DATA from: FBal0409362
+FBti0420140_cas	carries_tool	FBto0000326	FBrf0262580		TOOL DATA from: FBal0409363
+FBti0420141_cas	carries_tool	FBto0000326	FBrf0262580		TOOL DATA from: FBal0409364
+FBti0420141_cas	tagged_with	FBto0000079	FBrf0262580		TOOL DATA from: FBal0409364
+FBti0420144_cas	tagged_with	FBto0000601	FBrf0262601		TOOL DATA from: FBal0409370
+FBti0420145_cas	tagged_with	FBto0000121	FBrf0262601		TOOL DATA from: FBal0409371
+FBti0420146_cas	tagged_with	FBto0000077	FBrf0262601		TOOL DATA from: FBal0409372
+FBti0420206_cas	carries_tool	FBto0000318	FBrf0262907		TOOL DATA from: FBal0409401
+FBti0420206_cas	tagged_with	FBto0000077	FBrf0262907		TOOL DATA from: FBal0409401
+FBti0420210_cas	encodes_tool	FBto0000166	FBrf0262255		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420210_cas	tool_uses	promoter trap	FBrf0262255		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420211_cas	encodes_tool	FBto0000166	FBrf0262255		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420211_cas	tool_uses	promoter trap	FBrf0262255		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420325_cas	tagged_with	FBto0000076	FBrf0262872		TOOL DATA from: FBal0409512
+FBti0420326_cas	tagged_with	FBto0000076	FBrf0262872		TOOL DATA from: FBal0409513
+FBti0420327_cas	tagged_with	FBto0000076	FBrf0262872		TOOL DATA from: FBal0409514
+FBti0420328_cas	tagged_with	FBto0000076	FBrf0262872		TOOL DATA from: FBal0409515
+FBti0420370_cas	tagged_with	FBto0000030	FBrf0262579		TOOL DATA from: FBal0409557
+FBti0420370_cas	tagged_with	FBto0000077	FBrf0262579		TOOL DATA from: FBal0409557
+FBti0420373_cas	tagged_with	FBto0000093	FBrf0226720		TOOL DATA from: FBal0409562
+FBti0420374_cas	tagged_with	FBto0000093	FBrf0226720		TOOL DATA from: FBal0409563
+FBti0420375_cas	tagged_with	FBto0000093	FBrf0226720		TOOL DATA from: FBal0409564
+FBti0420377_cas	carries_tool	FBto0000323	FBrf0262698		TOOL DATA from: FBal0409566
+FBti0420377_cas	tagged_with	FBto0000093	FBrf0262698		TOOL DATA from: FBal0409566
+FBti0420378_cas	tagged_with	FBto0001048	FBrf0262395		TOOL DATA from: FBal0409567
+FBti0420446_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409656
+FBti0420446_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409656
+FBti0420446_cas	encodes_tool	FBto0000536	FBrf0263013		TOOL DATA from: FBal0409661
+FBti0420446_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409661
+FBti0420446_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409661
+FBti0420447_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409657
+FBti0420447_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409657
+FBti0420447_cas	encodes_tool	FBto0000536	FBrf0263013		TOOL DATA from: FBal0409662
+FBti0420447_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409662
+FBti0420447_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409662
+FBti0420448_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409658
+FBti0420448_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409658
+FBti0420448_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409667
+FBti0420448_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409667
+FBti0420449_cas	encodes_tool	FBto0000536	FBrf0263013		TOOL DATA from: FBal0409664
+FBti0420449_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409664
+FBti0420450_cas	tagged_with	FBto0000063	FBrf0263013		TOOL DATA from: FBal0409660
+FBti0420451_cas	encodes_tool	FBto0000536	FBrf0263013		TOOL DATA from: FBal0409663
+FBti0420451_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409663
+FBti0420451_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409663
+FBti0420451_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409665
+FBti0420451_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409665
+FBti0420452_cas	encodes_tool	FBto0000638	FBrf0263013		TOOL DATA from: FBal0409666
+FBti0420452_cas	tagged_with	FBto0001047	FBrf0263013		TOOL DATA from: FBal0409666
+FBti0420452_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409666
+FBti0420452_cas	tagged_with	FBto0001046	FBrf0263013		TOOL DATA from: FBal0409668
+FBti0420452_cas	tool_uses	gene product activity sensor	FBrf0263013		TOOL DATA from: FBal0409668
+FBti0420504_cas	tagged_with	FBto0000077	FBrf0263106		TOOL DATA from: FBal0409680
+FBti0420505_cas	carries_tool	FBto0000349	FBrf0262155		TOOL DATA from: FBal0402065
+FBti0420505_cas	tagged_with	FBto0000076	FBrf0262155		TOOL DATA from: FBal0402065
+FBti0420506_cas	carries_tool	FBto0000349	FBrf0262155		TOOL DATA from: FBal0409707
+FBti0420509_cas	tagged_with	FBto0000076	FBrf0262421		TOOL DATA from: FBal0409711
+FBti0420509_cas	tagged_with	FBto0000093	FBrf0262421		TOOL DATA from: FBal0409711
+FBti0420509_cas	tagged_with	FBto0000118	FBrf0262421		TOOL DATA from: FBal0409711
+FBti0420522_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420522_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420522_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409724
+FBti0420522_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409724
+FBti0420522_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409770
+FBti0420522_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409770
+FBti0420523_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420523_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420523_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409725
+FBti0420523_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409725
+FBti0420523_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409773
+FBti0420523_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409773
+FBti0420524_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420524_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420524_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409726
+FBti0420524_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409726
+FBti0420524_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409776
+FBti0420524_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409776
+FBti0420525_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420525_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420525_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409727
+FBti0420525_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409727
+FBti0420525_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409778
+FBti0420525_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409778
+FBti0420526_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420526_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420527_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420527_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420528_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420528_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420529_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420529_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420530_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420530_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420531_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420531_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420532_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420532_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420533_cas	encodes_tool	FBto0000146	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420533_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0135338, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420533_cas	carries_tool	FBto0000349	FBrf0262569		TOOL DATA from: FBal0409735
+FBti0420533_cas	carries_tool	FBto0000349	FBrf0262569		TOOL DATA from: FBal0409752
+FBti0420543_cas	encodes_tool	FBto0000166	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420543_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420544_cas	encodes_tool	FBto0000166	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420544_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420544_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409746
+FBti0420544_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409746
+FBti0420544_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409771
+FBti0420544_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409771
+FBti0420545_cas	encodes_tool	FBto0000166	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420545_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420545_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409747
+FBti0420545_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409747
+FBti0420545_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409774
+FBti0420545_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409774
+FBti0420546_cas	encodes_tool	FBto0000166	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420546_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420546_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409748
+FBti0420546_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409748
+FBti0420546_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409777
+FBti0420546_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409777
+FBti0420547_cas	encodes_tool	FBto0000166	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420547_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420547_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409749
+FBti0420547_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409749
+FBti0420547_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409779
+FBti0420547_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409779
+FBti0420548_cas	encodes_tool	FBto0000166	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420548_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420548_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409750
+FBti0420548_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409750
+FBti0420548_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409781
+FBti0420548_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409781
+FBti0420549_cas	encodes_tool	FBto0000166	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420549_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0140112, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420549_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409751
+FBti0420549_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409751
+FBti0420549_cas	carries_tool	FBto0000318	FBrf0262569		TOOL DATA from: FBal0409783
+FBti0420549_cas	carries_tool	FBto0000356	FBrf0262569		TOOL DATA from: FBal0409783
+FBti0420550_cas	encodes_tool	FBto0000184	FBrf0262569		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420550_cas	tool_uses	promoter trap	FBrf0262569		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420550_cas	carries_tool	FBto0000349	FBrf0262569		TOOL DATA from: FBal0409753
+FBti0420550_cas	carries_tool	FBto0000349	FBrf0262569		TOOL DATA from: FBal0409768
+FBti0420558_cas	tagged_with	FBto0000601	FBrf0262977		TOOL DATA from: FBal0409807
+FBti0420579_cas	tagged_with	FBto0000076	FBrf0262726		TOOL DATA from: FBal0409834
+FBti0420580_cas	tagged_with	FBto0000076	FBrf0262726		TOOL DATA from: FBal0409835
+FBti0420582_cas	tagged_with	FBto0000809	FBrf0262699		TOOL DATA from: FBal0409837
+FBti0420605_cas	tagged_with	FBto0000638	FBrf0262915		TOOL DATA from: FBal0409880
+FBti0420606_cas	tagged_with	FBto0000638	FBrf0262915		TOOL DATA from: FBal0409881
+FBti0420607_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409882
+FBti0420607_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409882
+FBti0420607_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409882
+FBti0420608_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409885
+FBti0420608_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409885
+FBti0420608_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409885
+FBti0420609_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409889
+FBti0420609_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409889
+FBti0420609_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409889
+FBti0420610_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409895
+FBti0420610_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409895
+FBti0420610_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409895
+FBti0420611_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409900
+FBti0420611_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409900
+FBti0420611_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409900
+FBti0420612_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409903
+FBti0420612_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409903
+FBti0420612_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409903
+FBti0420613_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409904
+FBti0420613_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409904
+FBti0420613_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409904
+FBti0420614_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0409905
+FBti0420614_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0409905
+FBti0420614_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0409905
+FBti0420713_cas	encodes_tool	FBto0000031	FBrf0263184		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420713_cas	tool_uses	promoter trap	FBrf0263184		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420713_cas	carries_tool	FBto0000318	FBrf0263184		TOOL DATA from: FBal0409924
+FBti0420713_cas	tagged_with	FBto0000079	FBrf0263184		TOOL DATA from: FBal0409924
+FBti0420713_cas	tagged_with	FBto0000242	FBrf0263184		TOOL DATA from: FBal0409924
+FBti0420714_cas	encodes_tool	FBto0000031	FBrf0263184		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420714_cas	tool_uses	promoter trap	FBrf0263184		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420714_cas	carries_tool	FBto0000318	FBrf0263184		TOOL DATA from: FBal0409925
+FBti0420714_cas	tagged_with	FBto0000079	FBrf0263184		TOOL DATA from: FBal0409925
+FBti0420714_cas	tagged_with	FBto0000242	FBrf0263184		TOOL DATA from: FBal0409925
+FBti0420715_cas	encodes_tool	FBto0000031	FBrf0263184		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420715_cas	tool_uses	promoter trap	FBrf0263184		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420715_cas	tagged_with	FBto0000079	FBrf0263184		TOOL DATA from: FBal0409926
+FBti0420715_cas	tagged_with	FBto0000242	FBrf0263184		TOOL DATA from: FBal0409926
+FBti0420717_cas	encodes_tool	FBto0000118	FBrf0263184		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420717_cas	tool_uses	promoter trap	FBrf0263184		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420717_cas	carries_tool	FBto0000318	FBrf0263184		TOOL DATA from: FBal0409928
+FBti0420719_cas	encodes_tool	FBto0000031	FBrf0263184		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420719_cas	tool_uses	promoter trap	FBrf0263184		TOOL DATA from: FBtp0099205, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420726_cas	tagged_with	FBto0000099	FBrf0263151		TOOL DATA from: FBal0409960
+FBti0420726_cas	tagged_with	FBto0000643	FBrf0263151		TOOL DATA from: FBal0409960
+FBti0420727_cas	tagged_with	FBto0000643	FBrf0263151		TOOL DATA from: FBal0409961
+FBti0420728_cas	tagged_with	FBto0000099	FBrf0263151		TOOL DATA from: FBal0409962
+FBti0420728_cas	tagged_with	FBto0000643	FBrf0263151		TOOL DATA from: FBal0409962
+FBti0420729_cas	tagged_with	FBto0000643	FBrf0263151		TOOL DATA from: FBal0409963
+FBti0420740_cas	tagged_with	FBto0000027	FBrf0263020		TOOL DATA from: FBal0409974
+FBti0420873_cas	tagged_with	FBto0000031	FBrf0260702		TOOL DATA from: FBal0410046
+FBti0420873_cas	tagged_with	FBto0000076	FBrf0260702		TOOL DATA from: FBal0410046
+FBti0420873_cas	tagged_with	FBto0000093	FBrf0260702		TOOL DATA from: FBal0410046
+FBti0420874_cas	tagged_with	FBto0000031	FBrf0262106		TOOL DATA from: FBal0410051
+FBti0420877_cas	carries_tool	FBto0000349	FBrf0263175		TOOL DATA from: FBal0410060
+FBti0420878_cas	carries_tool	FBto0000349	FBrf0263175		TOOL DATA from: FBal0410066
+FBti0420884_cas	tagged_with	FBto0000027	FBrf0263149		TOOL DATA from: FBal0410067
+FBti0420885_cas	tagged_with	FBto0000638	FBrf0263149		TOOL DATA from: FBal0410068
+FBti0420886_cas	tagged_with	FBto0000118	FBrf0263149		TOOL DATA from: FBal0410069
+FBti0420887_cas	tagged_with	FBto0000077	FBrf0263114		TOOL DATA from: FBal0410070
+FBti0420932_cas	encodes_tool	FBto0000135	FBrf0263365		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420932_cas	tool_uses	promoter trap	FBrf0263365		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420933_cas	encodes_tool	FBto0000158	FBrf0263365		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420933_cas	tool_uses	promoter trap	FBrf0263365		TOOL DATA from: FBtp0141597, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420936_cas	tagged_with	FBto0000076	FBrf0263276		TOOL DATA from: FBal0410145
+FBti0420936_cas	tagged_with	FBto0000077	FBrf0263276		TOOL DATA from: FBal0410145
+FBti0420937_cas	tagged_with	FBto0000076	FBrf0263276		TOOL DATA from: FBal0410146
+FBti0420937_cas	tagged_with	FBto0000077	FBrf0263276		TOOL DATA from: FBal0410146
+FBti0420980_cas	carries_tool	FBto0000349	FBrf0263431		TOOL DATA from: FBal0410149
+FBti0420980_cas	carries_tool	FBto0000356	FBrf0263431		TOOL DATA from: FBal0410149
+FBti0420981_cas	encodes_tool	FBto0000135	FBrf0263319		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420981_cas	tool_uses	promoter trap	FBrf0263319		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0420982_cas	tagged_with	FBto0000077	FBrf0263319		TOOL DATA from: FBal0410153
+FBti0420983_cas	tagged_with	FBto0000077	FBrf0263319		TOOL DATA from: FBal0410154
+FBti0420984_cas	tagged_with	FBto0000092	FBrf0263319		TOOL DATA from: FBal0410156
+FBti0421002_cas	tagged_with	FBto0000044	FBrf0263200		TOOL DATA from: FBal0410174
+FBti0421003_cas	tagged_with	FBto0000044	FBrf0263200		TOOL DATA from: FBal0410175
+FBti0421004_cas	tagged_with	FBto0000044	FBrf0263621		TOOL DATA from: FBal0410176
+FBti0421004_cas	tagged_with	FBto0000076	FBrf0263621		TOOL DATA from: FBal0410176
+FBti0421005_cas	tagged_with	FBto0000389	FBrf0263621		TOOL DATA from: FBal0410177
+FBti0421006_cas	carries_tool	FBto0000349	FBrf0263217		TOOL DATA from: FBal0410178
+FBti0421006_cas	tagged_with	FBto0000102	FBrf0263217		TOOL DATA from: FBal0410178
+FBti0421077_cas	encodes_tool	FBto0000135	FBrf0263534		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421077_cas	tool_uses	gene trap	FBrf0263534		TOOL DATA from: FBtp0128005, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421085_cas	carries_tool	FBto0000349	FBrf0263252		TOOL DATA from: FBal0410266
+FBti0421085_cas	carries_tool	FBto0000356	FBrf0263252		TOOL DATA from: FBal0410266
+FBti0421086_cas	tagged_with	FBto0000027	FBrf0263252		TOOL DATA from: FBal0410267
+FBti0421087_cas	tagged_with	FBto0000076	FBrf0263252		TOOL DATA from: FBal0410284
+FBti0421092_cas	encodes_tool	FBto0000027	FBrf0263657		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421092_cas	tool_uses	promoter trap	FBrf0263657		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421142_cas	carries_tool	FBto0000349	FBrf0263225		TOOL DATA from: FBal0410328
+FBti0421142_cas	tagged_with	FBto0000076	FBrf0263225		TOOL DATA from: FBal0410328
+FBti0421142_cas	tagged_with	FBto0000077	FBrf0263225		TOOL DATA from: FBal0410328
+FBti0421143_cas	carries_tool	FBto0000349	FBrf0263225		TOOL DATA from: FBal0410329
+FBti0421144_cas	carries_tool	FBto0000349	FBrf0263225		TOOL DATA from: FBal0410330
+FBti0421145_cas	carries_tool	FBto0000349	FBrf0263225		TOOL DATA from: FBal0410331
+FBti0421145_cas	tagged_with	FBto0000076	FBrf0263225		TOOL DATA from: FBal0410331
+FBti0421145_cas	tagged_with	FBto0000077	FBrf0263225		TOOL DATA from: FBal0410331
+FBti0421157_cas	tagged_with	FBto0000077	FBrf0263525		TOOL DATA from: FBal0410382
+FBti0421210_cas	tagged_with	FBto0000027	FBrf0263477		TOOL DATA from: FBal0410393
+FBti0421211_cas	tagged_with	FBto0000076	FBrf0262257		TOOL DATA from: FBal0410396
+FBti0421242_cas	encodes_tool	FBto0000184	FBrf0263481		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421242_cas	tool_uses	promoter trap	FBrf0263481		TOOL DATA from: FBtp0165198, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421245_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421245_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421246_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421246_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421247_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421247_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421248_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421248_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421249_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421249_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421250_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421250_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421251_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421251_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421252_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421252_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421253_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421253_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421254_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421254_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421255_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421255_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421256_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421256_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421257_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421257_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421258_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421258_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421259_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421259_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421260_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421260_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421261_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421261_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421262_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421262_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421263_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421263_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421264_cas	encodes_tool	FBto0000135	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421264_cas	tool_uses	promoter trap	FBrf0263874		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421265_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410502
+FBti0421266_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410503
+FBti0421267_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410504
+FBti0421268_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410505
+FBti0421269_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410506
+FBti0421270_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410507
+FBti0421271_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410508
+FBti0421272_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410509
+FBti0421273_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410510
+FBti0421274_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410511
+FBti0421275_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410512
+FBti0421276_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410513
+FBti0421277_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410514
+FBti0421278_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410515
+FBti0421279_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410516
+FBti0421280_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410517
+FBti0421281_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410518
+FBti0421282_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410519
+FBti0421283_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410520
+FBti0421284_cas	tagged_with	FBto0000063	FBrf0263875		TOOL DATA from: FBal0410521
+FBti0421285_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410522
+FBti0421285_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410522
+FBti0421286_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410523
+FBti0421286_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410523
+FBti0421287_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410524
+FBti0421287_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410524
+FBti0421288_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410525
+FBti0421288_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410525
+FBti0421289_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410526
+FBti0421289_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410526
+FBti0421290_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410527
+FBti0421290_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410527
+FBti0421291_cas	carries_tool	FBto0000349	FBrf0263641		TOOL DATA from: FBal0410528
+FBti0421291_cas	tagged_with	FBto0000031	FBrf0263641		TOOL DATA from: FBal0410528
+FBti0421337_cas	tagged_with	FBto0000093	FBrf0263937		TOOL DATA from: FBal0410566
+FBti0421338_cas	encodes_tool	FBto0000155	FBrf0263937		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421338_cas	tool_uses	promoter trap	FBrf0263937		TOOL DATA from: FBtp0128006, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421339_cas	encodes_tool	FBto0000158	FBrf0263937		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421339_cas	tool_uses	promoter trap	FBrf0263937		TOOL DATA from: FBtp0099210, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421375_cas	tagged_with	FBto0000126	FBrf0264045		TOOL DATA from: FBal0410596
+FBti0421433_cas	tagged_with	FBto0000027	FBrf0263903		TOOL DATA from: FBal0410623
+FBti0421439_cas	encodes_tool	FBto0000135	FBrf0263805		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421439_cas	tool_uses	promoter trap	FBrf0263805		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421440_cas	carries_tool	FBto0000318	FBrf0263805		TOOL DATA from: FBal0410635
+FBti0421483_cas	tagged_with	FBto0000063	FBrf0264007		TOOL DATA from: FBal0410662
+FBti0421506_cas	carries_tool	FBto0000349	FBrf0263983		TOOL DATA from: FBal0410693
+FBti0421506_cas	tagged_with	FBto0000126	FBrf0263983		TOOL DATA from: FBal0410693
+FBti0421507_cas	carries_tool	FBto0000349	FBrf0263983		TOOL DATA from: FBal0410695
+FBti0421507_cas	tagged_with	FBto0000126	FBrf0263983		TOOL DATA from: FBal0410695
+FBti0421508_cas	tagged_with	FBto0000070	FBrf0263976		TOOL DATA from: FBal0410705
+FBti0421509_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410709
+FBti0421509_cas	tagged_with	FBto0000929	FBrf0263639		TOOL DATA from: FBal0410709
+FBti0421510_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410710
+FBti0421510_cas	tagged_with	FBto0000055	FBrf0263639		TOOL DATA from: FBal0410710
+FBti0421511_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410711
+FBti0421511_cas	tagged_with	FBto0000004	FBrf0263639		TOOL DATA from: FBal0410711
+FBti0421512_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410712
+FBti0421512_cas	tagged_with	FBto0000118	FBrf0263639		TOOL DATA from: FBal0410712
+FBti0421513_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410713
+FBti0421513_cas	tagged_with	FBto0000118	FBrf0263639		TOOL DATA from: FBal0410713
+FBti0421514_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410714
+FBti0421514_cas	tagged_with	FBto0000929	FBrf0263639		TOOL DATA from: FBal0410714
+FBti0421515_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410715
+FBti0421515_cas	tagged_with	FBto0000929	FBrf0263639		TOOL DATA from: FBal0410715
+FBti0421516_cas	carries_tool	FBto0000349	FBrf0263639		TOOL DATA from: FBal0410716
+FBti0421516_cas	tagged_with	FBto0000929	FBrf0263639		TOOL DATA from: FBal0410716
+FBti0421538_cas	carries_tool	FBto0000349	FBrf0264230		TOOL DATA from: FBal0410747
+FBti0421538_cas	tagged_with	FBto0000027	FBrf0264230		TOOL DATA from: FBal0410747
+FBti0421539_cas	tagged_with	FBto0000070	FBrf0263931		TOOL DATA from: FBal0410758
+FBti0421639_cas	carries_tool	FBto0000349	FBrf0264199		TOOL DATA from: FBal0410821
+FBti0421639_cas	tagged_with	FBto0000077	FBrf0264199		TOOL DATA from: FBal0410821
+FBti0421640_cas	tagged_with	FBto0000076	FBrf0264199		TOOL DATA from: FBal0410822
+FBti0421641_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410823
+FBti0421641_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410823
+FBti0421641_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410823
+FBti0421641_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410823
+FBti0421642_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410824
+FBti0421642_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410824
+FBti0421642_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410824
+FBti0421642_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410824
+FBti0421643_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410826
+FBti0421643_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410826
+FBti0421643_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410826
+FBti0421643_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410826
+FBti0421644_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410829
+FBti0421644_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410829
+FBti0421644_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410829
+FBti0421644_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410829
+FBti0421645_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410830
+FBti0421645_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410830
+FBti0421645_cas	tagged_with	FBto0000076	FBrf0264384		TOOL DATA from: FBal0410830
+FBti0421645_cas	tagged_with	FBto0000093	FBrf0264384		TOOL DATA from: FBal0410830
+FBti0421646_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410832
+FBti0421646_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410832
+FBti0421646_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410832
+FBti0421646_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410832
+FBti0421647_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410836
+FBti0421647_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410836
+FBti0421647_cas	tagged_with	FBto0000076	FBrf0264384		TOOL DATA from: FBal0410836
+FBti0421647_cas	tagged_with	FBto0000093	FBrf0264384		TOOL DATA from: FBal0410836
+FBti0421648_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410837
+FBti0421648_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410837
+FBti0421648_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410837
+FBti0421648_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410837
+FBti0421649_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410838
+FBti0421649_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410838
+FBti0421649_cas	tagged_with	FBto0000077	FBrf0264384		TOOL DATA from: FBal0410838
+FBti0421649_cas	tagged_with	FBto0000079	FBrf0264384		TOOL DATA from: FBal0410838
+FBti0421650_cas	carries_tool	FBto0000318	FBrf0264384		TOOL DATA from: FBal0410839
+FBti0421650_cas	carries_tool	FBto0000349	FBrf0264384		TOOL DATA from: FBal0410839
+FBti0421650_cas	tagged_with	FBto0000076	FBrf0264384		TOOL DATA from: FBal0410839
+FBti0421650_cas	tagged_with	FBto0000093	FBrf0264384		TOOL DATA from: FBal0410839
+FBti0421656_cas	carries_tool	FBto0000318	FBrf0264585		TOOL DATA from: FBal0410848
+FBti0421656_cas	carries_tool	FBto0000349	FBrf0264585		TOOL DATA from: FBal0410848
+FBti0421656_cas	tagged_with	FBto0000076	FBrf0264585		TOOL DATA from: FBal0410848
+FBti0421656_cas	tagged_with	FBto0000093	FBrf0264585		TOOL DATA from: FBal0410848
+FBti0421657_cas	carries_tool	FBto0000318	FBrf0264585		TOOL DATA from: FBal0410849
+FBti0421657_cas	carries_tool	FBto0000349	FBrf0264585		TOOL DATA from: FBal0410849
+FBti0421657_cas	tagged_with	FBto0000076	FBrf0264585		TOOL DATA from: FBal0410849
+FBti0421657_cas	tagged_with	FBto0000093	FBrf0264585		TOOL DATA from: FBal0410849
+FBti0421658_cas	carries_tool	FBto0000318	FBrf0264585		TOOL DATA from: FBal0410850
+FBti0421658_cas	carries_tool	FBto0000349	FBrf0264585		TOOL DATA from: FBal0410850
+FBti0421658_cas	tagged_with	FBto0000077	FBrf0264585		TOOL DATA from: FBal0410850
+FBti0421658_cas	tagged_with	FBto0000079	FBrf0264585		TOOL DATA from: FBal0410850
+FBti0421663_cas	tagged_with	FBto0000335	FBrf0264200		TOOL DATA from: FBal0410855
+FBti0421664_cas	carries_tool	FBto0000349	FBrf0264200		TOOL DATA from: FBal0410856
+FBti0421664_cas	tagged_with	FBto0000126	FBrf0264200		TOOL DATA from: FBal0410856
+FBti0421665_cas	tagged_with	FBto0000118	FBrf0263770		TOOL DATA from: FBal0410857
+FBti0421666_cas	tagged_with	FBto0000077	FBrf0264375		TOOL DATA from: FBal0410867
+FBti0421667_cas	tagged_with	FBto0000077	FBrf0264375		TOOL DATA from: FBal0410868
+FBti0421670_cas	tagged_with	FBto0000027	FBrf0264269		TOOL DATA from: FBal0410871
+FBti0421726_cas	carries_tool	FBto0000349	FBrf0264409		TOOL DATA from: FBal0410896
+FBti0421726_cas	carries_tool	FBto0000356	FBrf0264409		TOOL DATA from: FBal0410896
+FBti0421727_cas	tagged_with	FBto0000077	FBrf0264409		TOOL DATA from: FBal0410898
+FBti0421728_cas	tagged_with	FBto0000077	FBrf0264409		TOOL DATA from: FBal0410899
+FBti0421729_cas	tagged_with	FBto0000077	FBrf0264435		TOOL DATA from: FBal0410901
+FBti0421740_cas	carries_tool	FBto0000349	FBrf0264327		TOOL DATA from: FBal0410928
+FBti0421740_cas	tagged_with	FBto0000027	FBrf0264327		TOOL DATA from: FBal0410928
+FBti0421740_cas	tagged_with	FBto0001064	FBrf0264327		TOOL DATA from: FBal0410928
+FBti0421741_cas	carries_tool	FBto0000349	FBrf0264327		TOOL DATA from: FBal0410929
+FBti0421741_cas	tagged_with	FBto0000027	FBrf0264327		TOOL DATA from: FBal0410929
+FBti0421741_cas	tagged_with	FBto0001064	FBrf0264327		TOOL DATA from: FBal0410929
+FBti0421742_cas	carries_tool	FBto0000349	FBrf0264327		TOOL DATA from: FBal0410930
+FBti0421742_cas	tagged_with	FBto0000027	FBrf0264327		TOOL DATA from: FBal0410930
+FBti0421742_cas	tagged_with	FBto0001064	FBrf0264327		TOOL DATA from: FBal0410930
+FBti0421743_cas	carries_tool	FBto0000349	FBrf0264327		TOOL DATA from: FBal0410931
+FBti0421743_cas	tagged_with	FBto0000027	FBrf0264327		TOOL DATA from: FBal0410931
+FBti0421743_cas	tagged_with	FBto0001064	FBrf0264327		TOOL DATA from: FBal0410931
+FBti0421754_cas	tagged_with	FBto0000027	FBrf0264536		TOOL DATA from: FBal0410943
+FBti0421817_cas	tagged_with	FBto0000403	FBrf0264213		TOOL DATA from: FBal0410979
+FBti0421819_cas	carries_tool	FBto0000349	FBrf0264549		TOOL DATA from: FBal0410987
+FBti0421872_cas	carries_tool	FBto0000349	FBrf0264660		TOOL DATA from: FBal0411045
+FBti0421872_cas	tagged_with	FBto0000936	FBrf0264660		TOOL DATA from: FBal0411045
+FBti0421873_cas	tagged_with	FBto0000936	FBrf0264660		TOOL DATA from: FBal0411046
+FBti0421874_cas	carries_tool	FBto0000349	FBrf0264019		TOOL DATA from: FBal0411047
+FBti0421874_cas	carries_tool	FBto0000356	FBrf0264019		TOOL DATA from: FBal0411047
+FBti0421875_cas	carries_tool	FBto0000349	FBrf0264019		TOOL DATA from: FBal0411048
+FBti0421875_cas	carries_tool	FBto0000356	FBrf0264019		TOOL DATA from: FBal0411048
+FBti0421876_cas	tagged_with	FBto0000077	FBrf0264019		TOOL DATA from: FBal0411049
+FBti0421880_cas	tagged_with	FBto0000027	FBrf0264511		TOOL DATA from: FBal0411058
+FBti0421881_cas	tagged_with	FBto0000027	FBrf0264511		TOOL DATA from: FBal0411062
+FBti0421882_cas	carries_tool	FBto0000349	FBrf0246291		TOOL DATA from: FBal0411068
+FBti0421944_cas	encodes_tool	FBto0000135	FBrf0264608		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421944_cas	tool_uses	promoter trap	FBrf0264608		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421945_cas	encodes_tool	FBto0000118	FBrf0264608		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421945_cas	tool_uses	promoter trap	FBrf0264608		TOOL DATA from: FBtp0099211, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421946_cas	encodes_tool	FBto0000135	FBrf0264600		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421946_cas	tool_uses	promoter trap	FBrf0264600		TOOL DATA from: FBtp0128007, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421947_cas	encodes_tool	FBto0000135	FBrf0264616		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421947_cas	tool_uses	promoter trap	FBrf0264616		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421949_cas	tagged_with	FBto0000081	FBrf0264515		TOOL DATA from: FBal0411092
+FBti0421951_cas	carries_tool	FBto0000349	FBrf0264472		TOOL DATA from: FBal0411095
+FBti0421952_cas	carries_tool	FBto0000356	FBrf0264083		TOOL DATA from: FBal0411102
+FBti0421953_cas	encodes_tool	FBto0000027	FBrf0264081		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421953_cas	tool_uses	promoter trap	FBrf0264081		TOOL DATA from: FBtp0099213, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421954_cas	encodes_tool	FBto0000791	FBrf0264081		TOOL DATA from: FBtp0150465, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421954_cas	tool_uses	promoter trap	FBrf0264081		TOOL DATA from: FBtp0150465, used single pub_curie from FBti->FBtp producedby f_r
+FBti0421955_cas	tagged_with	FBto0000601	FBrf0264081		TOOL DATA from: FBal0411111
+FBti0421956_cas	carries_tool	FBto0000356	FBrf0264081		TOOL DATA from: FBal0411112
+FBti0421960_cas	tagged_with	FBto0000102	FBrf0264151		TOOL DATA from: FBal0411114
+FBti0421961_cas	tagged_with	FBto0000102	FBrf0264151		TOOL DATA from: FBal0411116
+FBti0421962_cas	tagged_with	FBto0000601	FBrf0264151		TOOL DATA from: FBal0411117
+FBti0421999_cas	tagged_with	FBto0000027	FBrf0264645		TOOL DATA from: FBal0411131
+FBti0422000_cas	tagged_with	FBto0000027	FBrf0264645		TOOL DATA from: FBal0411132
+FBti0422001_cas	tagged_with	FBto0000027	FBrf0264645		TOOL DATA from: FBal0411133
+FBti0422004_cas	tagged_with	FBto0000516	FBrf0264025		TOOL DATA from: FBal0411142
+FBti0422005_cas	tagged_with	FBto0000790	FBrf0264025		TOOL DATA from: FBal0411143
+FBti0422006_cas	tagged_with	FBto0001067	FBrf0264025		TOOL DATA from: FBal0411145
+FBti0422007_cas	tagged_with	FBto0001068	FBrf0264025		TOOL DATA from: FBal0411146
+FBti0422011_cas	tagged_with	FBto0000014	FBrf0264020		TOOL DATA from: FBal0411154
+FBti0422012_cas	tagged_with	FBto0000014	FBrf0264020		TOOL DATA from: FBal0411155
+FBti0422013_cas	tagged_with	FBto0000014	FBrf0264020		TOOL DATA from: FBal0411156
+FBti0422040_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411180
+FBti0422041_cas	tagged_with	FBto0000031	FBrf0264543		TOOL DATA from: FBal0411181
+FBti0422042_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411182
+FBti0422043_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411183
+FBti0422044_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411184
+FBti0422045_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411185
+FBti0422046_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411186
+FBti0422047_cas	tagged_with	FBto0000118	FBrf0264543		TOOL DATA from: FBal0411187
+FBti0422052_cas	tagged_with	FBto0000077	FBrf0264207		TOOL DATA from: FBal0411235
+FBti0422053_cas	carries_tool	FBto0000318	FBrf0264207		TOOL DATA from: FBal0411236
+FBti0422054_cas	carries_tool	FBto0000318	FBrf0264207		TOOL DATA from: FBal0411237
+FBti0422054_cas	tagged_with	FBto0000077	FBrf0264207		TOOL DATA from: FBal0411237
+FBti0422063_cas	tagged_with	FBto0000336	FBrf0264745		TOOL DATA from: FBal0411251
+FBti0422064_cas	tagged_with	FBto0000336	FBrf0264745		TOOL DATA from: FBal0411252
+FBti0422073_cas	carries_tool	FBto0000349	FBrf0239915		TOOL DATA from: FBal0411260
+FBti0422073_cas	carries_tool	FBto0000356	FBrf0239915		TOOL DATA from: FBal0411260
+FBti0422075_cas	tagged_with	FBto0000027	FBrf0264833		TOOL DATA from: FBal0411264
+FBti0422242_cas	carries_tool	FBto0000349	FBrf0264798		TOOL DATA from: FBal0411336
+FBti0422244_cas	carries_tool	FBto0000349	FBrf0264820		TOOL DATA from: FBal0411340
+FBti0422244_cas	tagged_with	FBto0000070	FBrf0264820		TOOL DATA from: FBal0411340
+FBti0422246_cas	tagged_with	FBto0000031	FBrf0264317		TOOL DATA from: FBal0411342
+FBti0422247_cas	tagged_with	FBto0000031	FBrf0264317		TOOL DATA from: FBal0411343
+FBti0422248_cas	tagged_with	FBto0000031	FBrf0264317		TOOL DATA from: FBal0411344
+FBti0422326_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411508
+FBti0422326_cas	tagged_with	FBto0000118	FBrf0264723		TOOL DATA from: FBal0411508
+FBti0422327_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411509
+FBti0422327_cas	tagged_with	FBto0000118	FBrf0264723		TOOL DATA from: FBal0411509
+FBti0422328_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411510
+FBti0422328_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411510
+FBti0422329_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411511
+FBti0422329_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411511
+FBti0422330_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411512
+FBti0422330_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411512
+FBti0422331_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411513
+FBti0422331_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411513
+FBti0422332_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411514
+FBti0422332_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411514
+FBti0422333_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411515
+FBti0422333_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411515
+FBti0422334_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411516
+FBti0422334_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411516
+FBti0422335_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411517
+FBti0422335_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411517
+FBti0422336_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411521
+FBti0422336_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411521
+FBti0422337_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411523
+FBti0422337_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411523
+FBti0422338_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411525
+FBti0422338_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411525
+FBti0422339_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411529
+FBti0422339_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411529
+FBti0422340_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411530
+FBti0422340_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411530
+FBti0422341_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411531
+FBti0422341_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411531
+FBti0422342_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411532
+FBti0422342_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411532
+FBti0422343_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411533
+FBti0422343_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411533
+FBti0422344_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411534
+FBti0422344_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411534
+FBti0422345_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411536
+FBti0422345_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411536
+FBti0422347_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411538
+FBti0422347_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411538
+FBti0422348_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411539
+FBti0422348_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411539
+FBti0422349_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411541
+FBti0422349_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411541
+FBti0422350_cas	tagged_with	FBto0000031	FBrf0264723		TOOL DATA from: FBal0411542
+FBti0422350_cas	tagged_with	FBto0000076	FBrf0264723		TOOL DATA from: FBal0411542
+FBti0422374_cas	encodes_tool	FBto0000155	FBrf0264950		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0422374_cas	tool_uses	promoter trap	FBrf0264950		TOOL DATA from: FBtp0126682, used single pub_curie from FBti->FBtp producedby f_r
+FBti0422374_cas	carries_tool	FBto0000349	FBrf0264950		TOOL DATA from: FBal0411570
+FBti0422374_cas	carries_tool	FBto0000349	FBrf0264950		TOOL DATA from: FBal0411571
+FBti0422375_cas	encodes_tool	FBto0000135	FBrf0264950		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r
+FBti0422375_cas	tool_uses	promoter trap	FBrf0264950		TOOL DATA from: FBtp0099204, used single pub_curie from FBti->FBtp producedby f_r

--- a/docs/FTA-182/plan.md
+++ b/docs/FTA-182/plan.md
@@ -1,0 +1,284 @@
+# FTA-182 — Add tool-related data to anonymous `<FBti>_cas` cassettes
+
+## Context
+
+Sub-task of FTA-136. FTA-181 already creates anonymous `<FBti>_cas` cassettes for
+each generic-TI insertion, driven by `construct_handler.generic_ti_data_for_cassette_handler`
+→ `cassette_handler.receive_anon_cassette_data` → `map_anon_cassettes`. Today the
+anon cassette inherits `direct_rels` (`encodes_tool`, `has_reg_region`,
+`tagged_with`, `carries_tool`) and `tool_uses_data` **from the parent FBtp**, using
+the parent's pub_ids as pub_curies — which is wrong per the ticket.
+
+FTA-182 replaces the single-source logic with a gated two-source model:
+
+1. Tool data from the **parent generic-TI FBtp** is emitted with **blank** `pub_curies`,
+   AND only if `propagate_transgenic_uses` allows.
+2. Tool data from each **`associated_with` FBal** is emitted with the FBal's own
+   `pub_curies`, gated by an `is_represented_at_alliance_as` cross-check between that
+   FBal and the FBti.
+3. If the cross-check fails for an FBal that *has* tool data, the cassette gets a
+   NoteDTO (`internal_note`) explaining why the tool data was withheld.
+
+Authoritative algorithm: `docs/FTA-182/text_for_FTA-182.v2.txt`.
+Expected output shape: `docs/FTA-182/FTA-182_output.v2.txt` (9856 rows).
+
+## Algorithm (from ticket, restated)
+
+```
+for each <FBti>_cas:
+    associated_fbals = FeatureRelationship(type='associated_with',
+                                           object_id=FBti, subject_id~FBal)
+
+    if len(associated_fbals) == 0:
+        # Use parent FBtp data, pub_curies BLANK.
+        emit_parent_tool_data()
+
+    else:
+        propagate_transgenic_uses = True
+        for fbal in associated_fbals:
+            if fbal has Featureprop(type='propagate_transgenic_uses'):
+                propagate_transgenic_uses = False
+                break
+
+        if propagate_transgenic_uses:
+            emit_parent_tool_data()  # pub_curies BLANK
+
+        for fbal in associated_fbals:
+            if fbal has tool data:  # direct_rels OR tool_uses cvtermprops
+                if FeatureRelationship(type='is_represented_at_alliance_as',
+                                       subject=fbal, object=FBti) exists:
+                    emit_fbal_tool_data(pub_curies=<FBal pubs>)
+                else:
+                    cassette.note_dtos.append(NoteDTO(
+                        'internal_note',
+                        f"FTA: unable to add tool information from {fbal.uniquename} "
+                        f"(failed 'is_represented_at_alliance_as' cross-check)",
+                        []))
+                    log_warn_and_counter()
+```
+
+"Tool data" = the 4 feature_relationships (`encodes_tool`, `has_reg_region`,
+`tagged_with`, `carries_tool`) + `tool_uses` FeatureCvtermprops.
+
+## Approach
+
+Data loading stays in `ConstructHandler` (consistent with how the generic-TI
+pipeline already works). `CassetteHandler` remains the DTO builder but learns to
+distinguish the generic-TI path from the FTA-181 non-generic path via an explicit
+flag on each `anon_cassette_data` entry.
+
+### Files modified
+
+- `src/construct_handler.py` — new chado queries + enriched anon_data.
+- `src/cassette_handler.py` — refactor `map_anon_cassette_*` to honor the new
+  gating, emit FBal-sourced rels, blank parent pub_curies, and emit NoteDTOs.
+
+No schema changes; no new DTO classes.
+
+### 1. New chado data loads in `ConstructHandler`
+
+Add a single orchestrator method `get_associated_allele_tool_data(session, ti_feature_ids)`
+that issues the following queries once per run, keyed for cheap downstream lookups.
+Called from `query_chado_and_export` after `get_generic_ti_insertions` and before
+`get_generic_ti_anon_construct_data`.
+
+| Data | Query (chado) | Output shape |
+|---|---|---|
+| Associated FBals per FBti | `FeatureRelationship` where `type='associated_with'`, `object_id ∈ ti_feature_ids`, `subject_id` matches allele regex `^FBal[0-9]{7}$` | `self.ti_associated_alleles: {ti_feature_id: [fbal_feature_id, ...]}` |
+| Block flag per FBal | `Featureprop` where `type.name='propagate_transgenic_uses'`, `feature_id ∈ all_fbal_ids` | `self.fbal_block_propagation: set[fbal_feature_id]` (presence = block) |
+| `is_represented_at_alliance_as` pairs | `FeatureRelationship` where `type='is_represented_at_alliance_as'`, `subject_id ∈ fbal_ids`, `object_id ∈ ti_feature_ids` | `self.fbal_ti_represented: set[(fbal_fid, ti_fid)]` |
+| FBal tool-rels (4 types) | `FeatureRelationship` where `type.name ∈ {encodes_tool, has_reg_region, tagged_with, carries_tool}`, `subject_id ∈ fbal_ids`; join `FeatureRelationshipPub` | `self.fbal_tool_rels: {fbal_fid: [{rel_type, object_feature_id, pub_ids}, ...]}` |
+| FBal tool_uses | Mirror existing `get_construct_tool_uses` pattern: `FeatureCvterm` + `FeatureCvtermprop` where `cvtermprop.type.name='tool_uses'`, `feature_id ∈ fbal_ids` | `self.fbal_tool_uses: {fbal_fid: [{cvterm_name, accession, pub_id}, ...]}` |
+
+Rationale for batch loading: there can be thousands of generic-TI FBtis; a single
+bulk query per datum (filtered by `IN (...)` on the cached fbal_ids) is much cheaper
+than per-insertion queries, and matches the pattern used in `get_construct_tool_uses`
+(`construct_handler.py:278-310`).
+
+Reuse existing helpers:
+- `self.regex['allele']` — already defined in `handler.py` (uniquename regex pattern)
+- `self.feature_lookup[feature_id]` — uniquename + is_obsolete for any FB feature
+- `self.lookup_pub_curies(pub_ids)` — pub_id → FBrf curie conversion
+
+### 2. Extend `get_generic_ti_anon_construct_data` (`construct_handler.py:682`)
+
+Per insertion, attach the new data so downstream code doesn't need the handler's
+own caches. Add these keys to each anon_data dict:
+
+```python
+'is_generic_ti': True,             # FTA-182: differentiates from FTA-181 anon path
+'associated_alleles': [            # from self.ti_associated_alleles[ti_fid]
+    {
+        'feature_id': int,
+        'uniquename': str,
+        'blocks_propagation': bool, # fbal_fid in self.fbal_block_propagation
+        'is_represented_at_alliance_as': bool,  # (fbal_fid, ti_fid) in self.fbal_ti_represented
+        'direct_rels': [{rel_type, object_feature_id, pub_ids}, ...],
+        'tool_uses_data': [{cvterm_name, accession, pub_id}, ...],
+    },
+    ...
+],
+'propagate_transgenic_uses': bool, # computed: True unless any associated FBal blocks
+```
+
+`propagate_transgenic_uses` is computed here rather than in cassette_handler so
+the logic stays adjacent to the loaded chado data.
+
+Simultaneously, tag existing FTA-181 anon_data entries (produced by
+`get_anon_cassette_data` at `construct_handler.py:599`) with `'is_generic_ti': False`
+so the cassette handler can branch cleanly.
+
+### 3. Refactor `map_anon_cassette_*` methods (`cassette_handler.py:642-746`)
+
+The three mapping methods (`map_anon_cassette_simple_components`,
+`map_anon_cassette_encodes_tool`, `map_anon_cassette_tool_uses`) currently iterate
+`data['direct_rels']` / `data['tool_uses_data']` per entry. Change each to:
+
+```python
+for data in self.anon_cassette_data:
+    if data.get('is_generic_ti'):
+        self._emit_generic_ti_tool_data(data)   # NEW: FTA-182 logic
+    else:
+        self._emit_parent_tool_data_with_pubs(data)  # existing FTA-181 behavior, extracted
+```
+
+The extraction into two helpers preserves FTA-181 semantics verbatim and keeps the
+new gating isolated. Shared DTO-building code (pick FBto / FBgn / FBsf branch,
+instantiate the association DTO, append to the right list) factors into a small
+shared helper `_append_tool_component_dto(cassette_id, rel_type, object_feature_id,
+pub_curies, cassette_dto)`.
+
+### 4. New helper: `_emit_generic_ti_tool_data(data)` in `CassetteHandler`
+
+Implements the algorithm:
+
+```python
+def _emit_generic_ti_tool_data(self, data):
+    cassette_id = f'FB:{data["construct_uniquename"]}_cas'
+    cassette_dto = data['anon_cassette_dto']
+    propagate = data['propagate_transgenic_uses']
+
+    # 1. Parent FBtp data — only if propagate, and pub_curies BLANK.
+    if propagate:
+        for rel in data['direct_rels']:
+            self._append_tool_component_dto(cassette_id, rel, [], cassette_dto)
+        for tu in data['tool_uses_data']:
+            self._append_tool_use_dto(cassette_id, tu, [], cassette_dto)
+
+    # 2. Per associated FBal — emit iff represented, else NoteDTO.
+    for fbal in data['associated_alleles']:
+        has_tool_data = bool(fbal['direct_rels']) or bool(fbal['tool_uses_data'])
+        if not has_tool_data:
+            continue
+        if fbal['is_represented_at_alliance_as']:
+            for rel in fbal['direct_rels']:
+                pub_curies = self.lookup_pub_curies(rel['pub_ids'])
+                self._append_tool_component_dto(cassette_id, rel, pub_curies, cassette_dto)
+            # Group tool_uses by accession so each DTO gets its own pubs.
+            by_acc = {}
+            for tu in fbal['tool_uses_data']:
+                by_acc.setdefault(tu['accession'], []).append(tu['pub_id'])
+            for accession, pub_ids in by_acc.items():
+                pub_curies = self.lookup_pub_curies(pub_ids)
+                cassette_dto.cassette_use_dtos.append(
+                    agr_datatypes.CassetteUseSlotAnnotationDTO(
+                        pub_curies, [f'FBcv:{accession}']).dict_export())
+        else:
+            self.log.warning(
+                f"Skipping tool data from {fbal['uniquename']} for "
+                f"{data['construct_uniquename']}_cas: failed "
+                f"'is_represented_at_alliance_as' cross-check")
+            note_dto = agr_datatypes.NoteDTO(
+                'internal_note',
+                f"FTA: unable to add tool information from {fbal['uniquename']} "
+                f"(failed 'is_represented_at_alliance_as' cross-check)",
+                []).dict_export()
+            cassette_dto.note_dtos.append(note_dto)
+            self._ir_failure_counter += 1
+```
+
+`_ir_failure_counter` is summed + logged at the end of `map_anon_cassettes`.
+
+### 5. Helper: `_append_tool_component_dto`
+
+Consolidates the FBto/FBgn/FBsf branches from
+`map_anon_cassette_simple_components` (`cassette_handler.py:660-681`) and
+`map_anon_cassette_encodes_tool` (`684-718`). Handles the rel_type → alliance_rel
+mapping (`has_reg_region` → `is_regulated_by`, `tagged_with` → `tagged_with`,
+`carries_tool` → `contains`, `encodes_tool` → `expresses`). A single function used
+by both FTA-181 and FTA-182 paths eliminates the current near-duplication.
+
+### 6. Deduplication
+
+The ticket notes that the sample output has duplicate rows when the same tool is
+carried by multiple FBals (`FBti0168384_cas carries_tool FBto0000349` appears twice,
+once per source FBal). LinkML expects a single cassette-component entry. Use a
+`set` keyed by `(cassette_id, rel_type, object_feature_id)` inside
+`_emit_generic_ti_tool_data` to suppress repeats from multiple FBals, merging
+their `pub_curies`.
+
+For `tool_uses`, the grouping-by-accession pattern already does this naturally.
+
+## Touched files summary
+
+| File | Changes |
+|---|---|
+| `src/construct_handler.py` | New method `get_associated_allele_tool_data`; extend `get_generic_ti_anon_construct_data` to emit `is_generic_ti`, `associated_alleles`, `propagate_transgenic_uses`; tag FTA-181 path entries with `is_generic_ti: False` in `get_anon_cassette_data`; wire call into `query_chado_and_export`. |
+| `src/cassette_handler.py` | Split `map_anon_cassette_simple_components` / `_encodes_tool` / `_tool_uses` into FTA-181 + FTA-182 branches; add `_emit_generic_ti_tool_data`, `_emit_parent_tool_data_with_pubs`, `_append_tool_component_dto`, `_append_tool_use_dto`; add per-run IR-failure counter. |
+
+## Reused utilities / patterns
+
+- `FeatureRelationship` / `FeatureRelationshipPub` query pattern —
+  `construct_handler.py:627-670` (generic TI insertions)
+- `FeatureCvterm` + `FeatureCvtermprop` `tool_uses` pattern —
+  `construct_handler.py:278-310`
+- `Featureprop` query pattern — `construct_handler.py:314-336` (marked_with pub lookup)
+- `self.feature_lookup`, `self.organism_lookup`, `self.lookup_pub_curies` — handler base
+- Existing DTOs in `agr_datatypes.py`: `CassetteTransgenicToolAssociationDTO`,
+  `CassetteGenomicEntityAssociationDTO`, `CassetteComponentSlotAnnotationDTO`,
+  `CassetteUseSlotAnnotationDTO`, `NoteDTO`
+
+## Verification
+
+1. Run the cassette retrieval script with `ADD_CASS_TO_CONSTRUCT=YES`:
+   ```bash
+   ADD_CASS_TO_CONSTRUCT=YES python src/AGR_data_retrieval_curation_cassette.py
+   ```
+2. Grep the output JSON for `_cas` entries and compare against
+   `docs/FTA-182/FTA-182_output.v2.txt`. For each insertion in the sample:
+   - Confirm rel_type + tool ID + pub_curies match (after dedup).
+   - Confirm `pub_curies` is `[]` for every parent-FBtp-sourced row.
+   - Confirm `pub_curies` is populated for FBal-sourced rows.
+3. Targeted test cases (all currently in `construct_handler.test_set`):
+   - `FBti0212460` (parent FBtp0143312) — 0 associated FBals → parent-only path,
+     blank pub_curies.
+   - A generic-TI FBti with associated FBals where all pass `is_represented_at_alliance_as`
+     — no NoteDTOs, FBal pubs populated.
+   - A generic-TI FBti with a `propagate_transgenic_uses` featureprop on one of
+     its associated FBals — no parent tool data emitted.
+   - A generic-TI FBti with an associated FBal that has tool data but FAILS the
+     cross-check — one `NoteDTO` on the cassette with the exact text
+     `FTA: unable to add tool information from <FBal> (failed 'is_represented_at_alliance_as' cross-check)`.
+4. Check logs for the new IR-failure counter summary line.
+5. FTA-181 regression: for constructs in test_set that have `needs_anon_cassette`
+   (not `is_generic_ti`), confirm the emitted cassette DTOs are identical before
+   and after this change (use `git stash` + diff the output JSON).
+6. Schema validation:
+   ```bash
+   python src/validate_agr_schema.py <output.json>
+   ```
+
+## Open questions to resolve before coding
+
+1. **Dedup policy for `pub_curies` when merging multiple FBals.** Ticket shows the
+   raw (pre-dedup) rows; when two FBals both supply `carries_tool FBto0000349`
+   with different FBrfs, should the merged DTO carry the union of FBrfs, or just
+   the first? Proposal: union (set-deduped). Cheap and matches what a curator
+   would expect.
+2. **Whether FTA-181 path also needs pub_curies blanked for parent data.** The
+   ticket text restricts the "no parent pubs" rule to generic-TI cassettes, so
+   FTA-181 stays as-is. Confirm this with Gillian if unsure.
+3. **Allele regex for `associated_with` subject filter.** Use the strict
+   `^FBal[0-9]{7}$` from `self.regex['allele']`? Or accept anything subject_id
+   returns (chado integrity should already constrain)? Proposal: use the regex for
+   defensive correctness, matching how `get_generic_ti_insertions` filters FBti.

--- a/docs/FTA-182/text_for_FTA-182.v2.txt
+++ b/docs/FTA-182/text_for_FTA-182.v2.txt
@@ -1,0 +1,93 @@
+FTA-182: Add tool-related data to anonymous Cassettes made in FTA-181
+
+Tool-related information to be added to the <FBti_number>_cas Cassette made in FTA-181 can either come from:
+
+1. the parent generic TI FBtp of the original FBti
+  - in this case, the relevant FBtp is the object_id of feature_relationship type 'producedby', subject_id = FBti
+
+and/or
+
+2. any associated_with FBal that are linked to the original FBti
+
+ - in this case we need to check whether it is 'safe' to take information from the FBal to the FBti
+     - for this we should use the 'is_represented_at_alliance_as' feature_relationship in chado (this f_r is populated by map_alleles_to_insertions_for_alliance_genotypes.py is run each week every epicycle).
+
+
+foreach <FBti_number>_cas
+
+
+1. information needed:
+
+1a. get the list of associated FBal for the FBti: feature_relationship type: associated_with, object_id = FBti number, subject_id ~ FBal
+
+
+1b. for the list of associated FBal, see whether any FBal has a featureprop, type 'propagate_transgenic_uses'
+
+- an FBal only ever has this type of featureprop with the value 'n' (i.e. 'NO' do not propagate_transgenic_uses) - you don't need to check what the value of the featureprop is, just whether an FBal has a featureprop of this type
+
+- its quite rare for an FBal to have this featureprop - the featureprop only exists with the value 'n' in chado for the *small* proportion of cases where we do NOT want to propagate_transgenic_uses from the current generic FBtp to the FBal on the FlyBase web pages.
+
+- so I think the least least confusing way to do this is probably to have a propagate_transgenic_uses variable in the linkml code that has a default value of True, and if *any* of the associated FBal for an FBti that we are making a <FBti_number>_cas for have this kind of 'propagate_transgenic_uses' featureprop in chado, set the linkml code propagate_transgenic_uses to False - thats what I've done in the algorithm suggestion in 2. below
+
+
+
+1c. get the 'is_represented_at_alliance_as' feature_relationship information for the FBti, so we can check whether or not it is safe to add in any tool-related data attached to the FBal to the <FBti_number>_cas Cassette.
+
+info is in chado as: feature_relationship type = 'is_represented_at_alliance_as', object_id = FBti number, subject_id ~ FBal
+
+allele_handlers.py already has a dictionary with this info which can maybe be used:
+
+        self.at_locus_fbal_fbti_dict = {}      # Will be FBal-feature_id-keyed dict of FBti feature_id lists ("is_represented_at_Alliance_as").
+
+(I am not 100% sure, because we want to be looking at it from the point of view of the FBti, whereas at_locus_fbal_fbti_dict is keyed to FBal, so perhaps you'll need to make a new dictionary keyed to FBti instead so the lookup is easier ?)
+
+
+1d. tool-related information from the original parent generic TI FBtp
+
+this is the same kind of info that was grabbed previously for the 'construct.needs_anon_cassette' style FBtp
+
+
+- the 4 tool-related feature_relationships: 'encodes_tool', 'has_reg_region', 'tagged_with', 'carries_tool'  (parent generic TI FBtp = subject)
+- the tool_uses_data information that 'def get_construct_tool_uses' gathers (ie. FeatureCvterm with prop_type.name == 'tool_uses')
+- when we use this to add component information to the cassette, we should NOT used any pub_curies from the parent generic TI FBtp (they will not be correct for the individual <FBti_number>_cas)
+
+1e. tool-related information that is attached to any of the associated FBal identified in 1a.
+
+- the 4 tool-related feature_relationships: 'encodes_tool', 'has_reg_region', 'tagged_with', 'carries_tool'  - in this case the associated FBal is the subject
+- tool_uses_data information that is attached to the associated FBal (it is the same kind of data as for FBtp, i.e. FeatureCvterm with prop_type.name == 'tool_uses')
+- in this case we *will* want to use the list of pub_curies attached to this tool-related info when adding it to the <FBti_number>_cas
+
+
+
+
+2. Overall logic for algorithm
+
+for each <FBti_number>_cas
+
+    if the number of associated FBal for the FBti = 0
+        add tool-related information from the original parent generic TI FBtp # data from 1d. above - pub_curies = blank
+
+    else
+         # set the value of propagate_transgenic_uses variable to True/False depending on whether we want to use the information from associated FBal
+         # set to True as default, as this is the most common case
+         propagate_transgenic_uses = True
+             foreach (associated FBal)
+                if (exists featureprop, type 'propagate_transgenic_uses' for that associated FBal) # data from 1b. above
+                     propagate_transgenic_uses = False
+                     break # I think this is what you need in python to just short-circuit out of the loop here (i.e. last in perl) - once we've found one case we don't need to go through all the associated FBal, we just leave it as False
+
+         # first, add tool-related info from original parent generic TI FBtp if appropriate
+         if (propagate_transgenic_uses = True):
+             add tool-related information from the original parent generic TI FBtp # data from 1d. above - leave pub_curies blank
+
+         # second, add tool-related info from the associated FBal(s) if safe to do so
+         foreach (associated FBal)
+             if (there is tool-related information from the associated FBal) # data from 1e. above
+                     if (there is a 'is_represented_at_alliance_as' feature_relationship between the associated FBal and the FBti) # data from 1c. above
+                         add tool-related information from the associated FBal # data from 1e. above - use pub_curies
+                     else
+                         # add a log warning/counter that did not add any tool-related info
+                         # add an internal_note NoteDTO to the anonymous cassette so its easy to clean up later
+                         # text of internal_note: "FTA: unable to add tool information from <FBal_number> (failed 'is_represented_at_alliance_as' cross-check)"
+
+

--- a/docs/FTA-182/text_for_FTA-182.v3.txt
+++ b/docs/FTA-182/text_for_FTA-182.v3.txt
@@ -1,0 +1,104 @@
+FTA-182: Add tool-related data to anonymous Cassettes made in FTA-181
+
+Tool-related information to be added to the <FBti_number>_cas Cassette made in FTA-181 can either come from:
+
+1. the parent generic TI FBtp of the original FBti
+  - in this case, the relevant FBtp is the object_id of feature_relationship type 'producedby', subject_id = FBti
+
+and/or
+
+2. any associated_with FBal that are linked to the original FBti
+
+ - in this case we need to check whether it is 'safe' to take information from the FBal to the FBti
+     - for this we should use the 'is_represented_at_alliance_as' feature_relationship in chado (this f_r is populated by map_alleles_to_insertions_for_alliance_genotypes.py is run each week every epicycle).
+
+
+foreach <FBti_number>_cas
+
+
+1. information needed:
+
+1a. get the list of associated FBal for the FBti: feature_relationship type: associated_with, object_id = FBti number, subject_id ~ FBal
+
+
+1b. for the list of associated FBal, see whether any FBal has a featureprop, type 'propagate_transgenic_uses'
+
+- an FBal only ever has this type of featureprop with the value 'n' (i.e. 'NO' do not propagate_transgenic_uses) - you don't need to check what the value of the featureprop is, just whether an FBal has a featureprop of this type
+
+- its quite rare for an FBal to have this featureprop - the featureprop only exists with the value 'n' in chado for the *small* proportion of cases where we do NOT want to propagate_transgenic_uses from the current generic FBtp to the FBal on the FlyBase web pages.
+
+- so I think the least least confusing way to do this is probably to have a propagate_transgenic_uses variable in the linkml code that has a default value of True, and if *any* of the associated FBal for an FBti that we are making a <FBti_number>_cas for have this kind of 'propagate_transgenic_uses' featureprop in chado, set the linkml code propagate_transgenic_uses to False - thats what I've done in the algorithm suggestion in 2. below
+
+
+
+1c. get the 'is_represented_at_alliance_as' feature_relationship information for the FBti, so we can check whether or not it is safe to add in any tool-related data attached to the FBal to the <FBti_number>_cas Cassette.
+
+info is in chado as: feature_relationship type = 'is_represented_at_alliance_as', object_id = FBti number, subject_id ~ FBal
+
+allele_handlers.py already has a dictionary with this info which can maybe be used:
+
+        self.at_locus_fbal_fbti_dict = {}      # Will be FBal-feature_id-keyed dict of FBti feature_id lists ("is_represented_at_Alliance_as").
+
+(I am not 100% sure, because we want to be looking at it from the point of view of the FBti, whereas at_locus_fbal_fbti_dict is keyed to FBal, so perhaps you'll need to make a new dictionary keyed to FBti instead so the lookup is easier ?)
+
+
+1d. tool-related information from the original parent generic TI FBtp
+
+this is the same kind of info that was grabbed previously for the 'construct.needs_anon_cassette' style FBtp
+
+
+- the 4 tool-related feature_relationships: 'encodes_tool', 'has_reg_region', 'tagged_with', 'carries_tool'  (parent generic TI FBtp = subject)
+- the tool_uses_data information that 'def get_construct_tool_uses' gathers (ie. FeatureCvterm with prop_type.name == 'tool_uses')
+- when we use this to add component information to the cassette, we should NOT used any pub_curies from the parent generic TI FBtp (they will not be correct for the individual <FBti_number>_cas)
+
+1e. tool-related information that is attached to any of the associated FBal identified in 1a.
+
+- the 4 tool-related feature_relationships: 'encodes_tool', 'has_reg_region', 'tagged_with', 'carries_tool'  - in this case the associated FBal is the subject
+- tool_uses_data information that is attached to the associated FBal (it is the same kind of data as for FBtp, i.e. FeatureCvterm with prop_type.name == 'tool_uses')
+- in this case we *will* want to use the list of pub_curies attached to this tool-related info when adding it to the <FBti_number>_cas
+
+
+
+1f. pub_curies from the 'producedby' feature_relationship that links the FBti (subject_id) to the generic TI FBtp (object_id)
+
+
+2. Overall logic for algorithm
+
+for each <FBti_number>_cas
+
+    if the number of associated FBal for the FBti = 0
+        add tool-related information from the original parent generic TI FBtp # data from 1d. above 
+             # assigning the pub curie
+             if the FBti producedby FBtp feature_relationship has a single FBrf attached to it # data from 1f. above
+                 use that FBrf as the pub curie for the tool-related info
+             else leave the pub curie blank
+
+
+    else
+         # set the value of propagate_transgenic_uses variable to True/False depending on whether we want to use the information from associated FBal
+         # set to True as default, as this is the most common case
+         propagate_transgenic_uses = True
+             foreach (associated FBal)
+                if (exists featureprop, type 'propagate_transgenic_uses' for that associated FBal) # data from 1b. above
+                     propagate_transgenic_uses = False
+                     break # I think this is what you need in python to just short-circuit out of the loop here (i.e. last in perl) - once we've found one case we don't need to go through all the associated FBal, we just leave it as False
+
+         # first, add tool-related info from original parent generic TI FBtp if appropriate
+         if (propagate_transgenic_uses = True):
+             add tool-related information from the original parent generic TI FBtp # data from 1d. above
+                 # assigning the pub curie
+                 if the FBti producedby FBtp feature_relationship has a single FBrf attached to it # data from 1f. above
+                     use that FBrf as the pub curie for the tool-related info
+                 else leave the pub curie blank
+
+         # second, add tool-related info from the associated FBal(s) if safe to do so
+         foreach (associated FBal)
+             if (there is tool-related information from the associated FBal) # data from 1e. above
+                     if (there is a 'is_represented_at_alliance_as' feature_relationship between the associated FBal and the FBti) # data from 1c. above
+                         add tool-related information from the associated FBal # data from 1e. above - use pub_curies
+                     else
+                         # add a log warning/counter that did not add any tool-related info
+                         # add an internal_note NoteDTO to the anonymous cassette so its easy to clean up later
+                         # text of internal_note: "FTA: unable to add tool information from <FBal_number> (failed 'is_represented_at_alliance_as' cross-check)"
+
+

--- a/docs/plans/2026-03-02-fix-hardcoded-feature-cvterm-in-get-entity-cvterms.md
+++ b/docs/plans/2026-03-02-fix-hardcoded-feature-cvterm-in-get-entity-cvterms.md
@@ -1,0 +1,139 @@
+# Fix Hardcoded `feature_cvterm` in `get_entity_cvterms()` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace hardcoded `feature_cvterm` references in `entity_handler.py:get_entity_cvterms()` with generic `chado_type`-based attribute access so the method works for strains, genotypes, and all other entity types.
+
+**Architecture:** The method already uses a `chado_type` variable (set to `'feature'`, `'strain'`, `'genotype'`, etc.) and `getattr()` for dynamic table/column access throughout most of the method. Lines 579-591 break this pattern by hardcoding `feature_cvterm`. The fix makes these lines follow the same `getattr()` pattern, using the fact that all chado `*Cvtermprop` models have a `{chado_type}_cvterm` relationship, and all `*Cvterm` models have a `{chado_type}` relationship back to the parent entity plus `cvterm` and `pub` relationships.
+
+**Tech Stack:** Python, SQLAlchemy (harvdev_utils chado models)
+
+---
+
+## Root Cause
+
+In `src/entity_handler.py`, the `get_entity_cvterms()` method processes cvterm property results (lines 574-598). While the query building (lines 491-573) correctly uses `chado_type` and `getattr()` to be generic, the result-processing loop hardcodes `feature_cvterm`:
+
+```python
+# Line 579 - hardcoded
+entity_id = cvtermprop_result.feature_cvterm.feature.feature_id
+# Lines 588-591 - hardcoded
+prop_data = {'name': cvtermprop_result.feature_cvterm.cvterm.name, ...}
+```
+
+When `chado_type = 'strain'`, the `StrainCvtermprop` object has no `feature_cvterm` attribute. It has `strain_cvterm`, which points to `StrainCvterm` (which has `.strain`, `.cvterm`, `.pub`).
+
+### Model relationship pattern (all types follow this):
+
+| Cvtermprop model | Relationship to Cvterm | Cvterm → Entity | Cvterm → Cvterm | Cvterm → Pub |
+|---|---|---|---|---|
+| `FeatureCvtermprop` | `.feature_cvterm` | `.feature` | `.cvterm` | `.pub` |
+| `StrainCvtermprop` | `.strain_cvterm` | `.strain` | `.cvterm` | `.pub` |
+| `GenotypeCvtermprop` | `.genotype_cvterm` | `.genotype` | `.cvterm` | `.pub` |
+
+---
+
+### Task 1: Replace hardcoded `feature_cvterm` with generic `chado_type`-based access
+
+**Files:**
+- Modify: `src/entity_handler.py:574-598`
+
+**Step 1: Create the reusable cvterm accessor variable**
+
+At line 574 (just before the loop begins), add a line to get the cvterm relationship name:
+
+```python
+        cvterm_rel_name = f'{chado_type}_cvterm'
+```
+
+**Step 2: Replace line 579 (entity_id lookup)**
+
+Replace:
+```python
+            # Strain does not have feature_cvterm !!
+            entity_id = cvtermprop_result.feature_cvterm.feature.feature_id
+```
+
+With:
+```python
+            cvterm_obj = getattr(cvtermprop_result, cvterm_rel_name)
+            entity_obj = getattr(cvterm_obj, chado_type)
+            entity_id = getattr(entity_obj, f'{chado_type}_id')
+```
+
+**Step 3: Replace line 584 (error logging)**
+
+Replace:
+```python
+                    self.log.error(f"Entity_id:{entity_id} not in list of data_entities feature {cvtermprop_result.feature_cvterm.feature}")
+```
+
+With:
+```python
+                    self.log.error(f"Entity_id:{entity_id} not in list of data_entities {chado_type} {entity_obj}")
+```
+
+**Step 4: Replace lines 588-591 (prop_data dict)**
+
+Replace:
+```python
+                prop_data = {'name': cvtermprop_result.feature_cvterm.cvterm.name,
+                             'type': cvtermprop_result.feature_cvterm.cvterm.cv.name,
+                             'pub': cvtermprop_result.feature_cvterm.pub.uniquename,
+                             'accession': cvtermprop_result.feature_cvterm.cvterm.dbxref.accession}
+```
+
+With:
+```python
+                prop_data = {'name': cvterm_obj.cvterm.name,
+                             'type': cvterm_obj.cvterm.cv.name,
+                             'pub': cvterm_obj.pub.uniquename,
+                             'accession': cvterm_obj.cvterm.dbxref.accession}
+```
+
+Note: `cvterm_obj` is already set earlier in the loop iteration (Step 2), so we reuse it here. The `.cvterm` and `.pub` relationships exist on all `*Cvterm` models (FeatureCvterm, StrainCvterm, GenotypeCvterm, etc.).
+
+**Step 5: Verify the final code block looks correct**
+
+The full loop (lines 574-598) should read:
+
+```python
+        cvterm_prop_counter = 0
+        cvterm_rel_name = f'{chado_type}_cvterm'
+        for cvtermprop_result in cvtermprop_results:
+            entity_cvterm_id = getattr(cvtermprop_result, f'{chado_type}_cvterm_id')
+            entity_prop_type_name = self.cvterm_lookup[cvtermprop_result.type_id]['name']
+            cvterm_obj = getattr(cvtermprop_result, cvterm_rel_name)
+            entity_obj = getattr(cvterm_obj, chado_type)
+            entity_id = getattr(entity_obj, f'{chado_type}_id')
+            if entity_id in self.ignore_list:
+                continue
+            elif entity_id not in self.fb_data_entities:
+                if not self.testing:
+                    self.log.error(f"Entity_id:{entity_id} not in list of data_entities {chado_type} {entity_obj}")
+                    self.log.error(f"Ignore_list is {self.ignore_list}")
+                continue
+            if entity_prop_type_name in self.fb_data_entities[entity_id].prop_data:
+                prop_data = {'name': cvterm_obj.cvterm.name,
+                             'type': cvterm_obj.cvterm.cv.name,
+                             'pub': cvterm_obj.pub.uniquename,
+                             'accession': cvterm_obj.cvterm.dbxref.accession}
+                self.fb_data_entities[entity_id].prop_data[entity_prop_type_name].append(prop_data)
+            if entity_prop_type_name in cvterm_annotation_dict[entity_cvterm_id].props_by_type.keys():
+                cvterm_annotation_dict[entity_cvterm_id].props_by_type[entity_prop_type_name].append(fb_datatypes.FBProp(cvtermprop_result))
+                cvterm_prop_counter += 1
+            else:
+                cvterm_annotation_dict[entity_cvterm_id].props_by_type[entity_prop_type_name] = [fb_datatypes.FBProp(cvtermprop_result)]
+                cvterm_prop_counter += 1
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/entity_handler.py
+git commit -m "fix: replace hardcoded feature_cvterm with generic chado_type access in get_entity_cvterms
+
+The cvtermprop result processing loop hardcoded feature_cvterm relationships,
+causing AttributeError for StrainCvtermprop (and any non-feature entity type).
+Now uses getattr() with chado_type, matching the pattern used elsewhere in the method."
+```

--- a/docs/plans/2026-03-18-FTA-139-construct-cassette-association-design.md
+++ b/docs/plans/2026-03-18-FTA-139-construct-cassette-association-design.md
@@ -1,0 +1,235 @@
+# FTA-139: Construct-Cassette Association Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Export `marked_with` relationships between constructs (FBtp) and cassettes (FBal) as `ConstructCassetteAssociationDTO` for Alliance LinkML submission.
+
+**Architecture:** The `marked_with` relationships (FBtp subject → FBal object) are already captured by `get_entity_relationships(session, 'subject')` in `construct_handler.py:207`. We add a DTO class, a mapping method that uses `recall_relationships()` to filter for `marked_with`, and wire up the export pipeline.
+
+**Tech Stack:** Python, SQLAlchemy, chado PostgreSQL database
+
+---
+
+### Task 1: Create branch FTA-139
+
+**Step 1: Create and switch to new branch**
+
+Run: `cd /Users/ilongden/harvard/alliance-linkml-flybase && git checkout -b FTA-139`
+
+**Step 2: Commit** — N/A (no files changed yet)
+
+---
+
+### Task 2: Add ConstructCassetteAssociationDTO to agr_datatypes.py
+
+**Files:**
+- Modify: `src/agr_datatypes.py:354` (insert before `ConstructGenomicEntityAssociationDTO`)
+
+**Step 1: Add the new DTO class**
+
+Insert after line 372 (end of `ConstructGenomicEntityAssociationDTO`), before `class AnnotationDTO`:
+
+```python
+class ConstructCassetteAssociationDTO(EvidenceAssociationDTO):
+    """ConstructCassetteAssociationDTO class."""
+    def __init__(self, construct_id: str, rel_type: str, cassette_id: str, evidence_curies: list):
+        """Create ConstructCassetteAssociationDTO for FlyBase object.
+
+        Args:
+            construct_id (str): The FB:FBtp curie for the construct.
+            rel_type (str): A relation name: has_selectable_marker or has_transcriptional_unit.
+            cassette_id (str): The FB:FBal curie for the cassette.
+            evidence_curies (list): A list of FB:FBrf or PMID:### curies.
+
+        """
+        super().__init__(evidence_curies)
+        self.construct_identifier = construct_id
+        self.relation_name = rel_type
+        self.cassette_identifier = cassette_id
+        self.required_fields.extend(['construct_identifier', 'relation_name', 'cassette_identifier'])
+```
+
+**Step 2: Run flake8 check**
+
+Run: `cd /Users/ilongden/harvard/alliance-linkml-flybase && flake8 src/agr_datatypes.py`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/agr_datatypes.py
+git commit -m "feat(FTA-139): add ConstructCassetteAssociationDTO"
+```
+
+---
+
+### Task 3: Add cassette association list and mapping method to construct_handler.py
+
+**Files:**
+- Modify: `src/construct_handler.py`
+
+**Step 1: Add class attribute for cassette associations**
+
+After line 62 (`construct_associations = []`), add:
+
+```python
+    construct_cassette_associations = []    # Will be a list of FBExportEntity objects, map to ConstructCassetteAssociationDTO.
+```
+
+**Step 2: Replace the TODO comment with a pass-through comment**
+
+At line 216, replace:
+```python
+        # BOB: get_allele_marked_with()
+```
+with:
+```python
+        # marked_with rels already captured by get_entity_relationships(session, 'subject') above.
+```
+
+**Step 3: Add `map_construct_cassette_associations()` method**
+
+Insert after `map_construct_genomic_associations()` (after line 490), before `map_fb_data_to_alliance()`:
+
+```python
+    def map_construct_cassette_associations(self):
+        """Map construct marked_with cassette relations to ConstructCassetteAssociationDTO."""
+        self.log.info('Map construct marked_with cassette associations.')
+        counter = 0
+        for construct in self.fb_data_entities.values():
+            marked_with_rels = construct.recall_relationships(
+                self.log, entity_role='subject', rel_types='marked_with', rel_entity_types='allele')
+            for rel in marked_with_rels:
+                cassette_feature_id = rel.chado_obj.object_id
+                cassette_uniquename = self.feature_lookup[cassette_feature_id]['uniquename']
+                cons_curie = f'FB:{construct.uniquename}'
+                cassette_curie = f'FB:{cassette_uniquename}'
+                pub_curies = self.lookup_pub_curies(rel.pubs)
+                # FBal0345196 is a special case per FTA-139.
+                if cassette_uniquename == 'FBal0345196':
+                    relation_name = 'has_transcriptional_unit'
+                else:
+                    relation_name = 'has_selectable_marker'
+                fb_rel = fb_datatypes.FBExportEntity()
+                rel_dto = agr_datatypes.ConstructCassetteAssociationDTO(
+                    cons_curie, relation_name, cassette_curie, pub_curies)
+                if construct.is_obsolete is True or self.feature_lookup[cassette_feature_id]['is_obsolete'] is True:
+                    rel_dto.obsolete = True
+                    rel_dto.internal = True
+                fb_rel.linkmldto = rel_dto
+                self.construct_cassette_associations.append(fb_rel)
+                counter += 1
+        self.log.info(f'Mapped {counter} ConstructCassetteAssociationDTOs.')
+        return
+```
+
+**Step 4: Run flake8 check**
+
+Run: `flake8 src/construct_handler.py`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add src/construct_handler.py
+git commit -m "feat(FTA-139): add map_construct_cassette_associations method"
+```
+
+---
+
+### Task 4: Wire up mapping and export in construct_handler.py
+
+**Files:**
+- Modify: `src/construct_handler.py`
+
+**Step 1: Update `map_fb_data_to_alliance()`**
+
+In `map_fb_data_to_alliance()`, after line 509 (`self.flag_internal_fb_entities('construct_associations')`), add:
+
+```python
+        self.map_construct_cassette_associations()
+        self.flag_internal_fb_entities('construct_cassette_associations')
+```
+
+**Step 2: Update `query_chado_and_export()`**
+
+In `query_chado_and_export()`, after line 517 (`self.generate_export_dict(self.construct_associations, ...)`), add:
+
+```python
+        self.flag_unexportable_entities(self.construct_cassette_associations, 'construct_cassette_association_ingest_set')
+        self.generate_export_dict(self.construct_cassette_associations, 'construct_cassette_association_ingest_set')
+```
+
+**Step 3: Run flake8 check**
+
+Run: `flake8 src/construct_handler.py`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add src/construct_handler.py
+git commit -m "feat(FTA-139): wire cassette associations into export pipeline"
+```
+
+---
+
+### Task 5: Update entry point script to output cassette associations
+
+**Files:**
+- Modify: `src/AGR_data_retrieval_curation_construct.py`
+
+**Step 1: Add cassette association export**
+
+In `main()`, after line 116 (`generate_export_file(association_export_dict, ...)`), and still inside the `if not reference_session:` block, add:
+
+```python
+        # Export the construct-cassette associations to a separate file.
+        cassette_assoc_output_filename = output_filename.replace('construct', 'construct_cassette_association')
+        cassette_assoc_export_dict = {
+            'linkml_version': linkml_release,
+            'alliance_member_release_version': database_release,
+        }
+        cassette_assoc_export_dict['construct_cassette_association_ingest_set'] = cons_handler.export_data['construct_cassette_association_ingest_set']
+        if len(cassette_assoc_export_dict['construct_cassette_association_ingest_set']) == 0:
+            log.warning('The "construct_cassette_association_ingest_set" is empty.')
+        else:
+            generate_export_file(cassette_assoc_export_dict, log, cassette_assoc_output_filename)
+```
+
+Note: Using `log.warning` instead of raising ValueError since it's plausible that in test mode there may be no marked_with relationships in the test set.
+
+**Step 2: Run flake8 check**
+
+Run: `flake8 src/AGR_data_retrieval_curation_construct.py`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/AGR_data_retrieval_curation_construct.py
+git commit -m "feat(FTA-139): export construct-cassette associations to JSON"
+```
+
+---
+
+### Task 6: Final verification
+
+**Step 1: Run flake8 on all modified files**
+
+Run: `flake8 src/agr_datatypes.py src/construct_handler.py src/AGR_data_retrieval_curation_construct.py`
+Expected: No errors
+
+**Step 2: Review diff**
+
+Run: `git diff main --stat`
+Expected: 3 files changed
+
+---
+
+## Key Decisions
+
+- **No new query method needed**: `get_entity_relationships(session, 'subject')` already captures `marked_with` relationships. We use `recall_relationships()` to filter them in the mapping step.
+- **Separate output file**: Cassette associations get their own JSON file (`construct_cassette_association`), following the existing pattern where genomic entity associations have a separate file.
+- **Warning not error for empty set**: Test mode may not have `marked_with` data in the test_set, so we warn instead of raising ValueError.
+- **FBal0345196 hardcoded exception**: Per the Jira ticket, this specific allele uses `has_transcriptional_unit` instead of `has_selectable_marker`.

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -28,6 +28,76 @@ from harvdev_utils.psycopg_functions import set_up_db_reading
 from allele_handlers import AlleleHandler, AberrationHandler    # BalancerHandler
 from utils import export_chado_data, generate_export_file
 
+
+def generate_tsv_file(export_dict, filename):
+    """Generate tsv files for curators to read more easily.
+
+    Writes two TSVs: a main allele-summary file (symbols/names/synonyms) and
+    a notes file. Mirrors the pattern in AGR_data_retrieval_curation_cassette.py.
+    """
+    with open(filename, 'w') as outfile:
+        outfile.write("# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\n")
+        for entity_dict in export_dict["allele_ingest_set"]:
+            primary = entity_dict["primary_external_id"]
+            symbol = ''
+            name = ''
+            secondary = []
+            syns = []
+            if "allele_full_name_dto" in entity_dict:
+                name = entity_dict["allele_full_name_dto"]["format_text"]
+            if "allele_symbol_dto" in entity_dict:
+                symbol = entity_dict["allele_symbol_dto"]["format_text"]
+            if "allele_synonym_dtos" in entity_dict:
+                for synonym in entity_dict["allele_synonym_dtos"]:
+                    syns.append(synonym["format_text"])
+            if "secondary_identifiers" in entity_dict:
+                secondary = entity_dict["secondary_identifiers"]
+            try:
+                outfile.write(f"{primary}\t{symbol}\t{name}\t{'|'.join(secondary)}\t{'|'.join(syns)}\n")
+            except TypeError:
+                log.error(f"entity_dict: {entity_dict}")
+                log.error(f"primary: {primary}")
+                log.error(f"secondary {secondary}")
+                log.error(f"symbol: {symbol}")
+                log.error(f"name: {name}")
+                log.error(f"syns: {syns}")
+                raise
+
+    filename = filename.replace('.tsv', '_notes.tsv')
+    with open(filename, 'w') as outfile:
+        outfile.write("# Primary FBid\ttype\tcomment\n")
+        for entity_dict in export_dict["allele_ingest_set"]:
+            primary = entity_dict["primary_external_id"]
+            if "note_dtos" in entity_dict:
+                for note in entity_dict["note_dtos"]:
+                    ntype = note["note_type_name"]
+                    txt = note['free_text']
+                    outfile.write(f"{primary}\t{ntype}\t{txt}\n")
+
+
+def generate_association_tsv_file(export_dict, ingest_name, filename):
+    """Generate tsv file for an allele-* association ingest set."""
+    filename = filename.replace('.tsv', '_associations.tsv')
+    first_entity = 'allele_identifier'
+    if ingest_name == 'allele_gene_association_ingest_set':
+        second_entity = 'gene_identifier'
+    elif ingest_name == 'allele_construct_association_ingest_set':
+        second_entity = 'construct_identifier'
+    else:
+        second_entity = 'object_identifier'
+    with open(filename, 'w') as outfile:
+        outfile.write(f"#{first_entity}\tRelationship\t{second_entity}\tEvidence\n")
+        for entity_dict in export_dict[ingest_name]:
+            sub = entity_dict[first_entity]
+            obj = entity_dict[second_entity]
+            rel_type = entity_dict['relation_name']
+            if 'evidence_curies' in entity_dict:
+                pubs = "|".join(entity_dict['evidence_curies'])
+            else:
+                pubs = "NO PUBS"
+            outfile.write(f"{sub}\t{rel_type}\t{obj}\t{pubs}\n")
+
+
 # Data types handled by this script.
 REPORT_LABEL = 'allele_curation'
 
@@ -118,6 +188,7 @@ def main():
             raise ValueError('The "allele_ingest_set" is unexpectedly empty.')
     else:
         generate_export_file(export_dict, log, output_filename)
+        generate_tsv_file(export_dict, set_up_dict['output_filename'])
 
     if not reference_session:
         # Export the gene-allele associations to a separate file.
@@ -141,6 +212,16 @@ def main():
             raise ValueError('The "allele_construct_association_ingest_set" is unexpectedly empty.')
         # Print the output file.
         generate_export_file(association_export_dict, log, association_output_filename)
+        # Per-association-set TSV files for easy curator review.
+        for ingest_name in ('allele_gene_association_ingest_set',
+                            'allele_construct_association_ingest_set'):
+            set_name = ingest_name.replace('_ingest_set', '')
+            tsv_filename = set_up_dict['output_filename'].replace('allele', set_name)
+            try:
+                generate_association_tsv_file(association_export_dict, ingest_name, tsv_filename)
+            except KeyError as e:
+                log.error(f'The "{ingest_name}" blew up on tsv generation. KeyError {e}')
+                raise
 
     log.info('Ended main function.\n')
 

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -90,7 +90,7 @@ def generate_association_tsv_file(export_dict, ingest_name, filename):
     else:
         second_entity = 'object_identifier'
     with open(filename, 'w') as outfile:
-        outfile.write(f"#{first_entity}\tRelationship\t{second_entity}\tEvidence\n")
+        outfile.write(f"#{first_entity}\tRelationship\t{second_entity}\tEvidence\tinternal\n")
         for entity_dict in export_dict[ingest_name]:
             sub = entity_dict[first_entity]
             obj = entity_dict[second_entity]
@@ -99,7 +99,8 @@ def generate_association_tsv_file(export_dict, ingest_name, filename):
                 pubs = "|".join(entity_dict['evidence_curies'])
             else:
                 pubs = "NO PUBS"
-            outfile.write(f"{sub}\t{rel_type}\t{obj}\t{pubs}\n")
+            internal = entity_dict.get('internal', False)
+            outfile.write(f"{sub}\t{rel_type}\t{obj}\t{pubs}\t{internal}\n")
 
 
 # Data types handled by this script.

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -36,7 +36,8 @@ def generate_tsv_file(export_dict, filename):
     a notes file. Mirrors the pattern in AGR_data_retrieval_curation_cassette.py.
     """
     with open(filename, 'w') as outfile:
-        outfile.write("# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\n")
+        outfile.write(
+            "# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\tinternal\n")
         for entity_dict in export_dict["allele_ingest_set"]:
             primary = entity_dict["primary_external_id"]
             symbol = ''
@@ -52,8 +53,10 @@ def generate_tsv_file(export_dict, filename):
                     syns.append(synonym["format_text"])
             if "secondary_identifiers" in entity_dict:
                 secondary = entity_dict["secondary_identifiers"]
+            internal = entity_dict.get("internal", False)
             try:
-                outfile.write(f"{primary}\t{symbol}\t{name}\t{'|'.join(secondary)}\t{'|'.join(syns)}\n")
+                outfile.write(
+                    f"{primary}\t{symbol}\t{name}\t{'|'.join(secondary)}\t{'|'.join(syns)}\t{internal}\n")
             except TypeError:
                 log.error(f"entity_dict: {entity_dict}")
                 log.error(f"primary: {primary}")
@@ -61,6 +64,7 @@ def generate_tsv_file(export_dict, filename):
                 log.error(f"symbol: {symbol}")
                 log.error(f"name: {name}")
                 log.error(f"syns: {syns}")
+                log.error(f"internal: {internal}")
                 raise
 
     filename = filename.replace('.tsv', '_notes.tsv')

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -22,6 +22,7 @@ Notes:
 """
 
 import argparse
+from os import environ
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
@@ -34,11 +35,23 @@ def generate_tsv_file(export_dict, filename):
 
     Writes two TSVs: a main allele-summary file (symbols/names/synonyms) and
     a notes file. Mirrors the pattern in AGR_data_retrieval_curation_cassette.py.
+
+    ADD_OBSOLETE=NO suppresses obsolete/internal rows in the TSV only; the
+    JSON output is unaffected.
     """
+    skip_obsolete = environ.get('ADD_OBSOLETE') == 'NO'
+    if skip_obsolete:
+        log.info('ADD_OBSOLETE=NO: excluding obsolete/internal alleles from TSV.')
+
+    def _skip(d):
+        return skip_obsolete and (d.get('internal') or d.get('obsolete'))
+
     with open(filename, 'w') as outfile:
         outfile.write(
             "# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\tinternal\n")
         for entity_dict in export_dict["allele_ingest_set"]:
+            if _skip(entity_dict):
+                continue
             primary = entity_dict["primary_external_id"]
             symbol = ''
             name = ''
@@ -71,6 +84,8 @@ def generate_tsv_file(export_dict, filename):
     with open(filename, 'w') as outfile:
         outfile.write("# Primary FBid\ttype\tcomment\n")
         for entity_dict in export_dict["allele_ingest_set"]:
+            if _skip(entity_dict):
+                continue
             primary = entity_dict["primary_external_id"]
             if "note_dtos" in entity_dict:
                 for note in entity_dict["note_dtos"]:
@@ -80,7 +95,10 @@ def generate_tsv_file(export_dict, filename):
 
 
 def generate_association_tsv_file(export_dict, ingest_name, filename):
-    """Generate tsv file for an allele-* association ingest set."""
+    """Generate tsv file for an allele-* association ingest set.
+
+    ADD_OBSOLETE=NO suppresses obsolete/internal rows in the TSV only.
+    """
     filename = filename.replace('.tsv', '_associations.tsv')
     first_entity = 'allele_identifier'
     if ingest_name == 'allele_gene_association_ingest_set':
@@ -89,9 +107,12 @@ def generate_association_tsv_file(export_dict, ingest_name, filename):
         second_entity = 'construct_identifier'
     else:
         second_entity = 'object_identifier'
+    skip_obsolete = environ.get('ADD_OBSOLETE') == 'NO'
     with open(filename, 'w') as outfile:
         outfile.write(f"#{first_entity}\tRelationship\t{second_entity}\tEvidence\tinternal\n")
         for entity_dict in export_dict[ingest_name]:
+            if skip_obsolete and (entity_dict.get('internal') or entity_dict.get('obsolete')):
+                continue
             sub = entity_dict[first_entity]
             obj = entity_dict[second_entity]
             rel_type = entity_dict['relation_name']
@@ -126,6 +147,7 @@ parser = argparse.ArgumentParser(
 Environment variables:
   SERVER              Database server (e.g. flysql25)
   DATABASE            Database name (e.g. production_chado)
+  ADD_OBSOLETE        Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -98,7 +98,8 @@ else:
 def generate_tsv_file(export_dict, filename):
     """Generate tsv files for curators to read more easily. This can be commented out later."""
     with open(filename, 'w') as outfile:
-        outfile.write("# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\n")
+        outfile.write(
+            "# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\tinternal\n")
         for entity_dict in export_dict["cassette_ingest_set"]:
             primary = entity_dict["primary_external_id"]
             symbol = ''
@@ -114,8 +115,10 @@ def generate_tsv_file(export_dict, filename):
                     syns.append(synonym["format_text"])
             if "secondary_identifiers" in entity_dict:
                 secondary = entity_dict["secondary_identifiers"]
+            internal = entity_dict.get("internal", False)
             try:
-                outfile.write(f"{primary}\t{symbol}\t{name}\t{'|'.join(secondary)}\t{'|'.join(syns)}\n")
+                outfile.write(
+                    f"{primary}\t{symbol}\t{name}\t{'|'.join(secondary)}\t{'|'.join(syns)}\t{internal}\n")
             except TypeError:
                 log.error(f"entity_dict: {entity_dict}")
                 log.error(f"primary: {primary}")
@@ -123,6 +126,7 @@ def generate_tsv_file(export_dict, filename):
                 log.error(f"symbol: {symbol}")
                 log.error(f"name: {name}")
                 log.error(f"syns: {syns}")
+                log.error(f"internal: {internal}")
                 raise
 
     filename = filename.replace('.tsv', '_notes.tsv')

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -228,17 +228,6 @@ def main():
             cassette_handler.receive_anon_cassette_data(cassette_data)
             cassette_handler.map_anon_cassettes()
             cassette_handler.export_anon_cassettes()
-            # Export anonymous constructs to a separate JSON file.
-            anon_con_set = 'generic_ti_anon_construct_ingest_set'
-            if anon_con_set in cons_handler.export_data and cons_handler.export_data[anon_con_set]:
-                anon_construct_export = {
-                    'linkml_version': linkml_release,
-                    'alliance_member_release_version': database_release,
-                    anon_con_set: cons_handler.export_data[anon_con_set],
-                }
-                anon_con_filename = output_filename.replace(
-                    'cassette', 'generic_ti_anon_construct')
-                generate_export_file(anon_construct_export, log, anon_con_filename)
             log.info(f'Created {len(generic_ti_data)} anonymous constructs '
                      f'and cassettes for generic TI insertions.')
         else:

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -179,7 +179,7 @@ def generate_association_tsv_file(export_dict, ingest_name, filename):
     with open(filename, 'w') as outfile:
         outfile.write(f"#{first_entity}\tRelationship\t{second_entity}\tEvidence\tComp type curie\n")
         for entity_dict in export_dict[ingest_name]:
-            print(f"Dumping {entity_dict}.")
+            # print(f"Dumping {entity_dict}.")
             sub = entity_dict[first_entity]
             obj = entity_dict[second_entity]
             rel_type = entity_dict['relation_name']

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -162,7 +162,7 @@ def generate_tsv_file(export_dict, filename):
                     if 'evidence_curies' in comp:
                         evidence = '|'.join(comp['evidence_curies'])
                     else:
-                        evidence = ""
+                        evidence = "NO PUBS"
                     tools = '|'.join(comp["use_curies"])
                     outfile.write(f"{primary}\t{tools}\t{evidence}\n")
 
@@ -189,7 +189,7 @@ def generate_association_tsv_file(export_dict, ingest_name, filename):
             if 'evidence_curies' in entity_dict:
                 pubs = "|".join(entity_dict['evidence_curies'])
             else:
-                pubs = ""
+                pubs = "NO PUBS"
             if 'component_type_curies' in entity_dict:
                 comp = "|".join(entity_dict['component_type_curies'])
             else:

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -220,15 +220,10 @@ def main():
         cassette_handler.receive_anon_cassette_data(anon_data)
         cassette_handler.map_anon_cassettes()
         cassette_handler.export_anon_cassettes()
-        # FTA-136: Process generic TI constructs — create anon constructs + cassettes per insertion.
-        insertions_by_construct = cons_handler.get_generic_ti_insertions(session)
-        cons_handler.attach_generic_ti_insertions(insertions_by_construct)
+        # FTA-136: Anonymous constructs are already created by ConstructHandler.
+        # Pass their data to CassetteHandler for anonymous cassette creation.
         generic_ti_data = cons_handler.get_generic_ti_anon_construct_data()
         if generic_ti_data:
-            # Create anonymous constructs for each insertion.
-            cons_handler.map_generic_ti_anon_constructs(generic_ti_data)
-            cons_handler.export_generic_ti_anon_constructs()
-            # Create anonymous cassettes for each anonymous construct.
             cassette_data = cons_handler.generic_ti_data_for_cassette_handler(generic_ti_data)
             cassette_handler.receive_anon_cassette_data(cassette_data)
             cassette_handler.map_anon_cassettes()

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -159,7 +159,10 @@ def generate_tsv_file(export_dict, filename):
             primary = entity_dict["primary_external_id"]
             if "cassette_use_dtos" in entity_dict:
                 for comp in entity_dict["cassette_use_dtos"]:
-                    evidence = '|'.join(comp["evidence_curies"])
+                    if 'evidence_curies' in comp:
+                        evidence = '|'.join(comp['evidence_curies'])
+                    else:
+                        evidence = ""
                     tools = '|'.join(comp["use_curies"])
                     outfile.write(f"{primary}\t{tools}\t{evidence}\n")
 

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -220,6 +220,35 @@ def main():
         cassette_handler.receive_anon_cassette_data(anon_data)
         cassette_handler.map_anon_cassettes()
         cassette_handler.export_anon_cassettes()
+        # FTA-136: Process generic TI constructs — create anon constructs + cassettes per insertion.
+        insertions_by_construct = cons_handler.get_generic_ti_insertions(session)
+        cons_handler.attach_generic_ti_insertions(insertions_by_construct)
+        generic_ti_data = cons_handler.get_generic_ti_anon_construct_data()
+        if generic_ti_data:
+            # Create anonymous constructs for each insertion.
+            anon_constructs = cons_handler.map_generic_ti_anon_constructs(generic_ti_data)
+            # Create anonymous cassettes for each anonymous construct.
+            cassette_data = cons_handler.generic_ti_data_for_cassette_handler(generic_ti_data)
+            cassette_handler.receive_anon_cassette_data(cassette_data)
+            cassette_handler.map_anon_cassettes()
+            cassette_handler.export_anon_cassettes()
+            # Export anonymous constructs to a separate JSON file.
+            anon_construct_export = {
+                'linkml_version': linkml_release,
+                'alliance_member_release_version': database_release,
+                'construct_ingest_set': [
+                    e.linkmldto.dict_export() for e in anon_constructs
+                    if e.linkmldto is not None
+                ],
+            }
+            if anon_construct_export['construct_ingest_set']:
+                anon_con_filename = output_filename.replace(
+                    'cassette', 'generic_ti_anon_construct')
+                generate_export_file(anon_construct_export, log, anon_con_filename)
+            log.info(f'Created {len(generic_ti_data)} anonymous constructs '
+                     f'and cassettes for generic TI insertions.')
+        else:
+            log.info('No generic TI insertions found.')
     else:
         log.warning('ADD_CASS_TO_CONSTRUCT not set to "YES". '
                     'Skipping anonymous cassette creation.')

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -226,22 +226,21 @@ def main():
         generic_ti_data = cons_handler.get_generic_ti_anon_construct_data()
         if generic_ti_data:
             # Create anonymous constructs for each insertion.
-            anon_constructs = cons_handler.map_generic_ti_anon_constructs(generic_ti_data)
+            cons_handler.map_generic_ti_anon_constructs(generic_ti_data)
+            cons_handler.export_generic_ti_anon_constructs()
             # Create anonymous cassettes for each anonymous construct.
             cassette_data = cons_handler.generic_ti_data_for_cassette_handler(generic_ti_data)
             cassette_handler.receive_anon_cassette_data(cassette_data)
             cassette_handler.map_anon_cassettes()
             cassette_handler.export_anon_cassettes()
             # Export anonymous constructs to a separate JSON file.
-            anon_construct_export = {
-                'linkml_version': linkml_release,
-                'alliance_member_release_version': database_release,
-                'construct_ingest_set': [
-                    e.linkmldto.dict_export() for e in anon_constructs
-                    if e.linkmldto is not None
-                ],
-            }
-            if anon_construct_export['construct_ingest_set']:
+            anon_con_set = 'generic_ti_anon_construct_ingest_set'
+            if anon_con_set in cons_handler.export_data and cons_handler.export_data[anon_con_set]:
+                anon_construct_export = {
+                    'linkml_version': linkml_release,
+                    'alliance_member_release_version': database_release,
+                    anon_con_set: cons_handler.export_data[anon_con_set],
+                }
                 anon_con_filename = output_filename.replace(
                     'cassette', 'generic_ti_anon_construct')
                 generate_export_file(anon_construct_export, log, anon_con_filename)

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -226,7 +226,11 @@ def main():
         anon_data = cons_handler.get_anon_cassette_data()
         cassette_handler.receive_anon_cassette_data(anon_data)
         cassette_handler.map_anon_cassettes()
-        cassette_handler.export_anon_cassettes()
+        # Note: do NOT export yet. self.anon_cassettes accumulates across
+        # both map passes below, and export_anon_cassettes iterates the
+        # full list, so calling it twice would duplicate the FTA-181
+        # batch in cassette_ingest_set. Single export at the end covers
+        # both batches.
         # FTA-136: Anonymous constructs are already created by ConstructHandler.
         # Pass their data to CassetteHandler for anonymous cassette creation.
         generic_ti_data = cons_handler.get_generic_ti_anon_construct_data()
@@ -234,11 +238,12 @@ def main():
             cassette_data = cons_handler.generic_ti_data_for_cassette_handler(generic_ti_data)
             cassette_handler.receive_anon_cassette_data(cassette_data)
             cassette_handler.map_anon_cassettes()
-            cassette_handler.export_anon_cassettes()
             log.info(f'Created {len(generic_ti_data)} anonymous constructs '
                      f'and cassettes for generic TI insertions.')
         else:
             log.info('No generic TI insertions found.')
+        # Export both batches (FTA-181 non-generic + FTA-136 generic TI) together.
+        cassette_handler.export_anon_cassettes()
     else:
         log.warning('ADD_CASS_TO_CONSTRUCT not set to "YES". '
                     'Skipping anonymous cassette creation.')

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -57,6 +57,7 @@ Environment variables:
   DATABASE            Database name (e.g. production_chado)
   SQL_PORT            Database port (default: 5432)
   ALT_OUTPUT          Override default output file path
+  ADD_OBSOLETE        Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
@@ -96,11 +97,24 @@ else:
 
 
 def generate_tsv_file(export_dict, filename):
-    """Generate tsv files for curators to read more easily. This can be commented out later."""
+    """Generate tsv files for curators to read more easily. This can be commented out later.
+
+    ADD_OBSOLETE=NO suppresses obsolete/internal rows in the TSVs only; the
+    JSON output is unaffected.
+    """
+    skip_obsolete = environ.get('ADD_OBSOLETE') == 'NO'
+    if skip_obsolete:
+        log.info('ADD_OBSOLETE=NO: excluding obsolete/internal cassettes from TSV.')
+
+    def _skip(d):
+        return skip_obsolete and (d.get('internal') or d.get('obsolete'))
+
     with open(filename, 'w') as outfile:
         outfile.write(
             "# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\tinternal\n")
         for entity_dict in export_dict["cassette_ingest_set"]:
+            if _skip(entity_dict):
+                continue
             primary = entity_dict["primary_external_id"]
             symbol = ''
             name = ''
@@ -133,6 +147,8 @@ def generate_tsv_file(export_dict, filename):
     with open(filename, 'w') as outfile:
         outfile.write("# Primary FBid\ttype\tcomment\n")
         for entity_dict in export_dict["cassette_ingest_set"]:
+            if _skip(entity_dict):
+                continue
             primary = entity_dict["primary_external_id"]
             if "note_dtos" in entity_dict:
                 for note in entity_dict["note_dtos"]:
@@ -144,6 +160,8 @@ def generate_tsv_file(export_dict, filename):
     with open(filename, 'w') as outfile:
         outfile.write("# Primary FBid\tsymbol\trelation\ttaxon\tevidence\n")
         for entity_dict in export_dict["cassette_ingest_set"]:
+            if _skip(entity_dict):
+                continue
             primary = entity_dict["primary_external_id"]
             if "cassette_component_dtos" in entity_dict:
                 for comp in entity_dict["cassette_component_dtos"]:
@@ -160,6 +178,8 @@ def generate_tsv_file(export_dict, filename):
     with open(filename, 'w') as outfile:
         outfile.write("# Primary FBid\tevidence\ttool_uses\n")
         for entity_dict in export_dict["cassette_ingest_set"]:
+            if _skip(entity_dict):
+                continue
             primary = entity_dict["primary_external_id"]
             if "cassette_use_dtos" in entity_dict:
                 for comp in entity_dict["cassette_use_dtos"]:
@@ -172,6 +192,8 @@ def generate_tsv_file(export_dict, filename):
 
 
 def generate_association_tsv_file(export_dict, ingest_name, filename):
+    """ADD_OBSOLETE=NO suppresses obsolete/internal rows from the TSV only."""
+    skip_obsolete = environ.get('ADD_OBSOLETE') == 'NO'
     filename = filename.replace('.tsv', '_associations.tsv')
     # To help in debugging, the 'first_entity' and 'second_entity' variables are used:
     # - to get the entities involved in the association out of the relevant 'export_dict[ingest_name]'
@@ -186,6 +208,8 @@ def generate_association_tsv_file(export_dict, ingest_name, filename):
     with open(filename, 'w') as outfile:
         outfile.write(f"#{first_entity}\tRelationship\t{second_entity}\tEvidence\tComp type curie\n")
         for entity_dict in export_dict[ingest_name]:
+            if skip_obsolete and (entity_dict.get('internal') or entity_dict.get('obsolete')):
+                continue
             # print(f"Dumping {entity_dict}.")
             sub = entity_dict[first_entity]
             obj = entity_dict[second_entity]

--- a/src/AGR_data_retrieval_curation_construct.py
+++ b/src/AGR_data_retrieval_curation_construct.py
@@ -90,7 +90,7 @@ def generate_tsv_file(export_dict, filename):
     """Generate tsv files for curators to read more easily."""
     with open(filename, 'w') as outfile:
         outfile.write("# Primary FBid\tValid symbol\tValid full name\t"
-                      "secondary FBid(s)\tsynonyms\n")
+                      "secondary FBid(s)\tsynonyms\tinternal\n")
         for entity_dict in export_dict["construct_ingest_set"]:
             primary = entity_dict["primary_external_id"]
             symbol = ''
@@ -106,10 +106,11 @@ def generate_tsv_file(export_dict, filename):
                     syns.append(synonym["format_text"])
             if "secondary_identifiers" in entity_dict:
                 secondary = entity_dict["secondary_identifiers"]
+            internal = entity_dict.get("internal", False)
             try:
                 outfile.write(
                     f"{primary}\t{symbol}\t{name}\t"
-                    f"{'|'.join(secondary)}\t{'|'.join(syns)}\n")
+                    f"{'|'.join(secondary)}\t{'|'.join(syns)}\t{internal}\n")
             except TypeError:
                 log.error(f"entity_dict: {entity_dict}")
                 log.error(f"primary: {primary}")
@@ -117,6 +118,7 @@ def generate_tsv_file(export_dict, filename):
                 log.error(f"symbol: {symbol}")
                 log.error(f"name: {name}")
                 log.error(f"syns: {syns}")
+                log.error(f"internal: {internal}")
                 raise
 
 

--- a/src/AGR_data_retrieval_curation_construct.py
+++ b/src/AGR_data_retrieval_curation_construct.py
@@ -55,6 +55,7 @@ Environment variables:
   SERVER              Database server (e.g. flysql25)
   DATABASE            Database name (e.g. production_chado)
   ADD_CASS_TO_CONSTRUCT  Set to 'YES' to include cassette associations
+  ADD_OBSOLETE        Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
@@ -87,11 +88,20 @@ else:
 
 
 def generate_tsv_file(export_dict, filename):
-    """Generate tsv files for curators to read more easily."""
+    """Generate tsv files for curators to read more easily.
+
+    ADD_OBSOLETE=NO suppresses obsolete/internal rows in the TSV only; the
+    JSON output is unaffected.
+    """
+    skip_obsolete = os.environ.get('ADD_OBSOLETE') == 'NO'
+    if skip_obsolete:
+        log.info('ADD_OBSOLETE=NO: excluding obsolete/internal constructs from TSV.')
     with open(filename, 'w') as outfile:
         outfile.write("# Primary FBid\tValid symbol\tValid full name\t"
                       "secondary FBid(s)\tsynonyms\tinternal\n")
         for entity_dict in export_dict["construct_ingest_set"]:
+            if skip_obsolete and (entity_dict.get('internal') or entity_dict.get('obsolete')):
+                continue
             primary = entity_dict["primary_external_id"]
             symbol = ''
             name = ''
@@ -123,7 +133,11 @@ def generate_tsv_file(export_dict, filename):
 
 
 def generate_association_tsv_file(export_dict, ingest_name, filename):
-    """Generate a TSV file for an association ingest set."""
+    """Generate a TSV file for an association ingest set.
+
+    ADD_OBSOLETE=NO suppresses obsolete/internal rows from the TSV only.
+    """
+    skip_obsolete = os.environ.get('ADD_OBSOLETE') == 'NO'
     first_entity = 'construct_identifier'
     if ingest_name == 'construct_cassette_association_ingest_set':
         second_entity = 'cassette_identifier'
@@ -132,6 +146,8 @@ def generate_association_tsv_file(export_dict, ingest_name, filename):
     with open(filename, 'w') as outfile:
         outfile.write(f"#{first_entity}\tRelationship\t{second_entity}\tEvidence\n")
         for entity_dict in export_dict[ingest_name]:
+            if skip_obsolete and (entity_dict.get('internal') or entity_dict.get('obsolete')):
+                continue
             sub = entity_dict[first_entity]
             obj = entity_dict[second_entity]
             rel_type = entity_dict['relation_name']

--- a/src/AGR_data_retrieval_curation_gene_group.py
+++ b/src/AGR_data_retrieval_curation_gene_group.py
@@ -88,7 +88,7 @@ Environment variables:
   DATABASE            Database name (e.g. production_chado)
   SQL_PORT            Database port (default: 5432)
   ALT_OUTPUT          Override default output file path
-  ADD_OBSOLETE        Set to 'NO' to exclude obsolete gene groups from JSON and TSV output
+  ADD_OBSOLETE        Set to 'NO' to exclude obsolete gene groups from the TSV only; JSON still includes them (with internal=True)
   EXPORT_GG_XREFS    Set to 'YES' to include gene group cross-references
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/AGR_data_retrieval_curation_transgenic_tool.py
+++ b/src/AGR_data_retrieval_curation_transgenic_tool.py
@@ -84,7 +84,8 @@ else:
 def generate_tsv_file(export_dict, filename):
     """Generate tsv files for curators to read more easily. This can be commented out later."""
     with open(filename, 'w') as outfile:
-        outfile.write("# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\n")
+        outfile.write(
+            "# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\tinternal\n")
         for entity_dict in export_dict["transgenic_tool_ingest_set"]:
             primary = entity_dict["primary_external_id"]
             symbol = ''
@@ -100,7 +101,9 @@ def generate_tsv_file(export_dict, filename):
                     syns.append(synonym["format_text"])
             if "secondary_identifiers" in entity_dict:
                 secondary = entity_dict["secondary_identifiers"]
-            outfile.write(f"{primary}\t{symbol}\t{name}\t{'|'.join(secondary)}\t{'|'.join(syns)}\n")
+            internal = entity_dict.get("internal", False)
+            outfile.write(
+                f"{primary}\t{symbol}\t{name}\t{'|'.join(secondary)}\t{'|'.join(syns)}\t{internal}\n")
 
     filename = filename.replace('.tsv', '_notes.tsv')
     with open(filename, 'w') as outfile:

--- a/src/AGR_data_retrieval_curation_transgenic_tool.py
+++ b/src/AGR_data_retrieval_curation_transgenic_tool.py
@@ -21,6 +21,7 @@ Notes:
 """
 
 import argparse
+from os import environ
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
@@ -50,6 +51,7 @@ parser = argparse.ArgumentParser(
 Environment variables:
   SERVER              Database server (e.g. flysql25)
   DATABASE            Database name (e.g. production_chado)
+  ADD_OBSOLETE        Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
@@ -82,11 +84,24 @@ else:
 
 
 def generate_tsv_file(export_dict, filename):
-    """Generate tsv files for curators to read more easily. This can be commented out later."""
+    """Generate tsv files for curators to read more easily.
+
+    ADD_OBSOLETE=NO suppresses obsolete/internal rows in the TSVs only; the
+    JSON output is unaffected.
+    """
+    skip_obsolete = environ.get('ADD_OBSOLETE') == 'NO'
+    if skip_obsolete:
+        log.info('ADD_OBSOLETE=NO: excluding obsolete/internal tools from TSV.')
+
+    def _skip(d):
+        return skip_obsolete and (d.get('internal') or d.get('obsolete'))
+
     with open(filename, 'w') as outfile:
         outfile.write(
             "# Primary FBid\tValid symbol\tValid full name\tsecondary FBid(s)\tsynonyms\tinternal\n")
         for entity_dict in export_dict["transgenic_tool_ingest_set"]:
+            if _skip(entity_dict):
+                continue
             primary = entity_dict["primary_external_id"]
             symbol = ''
             name = ''
@@ -109,6 +124,8 @@ def generate_tsv_file(export_dict, filename):
     with open(filename, 'w') as outfile:
         outfile.write("# Primary FBid\ttype\tcomment\n")
         for entity_dict in export_dict["transgenic_tool_ingest_set"]:
+            if _skip(entity_dict):
+                continue
             primary = entity_dict["primary_external_id"]
             if "note_dtos" in entity_dict:
                 for note in entity_dict["note_dtos"]:
@@ -118,10 +135,14 @@ def generate_tsv_file(export_dict, filename):
 
 
 def generate_association_tsv_file(export_dict, filename):
+    """ADD_OBSOLETE=NO suppresses obsolete/internal rows from the TSV only."""
+    skip_obsolete = environ.get('ADD_OBSOLETE') == 'NO'
     filename = filename.replace('.tsv', '_associations.tsv')
     with open(filename, 'w') as outfile:
         outfile.write("# Object curie\tSubject curie\tPub\n")
         for entity_dict in export_dict['transgenic_tool_transgenic_tool_association_ingest_set']:
+            if skip_obsolete and (entity_dict.get('internal') or entity_dict.get('obsolete')):
+                continue
             obj = entity_dict['transgenic_tool_object_identifier']
             sub = entity_dict['transgenic_tool_subject_identifier']
             # pubs = "|".join(entity_dict['evidence_curies'])

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1081,7 +1081,6 @@ class InsertionHandler(MetaAlleleHandler):
         'FBti0000005': 'P{hsneo}102',               # type=transposable_element_insertion_site. Has synTE_insertion subtype, producedby FBtp0000078 (P{hsneo}).
         'FBti0145331': 'P{PTGAL}26',                # type=transposable_element_insertion_site. Has synTE_insertion TI_subtype, no current producedby.
         'FBti0128384': 'FBti0128384',               # Had null mutation_type_curies bug.
-        'FBti0167947': 'FBti0167947',               # Anon
     }
 
     # Elaborate on get_general_data() for the InsertionHandler.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -12,13 +12,14 @@ Author(s):
 from logging import Logger
 from sqlalchemy.orm import aliased
 import agr_datatypes
+import fb_datatypes
 from fb_datatypes import (
     FBAberration, FBAllele, FBBalancer
 )
 from feature_handler import FeatureHandler
 from harvdev_utils.reporting import (
     Cvterm, Feature, FeatureGenotype, FeatureRelationship,
-    Genotype, Phenotype, PhenotypeCvterm, Phenstatement, Pub
+    Featureprop, Genotype, Phenotype, PhenotypeCvterm, Phenstatement, Pub
 )
 from utils import export_chado_data
 
@@ -133,6 +134,7 @@ class AlleleHandler(MetaAlleleHandler):
         self.at_locus_fbal_fbti_dict = {}      # Will be FBal-feature_id-keyed dict of FBti feature_id lists ("is_represented_at_Alliance_as").
         self.transgenic_fbal_fbti_dict = {}    # Will be FBal-feature_id-keyed dict of FBti feature_id lists (via FBtp to unspecified FBti).
         self.fbti_entities = {}                # Will be feature_id-keyed FBAllele objects generated from FBti insertions.
+        self.generic_ti_fbtp_ids = set()       # FTA-180 Part B: set of FBtp feature_ids flagged 'FTA: generic TI construct'.
 
     test_set = {
         'FBal0386858': 'SppL[CR70402-TG4.1]',   # Insertion allele superceded by FBti0226866 (superseded_by_at_locus_insertion).
@@ -346,6 +348,25 @@ class AlleleHandler(MetaAlleleHandler):
         self.log.info(f'The AlleleHandler obtained {len(self.fbti_entities)} FBti insertions from chado.\n{separator}')
         return
 
+    def get_generic_ti_fbtp_ids(self, session):
+        """Identify FBtp feature_ids flagged 'FTA: generic TI construct' (FTA-180 Part B)."""
+        self.log.info('Get generic-TI FBtp feature_ids.')
+        fp_type = aliased(Cvterm, name='fp_type')
+        results = session.query(Featureprop.feature_id).\
+            select_from(Feature).\
+            join(Featureprop, Featureprop.feature_id == Feature.feature_id).\
+            join(fp_type, fp_type.cvterm_id == Featureprop.type_id).\
+            filter(
+                Feature.uniquename.op('~')(self.regex['construct']),
+                Feature.is_obsolete.is_(False),
+                fp_type.name == 'internalnotes',
+                Featureprop.value == 'FTA: generic TI construct').\
+            distinct()
+        for (fid,) in results:
+            self.generic_ti_fbtp_ids.add(fid)
+        self.log.info(f'Found {len(self.generic_ti_fbtp_ids)} generic-TI FBtp feature_ids.')
+        return
+
     # Elaborate on get_datatype_data() for the AlleleHandler.
     def get_datatype_data(self, session):
         """Extend the method for the AlleleHandler."""
@@ -374,6 +395,8 @@ class AlleleHandler(MetaAlleleHandler):
         self.get_phenotypes(session)
         self.get_fbal_fbti_replacements(session)
         self.get_insertion_entities(session)
+        # FTA-180 Part B: FBtp feature_ids flagged 'FTA: generic TI construct'.
+        self.get_generic_ti_fbtp_ids(session)
         return
 
     # Additional sub-methods to be run by synthesize_info() below.
@@ -945,6 +968,39 @@ class AlleleHandler(MetaAlleleHandler):
         self.log.info(f'Generated {counter} allele-construct unique associations.')
         return
 
+    def map_generic_ti_anon_construct_associations(self):
+        """Emit AlleleConstructAssociationDTOs linking each generic-TI FBti to its <FBti>_con anon construct (FTA-180 Part B)."""
+        self.log.info('Map generic-TI anon AlleleConstructAssociationDTOs.')
+        if not self.generic_ti_fbtp_ids:
+            self.log.info('No generic-TI FBtps; skipping.')
+            return
+        counter = 0
+        for fbti in self.fbti_entities.values():
+            producedby_rels = fbti.recall_relationships(
+                self.log, entity_role='subject', rel_types='producedby')
+            all_pub_ids = []
+            matched = False
+            for rel in producedby_rels:
+                if rel.chado_obj.object_id in self.generic_ti_fbtp_ids:
+                    matched = True
+                    all_pub_ids.extend(rel.pubs)
+            if not matched:
+                continue
+            allele_curie = f'FB:{fbti.uniquename}'
+            construct_curie = f'FB:{fbti.uniquename}_con'
+            pub_curies = self.lookup_pub_curies(all_pub_ids)
+            fb_rel = fb_datatypes.FBExportEntity()
+            rel_dto = agr_datatypes.AlleleConstructAssociationDTO(
+                allele_curie, 'contains', construct_curie, pub_curies)
+            # Parent FBtp is effectively obsolete (generic-TI, FTA-179) -> flag association too.
+            rel_dto.obsolete = True
+            rel_dto.internal = True
+            fb_rel.linkmldto = rel_dto
+            self.allele_construct_associations.append(fb_rel)
+            counter += 1
+        self.log.info(f'Created {counter} generic-TI anon AlleleConstructAssociationDTOs.')
+        return
+
     # Elaborate on map_fb_data_to_alliance() for the AlleleHandler.
     def map_fb_data_to_alliance(self):
         """Extend the method for the AlleleHandler."""
@@ -968,6 +1024,8 @@ class AlleleHandler(MetaAlleleHandler):
         self.map_allele_gene_associations()
         self.flag_internal_fb_entities('allele_gene_associations')
         self.map_allele_construct_associations()
+        # FTA-180 Part B: anon <FBti>_con associations for generic-TI insertions.
+        self.map_generic_ti_anon_construct_associations()
         self.flag_internal_fb_entities('allele_construct_associations')
         return
 
@@ -1023,6 +1081,7 @@ class InsertionHandler(MetaAlleleHandler):
         'FBti0000005': 'P{hsneo}102',               # type=transposable_element_insertion_site. Has synTE_insertion subtype, producedby FBtp0000078 (P{hsneo}).
         'FBti0145331': 'P{PTGAL}26',                # type=transposable_element_insertion_site. Has synTE_insertion TI_subtype, no current producedby.
         'FBti0128384': 'FBti0128384',               # Had null mutation_type_curies bug.
+        'FBti0167947': 'FBti0167947',               # Anon
     }
 
     # Elaborate on get_general_data() for the InsertionHandler.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -10,6 +10,7 @@ Author(s):
 """
 
 from logging import Logger
+from os import getenv
 from sqlalchemy.orm import aliased
 import agr_datatypes
 import fb_datatypes
@@ -397,7 +398,14 @@ class AlleleHandler(MetaAlleleHandler):
         self.get_fbal_fbti_replacements(session)
         self.get_insertion_entities(session)
         # FTA-180 Part B: FBtp feature_ids flagged 'FTA: generic TI construct'.
-        self.get_generic_ti_fbtp_ids(session)
+        # Gated by ADD_CASS_TO_CONSTRUCT=YES so the anon AlleleConstructAssociationDTOs
+        # are only emitted when the matching <FBti>_con constructs are also being submitted
+        # (which happens in the cassette/construct retrieval scripts under the same gate).
+        if getenv('ADD_CASS_TO_CONSTRUCT', None) == 'YES':
+            self.get_generic_ti_fbtp_ids(session)
+        else:
+            self.log.info('ADD_CASS_TO_CONSTRUCT not set to "YES"; skipping generic-TI FBtp lookup '
+                          '(no anon AlleleConstructAssociationDTOs will be emitted).')
         return
 
     # Additional sub-methods to be run by synthesize_info() below.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -968,7 +968,10 @@ class AlleleHandler(MetaAlleleHandler):
             first_feat_rel.pubs = all_pub_ids
             pub_curies = self.lookup_pub_curies(all_pub_ids)
             rel_dto = agr_datatypes.AlleleConstructAssociationDTO(allele_curie, alliance_rel_type_name, construct_curie, pub_curies)
-            if allele.is_obsolete is True or construct['is_obsolete'] is True:
+            construct_feature_id = allele_construct_key[CONSTRUCT]
+            # FTA-179 follow-up: generic-TI FBtps are effectively obsolete on
+            # the Alliance side, so flag their incoming associations to match.
+            if allele.is_obsolete is True or construct['is_obsolete'] is True or construct_feature_id in self.generic_ti_fbtp_ids:
                 rel_dto.obsolete = True
                 rel_dto.internal = True
             first_feat_rel.linkmldto = rel_dto
@@ -1001,9 +1004,9 @@ class AlleleHandler(MetaAlleleHandler):
             fb_rel = fb_datatypes.FBExportEntity()
             rel_dto = agr_datatypes.AlleleConstructAssociationDTO(
                 allele_curie, 'contains', construct_curie, pub_curies)
-            # Parent FBtp is effectively obsolete (generic-TI, FTA-179) -> flag association too.
-            rel_dto.obsolete = True
-            rel_dto.internal = True
+            # Both endpoints are active: the FBti and its <FBti>_con anon
+            # construct (the public-facing replacement for the obsoleted
+            # parent FBtp link). Leave obsolete/internal at their defaults.
             fb_rel.linkmldto = rel_dto
             self.allele_construct_associations.append(fb_rel)
             counter += 1

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -285,7 +285,8 @@ class AlleleHandler(MetaAlleleHandler):
                                                                   rel_entity_types=self.feature_subtypes['insertion'])
             for feat_rel in fbal_fbti_alliance_rels:
                 insertion = self.feature_lookup[feat_rel.chado_obj.object_id]
-                self.log.debug(f'Report {allele} under {insertion["name"]} ({insertion["uniquename"]}).')
+                if self.testing:
+                    self.log.debug(f'Report {allele} under {insertion["name"]} ({insertion["uniquename"]}).')
                 try:
                     self.at_locus_fbal_fbti_dict[allele.db_primary_id].append(insertion["feature_id"])
                     self.log.warning(f'Found another FBti for {allele}, but expected a one-to-one relationship.')

--- a/src/audit_alleles_in_curation_tsvs.py
+++ b/src/audit_alleles_in_curation_tsvs.py
@@ -1,0 +1,190 @@
+# !/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Cross-reference chado alleles against curation TSV files.
+
+Author(s):
+    Ian Longden ilongden@morgan.harvard.edu
+
+Usage:
+    audit_alleles_in_curation_tsvs.py [-h] [-v VERBOSE] [-c CONFIG]
+    [--tsv-dir TSV_DIR]
+
+Example:
+    python audit_alleles_in_curation_tsvs.py -v -c /path/to/config.cfg
+
+Notes:
+    Queries chado for the set of all non-obsolete FBal alleles, walks every
+    *_curation*.tsv file under the TSV directory (default: ./tsvs), and
+    writes a long-format audit TSV listing each (allele, file, count) tuple.
+    Alleles in chado but absent from every TSV are emitted with a sentinel
+    file value '<not in any tsv>' and count=0; FBals appearing in TSVs but
+    absent from chado are emitted with sentinel file '<not_in_chado>' so
+    typos and stale references are surfaced.
+"""
+
+import argparse
+import re
+from collections import Counter
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, aliased
+from harvdev_utils.psycopg_functions import set_up_db_reading
+from harvdev_utils.reporting import Cvterm, Feature
+
+# Data types handled by this script.
+REPORT_LABEL = 'audit_alleles_in_curation_tsvs'
+
+# Now proceed with generic setup.
+set_up_dict = set_up_db_reading(REPORT_LABEL)
+server = set_up_dict['server']
+database = set_up_dict['database']
+username = set_up_dict['username']
+password = set_up_dict['password']
+output_filename = set_up_dict['output_filename']
+log = set_up_dict['log']
+
+# Process additional input parameters not handled by the set_up_db_reading() function above.
+parser = argparse.ArgumentParser(
+    description='Audit chado FBal alleles against the curation TSV files.')
+parser.add_argument('--tsv-dir', default='tsvs',
+                    help='Directory containing the *_curation*.tsv files (default: tsvs).')
+args, extra_args = parser.parse_known_args()
+log.info(f'These args are handled by this specific script: {args}')
+log.info(f'These args are handled by modules: {extra_args}')
+
+# Create SQL Alchemy engine from environmental variables.
+engine_var_rep = 'postgresql://' + username + ':' + password + '@' + server + '/' + database
+ENGINE = create_engine(engine_var_rep)
+Session = sessionmaker(bind=ENGINE)
+
+ALLELE_REGEX = r'^FBal[0-9]{7}$'
+FBAL_RE = re.compile(r'\bFBal\d{7}\b')
+TSV_GLOB = '*_curation*.tsv'
+# Filter out filenames whose names contain any of these substrings; these
+# are auxiliary curation TSVs (notes, association, component slots) that we
+# don't want in the cross-reference audit.
+EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses')
+SENTINEL_NO_TSV = '<not in any tsv>'
+SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
+
+
+def query_chado_alleles(session):
+    """Return the set of non-obsolete FBal allele uniquenames from chado."""
+    log.info('Query chado for non-obsolete FBal alleles.')
+    allele_type = aliased(Cvterm, name='allele_type')
+    results = session.query(Feature.uniquename).\
+        join(allele_type, allele_type.cvterm_id == Feature.type_id).\
+        filter(
+            Feature.uniquename.op('~')(ALLELE_REGEX),
+            Feature.is_obsolete.is_(False),
+            allele_type.name == 'allele').\
+        distinct()
+    chado_alleles = {row.uniquename for row in results}
+    log.info(f'Loaded {len(chado_alleles):,} non-obsolete FBal alleles from chado.')
+    return chado_alleles
+
+
+def collect_tsv_counts(tsv_dir):
+    """Walk *_curation*.tsv files and count FBal occurrences per file.
+
+    Skips auxiliary files whose names contain any of EXCLUDE_SUBSTRINGS
+    (notes, association, component slots).
+    """
+    log.info(f'Walk TSV files matching "{TSV_GLOB}" under {tsv_dir}.')
+    counts_by_file = {}
+    all_paths = sorted(Path(tsv_dir).glob(TSV_GLOB))
+    paths = [p for p in all_paths
+             if not any(sub in p.name for sub in EXCLUDE_SUBSTRINGS)]
+    skipped = len(all_paths) - len(paths)
+    if skipped:
+        log.info(
+            f'Skipping {skipped} files whose names contain any of '
+            f'{EXCLUDE_SUBSTRINGS}.')
+    if not paths:
+        log.warning(f'No files matched "{TSV_GLOB}" under {tsv_dir}.')
+    for path in paths:
+        counter = Counter()
+        with path.open() as fh:
+            for line in fh:
+                for m in FBAL_RE.findall(line):
+                    counter[m] += 1
+        counts_by_file[path.name] = counter
+        log.info(
+            f'  {path.name}: {len(counter):,} unique FBals, '
+            f'{sum(counter.values()):,} occurrences.')
+    return counts_by_file
+
+
+def write_audit(chado_alleles, counts_by_file, output_path):
+    """Write the long-format audit TSV plus a summary footer."""
+    log.info(f'Write audit output to {output_path}.')
+    # Build the union universe so we cover both chado-only and TSV-only alleles.
+    tsv_alleles = set()
+    for counter in counts_by_file.values():
+        tsv_alleles.update(counter)
+    universe = sorted(chado_alleles | tsv_alleles)
+    file_names = sorted(counts_by_file.keys())
+
+    in_chado_and_any_tsv = 0
+    in_chado_no_tsv = 0
+    in_tsv_not_in_chado = 0
+    per_file_unique = {fn: 0 for fn in file_names}
+
+    with open(output_path, 'w') as out:
+        out.write('# uniquename\tfile\tcount\n')
+        for allele in universe:
+            in_chado = allele in chado_alleles
+            found_anywhere = False
+            for fn in file_names:
+                count = counts_by_file[fn].get(allele, 0)
+                if count == 0:
+                    continue
+                found_anywhere = True
+                tag = fn if in_chado else f'{fn} {SENTINEL_NOT_IN_CHADO}'
+                out.write(f'{allele}\t{tag}\t{count}\n')
+                per_file_unique[fn] += 1
+            if in_chado and not found_anywhere:
+                out.write(f'{allele}\t{SENTINEL_NO_TSV}\t0\n')
+                in_chado_no_tsv += 1
+            if in_chado and found_anywhere:
+                in_chado_and_any_tsv += 1
+            if not in_chado and found_anywhere:
+                in_tsv_not_in_chado += 1
+        # Summary footer.
+        out.write('# --- summary ---\n')
+        out.write(f'# total alleles in chado: {len(chado_alleles):,}\n')
+        out.write(f'# total alleles found in any TSV: {len(tsv_alleles):,}\n')
+        out.write(f'# alleles in chado AND in >=1 TSV: {in_chado_and_any_tsv:,}\n')
+        out.write(
+            f'# alleles in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
+        out.write(
+            f'# alleles in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
+            f'(orphaned references)\n')
+        out.write('# per-file unique-allele totals:\n')
+        for fn in file_names:
+            out.write(f'#   {fn}: {per_file_unique[fn]:,}\n')
+
+    log.info(f'Wrote audit with {len(universe):,} alleles to {output_path}.')
+    log.info(
+        f'  in-chado-and-any-tsv={in_chado_and_any_tsv:,}, '
+        f'in-chado-no-tsv={in_chado_no_tsv:,}, '
+        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}.')
+
+
+def main():
+    """Run the audit."""
+    log.info(f'Running script "{__file__}"')
+    log.info('Started main function.')
+    session = Session()
+    try:
+        chado_alleles = query_chado_alleles(session)
+    finally:
+        session.close()
+    counts_by_file = collect_tsv_counts(args.tsv_dir)
+    write_audit(chado_alleles, counts_by_file, output_filename)
+    log.info('Ended main function.\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/audit_alleles_in_curation_tsvs.py
+++ b/src/audit_alleles_in_curation_tsvs.py
@@ -88,6 +88,10 @@ TSV_GLOB = '*_curation*.tsv'
 EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses', 'curation_tsvs')
 SENTINEL_NO_TSV = '<not in any tsv>'
 SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
+# Used in place of SENTINEL_NOT_IN_CHADO when the TSV row carried
+# internal=True (likely an obsolete-in-chado entity that the chado query
+# filtered out via is_obsolete=False).
+SENTINEL_OBSOLETE_IN_CHADO = '<obsolete_in_chado>'
 
 
 def query_chado_alleles(session):
@@ -153,6 +157,7 @@ def collect_tsv_counts(tsv_dir):
     """
     log.info(f'Walk TSV files matching "{TSV_GLOB}" under {tsv_dir}.')
     counts_by_file = {}
+    internal_ids = set()
     all_paths = sorted(Path(tsv_dir).glob(TSV_GLOB))
     paths = [p for p in all_paths
              if not any(sub in p.name for sub in EXCLUDE_SUBSTRINGS)]
@@ -169,17 +174,24 @@ def collect_tsv_counts(tsv_dir):
             for line in fh:
                 if not line or line.startswith('#'):
                     continue
-                first_col = line.split('\t', 1)[0]
+                parts = line.rstrip('\n').split('\t')
+                first_col = parts[0]
+                # The 'internal' flag is the last column on rows produced by
+                # the curation retrieval scripts; older TSVs without that
+                # column will fall through as 'not internal'.
+                row_is_internal = (parts[-1].strip() == 'True' and len(parts) > 1)
                 for m in ID_RE.findall(first_col):
                     counter[m] += 1
+                    if row_is_internal:
+                        internal_ids.add(m)
         counts_by_file[path.name] = counter
         log.info(
             f'  {path.name}: {len(counter):,} unique FBal/FBab/FBti ids, '
             f'{sum(counter.values()):,} occurrences.')
-    return counts_by_file
+    return counts_by_file, internal_ids
 
 
-def write_audit(chado_universe, counts_by_file, output_path):
+def write_audit(chado_universe, counts_by_file, internal_ids, output_path):
     """Write the long-format audit TSV plus a summary footer."""
     log.info(f'Write audit output to {output_path}.')
     # Build the union universe so we cover both chado-only and TSV-only ids.
@@ -192,19 +204,25 @@ def write_audit(chado_universe, counts_by_file, output_path):
     in_chado_and_any_tsv = 0
     in_chado_no_tsv = 0
     in_tsv_not_in_chado = 0
+    in_tsv_obsolete_in_chado = 0
     per_file_unique = {fn: 0 for fn in file_names}
 
     with open(output_path, 'w') as out:
         out.write('# uniquename\tfile\tcount\n')
         for uname in universe:
             in_chado = uname in chado_universe
+            # Pick the orphan sentinel once per id: 'obsolete_in_chado' if any
+            # TSV row marked it internal=True, else the generic 'not_in_chado'.
+            orphan_sentinel = (SENTINEL_OBSOLETE_IN_CHADO
+                               if uname in internal_ids
+                               else SENTINEL_NOT_IN_CHADO)
             found_anywhere = False
             for fn in file_names:
                 count = counts_by_file[fn].get(uname, 0)
                 if count == 0:
                     continue
                 found_anywhere = True
-                tag = fn if in_chado else f'{fn} {SENTINEL_NOT_IN_CHADO}'
+                tag = fn if in_chado else f'{fn} {orphan_sentinel}'
                 out.write(f'{uname}\t{tag}\t{count}\n')
                 per_file_unique[fn] += 1
             if in_chado and not found_anywhere:
@@ -213,7 +231,10 @@ def write_audit(chado_universe, counts_by_file, output_path):
             if in_chado and found_anywhere:
                 in_chado_and_any_tsv += 1
             if not in_chado and found_anywhere:
-                in_tsv_not_in_chado += 1
+                if uname in internal_ids:
+                    in_tsv_obsolete_in_chado += 1
+                else:
+                    in_tsv_not_in_chado += 1
         # Summary footer.
         out.write('# --- summary ---\n')
         out.write(f'# total allele-ingest ids in chado: {len(chado_universe):,}\n')
@@ -222,8 +243,10 @@ def write_audit(chado_universe, counts_by_file, output_path):
         out.write(
             f'# ids in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
         out.write(
-            f'# ids in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
-            f'(orphaned references)\n')
+            f'# ids in TSVs but absent from chado (orphans): {in_tsv_not_in_chado:,}\n')
+        out.write(
+            f'# ids in TSVs marked internal (obsolete-in-chado): '
+            f'{in_tsv_obsolete_in_chado:,}\n')
         out.write('# per-file unique-id totals:\n')
         for fn in file_names:
             out.write(f'#   {fn}: {per_file_unique[fn]:,}\n')
@@ -232,7 +255,8 @@ def write_audit(chado_universe, counts_by_file, output_path):
     log.info(
         f'  in-chado-and-any-tsv={in_chado_and_any_tsv:,}, '
         f'in-chado-no-tsv={in_chado_no_tsv:,}, '
-        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}.')
+        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}, '
+        f'in-tsv-obsolete-in-chado={in_tsv_obsolete_in_chado:,}.')
 
 
 def main():
@@ -244,8 +268,8 @@ def main():
         chado_universe = query_chado_alleles(session)
     finally:
         session.close()
-    counts_by_file = collect_tsv_counts(args.tsv_dir)
-    write_audit(chado_universe, counts_by_file, output_filename)
+    counts_by_file, internal_ids = collect_tsv_counts(args.tsv_dir)
+    write_audit(chado_universe, counts_by_file, internal_ids, output_filename)
     log.info('Ended main function.\n')
 
 

--- a/src/audit_alleles_in_curation_tsvs.py
+++ b/src/audit_alleles_in_curation_tsvs.py
@@ -64,7 +64,7 @@ TSV_GLOB = '*_curation*.tsv'
 # Filter out filenames whose names contain any of these substrings; these
 # are auxiliary curation TSVs (notes, association, component slots) that we
 # don't want in the cross-reference audit.
-EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses')
+EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses', 'curation_tsvs')
 SENTINEL_NO_TSV = '<not in any tsv>'
 SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
 

--- a/src/audit_alleles_in_curation_tsvs.py
+++ b/src/audit_alleles_in_curation_tsvs.py
@@ -1,6 +1,6 @@
 # !/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Cross-reference chado alleles against curation TSV files.
+"""Cross-reference chado allele-ingest features against curation TSV files.
 
 Author(s):
     Ian Longden ilongden@morgan.harvard.edu
@@ -13,13 +13,22 @@ Example:
     python audit_alleles_in_curation_tsvs.py -v -c /path/to/config.cfg
 
 Notes:
-    Queries chado for the set of all non-obsolete FBal alleles, walks every
-    *_curation*.tsv file under the TSV directory (default: ./tsvs), and
-    writes a long-format audit TSV listing each (allele, file, count) tuple.
-    Alleles in chado but absent from every TSV are emitted with a sentinel
-    file value '<not in any tsv>' and count=0; FBals appearing in TSVs but
-    absent from chado are emitted with sentinel file '<not_in_chado>' so
-    typos and stale references are surfaced.
+    The Alliance "allele_ingest_set" is fed by three FlyBase handlers
+    (AlleleHandler -> FBal, AberrationHandler -> FBab, InsertionHandler ->
+    FBti), so this audit unions the chado universes of all three:
+
+      - non-obsolete FBal alleles      (cvterm.name = 'allele')
+      - non-obsolete FBab aberrations  (cvterm.name = 'chromosome_structure_variation')
+      - non-obsolete FBti insertions   (cvterm.name in the insertion subtypes
+                                        from handler.py:252)
+
+    The script walks every *_curation*.tsv file under the TSV directory
+    (default: ./tsvs), counts FBal/FBab/FBti occurrences in column 0 only,
+    and writes a long-format audit TSV listing each (uniquename, file,
+    count) tuple. Ids in chado but absent from every TSV are emitted with
+    a sentinel file value '<not in any tsv>' and count=0; ids appearing in
+    TSVs but absent from chado are emitted with sentinel file
+    '<not_in_chado>' so typos and stale references are surfaced.
 """
 
 import argparse
@@ -59,7 +68,19 @@ ENGINE = create_engine(engine_var_rep)
 Session = sessionmaker(bind=ENGINE)
 
 ALLELE_REGEX = r'^FBal[0-9]{7}$'
-FBAL_RE = re.compile(r'\bFBal\d{7}\b')
+ABERRATION_REGEX = r'^FBab[0-9]{7}$'
+INSERTION_REGEX = r'^FBti[0-9]{7}$'
+# Match any of the three id forms anywhere in a cell. Suffixes like
+# '_cas' or '_con' on FBti ids still leave the FBti0xxxxxx portion
+# matched and counted under the bare FBti id.
+ID_RE = re.compile(r'\b(?:FBal|FBab|FBti)\d{7}\b')
+# Cvterm filters per src/handler.py:245-252.
+ABERRATION_TYPES = ('chromosome_structure_variation',)
+INSERTION_TYPES = (
+    'insertion_site',
+    'transposable_element',
+    'transposable_element_insertion_site',
+)
 TSV_GLOB = '*_curation*.tsv'
 # Filter out filenames whose names contain any of these substrings; these
 # are auxiliary curation TSVs (notes, association, component slots) that we
@@ -70,26 +91,65 @@ SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
 
 
 def query_chado_alleles(session):
-    """Return the set of non-obsolete FBal allele uniquenames from chado."""
+    """Return the union of non-obsolete FBal/FBab/FBti uniquenames from chado.
+
+    These are the three FlyBase feature classes that feed Alliance's
+    allele_ingest_set (via AlleleHandler / AberrationHandler /
+    InsertionHandler in src/allele_handlers.py).
+    """
+    # FBal alleles.
     log.info('Query chado for non-obsolete FBal alleles.')
     allele_type = aliased(Cvterm, name='allele_type')
-    results = session.query(Feature.uniquename).\
+    fbal_results = session.query(Feature.uniquename).\
         join(allele_type, allele_type.cvterm_id == Feature.type_id).\
         filter(
             Feature.uniquename.op('~')(ALLELE_REGEX),
             Feature.is_obsolete.is_(False),
             allele_type.name == 'allele').\
         distinct()
-    chado_alleles = {row.uniquename for row in results}
-    log.info(f'Loaded {len(chado_alleles):,} non-obsolete FBal alleles from chado.')
-    return chado_alleles
+    fbals = {row.uniquename for row in fbal_results}
+    log.info(f'  loaded {len(fbals):,} non-obsolete FBal alleles.')
+
+    # FBab aberrations.
+    log.info('Query chado for non-obsolete FBab aberrations.')
+    aberration_type = aliased(Cvterm, name='aberration_type')
+    fbab_results = session.query(Feature.uniquename).\
+        join(aberration_type, aberration_type.cvterm_id == Feature.type_id).\
+        filter(
+            Feature.uniquename.op('~')(ABERRATION_REGEX),
+            Feature.is_obsolete.is_(False),
+            aberration_type.name.in_(ABERRATION_TYPES)).\
+        distinct()
+    fbabs = {row.uniquename for row in fbab_results}
+    log.info(f'  loaded {len(fbabs):,} non-obsolete FBab aberrations.')
+
+    # FBti insertions.
+    log.info('Query chado for non-obsolete FBti insertions.')
+    insertion_type = aliased(Cvterm, name='insertion_type')
+    fbti_results = session.query(Feature.uniquename).\
+        join(insertion_type, insertion_type.cvterm_id == Feature.type_id).\
+        filter(
+            Feature.uniquename.op('~')(INSERTION_REGEX),
+            Feature.is_obsolete.is_(False),
+            insertion_type.name.in_(INSERTION_TYPES)).\
+        distinct()
+    fbtis = {row.uniquename for row in fbti_results}
+    log.info(f'  loaded {len(fbtis):,} non-obsolete FBti insertions.')
+
+    universe = fbals | fbabs | fbtis
+    log.info(
+        f'allele-ingest universe = {len(universe):,} ids '
+        f'({len(fbals):,} FBal + {len(fbabs):,} FBab + {len(fbtis):,} FBti).')
+    return universe
 
 
 def collect_tsv_counts(tsv_dir):
-    """Walk *_curation*.tsv files and count FBal occurrences per file.
+    """Walk *_curation*.tsv files and count FBal/FBab/FBti occurrences per file.
 
-    Skips auxiliary files whose names contain any of EXCLUDE_SUBSTRINGS
-    (notes, association, component slots).
+    Only the first tab-separated column is scanned, so an id is only
+    counted when the row's primary id is that id. Skips auxiliary files
+    whose names contain any of EXCLUDE_SUBSTRINGS (notes, association,
+    component slots, tool_uses, prior audit output).
     """
     log.info(f'Walk TSV files matching "{TSV_GLOB}" under {tsv_dir}.')
     counts_by_file = {}
@@ -110,23 +170,23 @@ def collect_tsv_counts(tsv_dir):
                 if not line or line.startswith('#'):
                     continue
                 first_col = line.split('\t', 1)[0]
-                for m in FBAL_RE.findall(first_col):
+                for m in ID_RE.findall(first_col):
                     counter[m] += 1
         counts_by_file[path.name] = counter
         log.info(
-            f'  {path.name}: {len(counter):,} unique FBals, '
+            f'  {path.name}: {len(counter):,} unique FBal/FBab/FBti ids, '
             f'{sum(counter.values()):,} occurrences.')
     return counts_by_file
 
 
-def write_audit(chado_alleles, counts_by_file, output_path):
+def write_audit(chado_universe, counts_by_file, output_path):
     """Write the long-format audit TSV plus a summary footer."""
     log.info(f'Write audit output to {output_path}.')
-    # Build the union universe so we cover both chado-only and TSV-only alleles.
-    tsv_alleles = set()
+    # Build the union universe so we cover both chado-only and TSV-only ids.
+    tsv_ids = set()
     for counter in counts_by_file.values():
-        tsv_alleles.update(counter)
-    universe = sorted(chado_alleles | tsv_alleles)
+        tsv_ids.update(counter)
+    universe = sorted(chado_universe | tsv_ids)
     file_names = sorted(counts_by_file.keys())
 
     in_chado_and_any_tsv = 0
@@ -136,19 +196,19 @@ def write_audit(chado_alleles, counts_by_file, output_path):
 
     with open(output_path, 'w') as out:
         out.write('# uniquename\tfile\tcount\n')
-        for allele in universe:
-            in_chado = allele in chado_alleles
+        for uname in universe:
+            in_chado = uname in chado_universe
             found_anywhere = False
             for fn in file_names:
-                count = counts_by_file[fn].get(allele, 0)
+                count = counts_by_file[fn].get(uname, 0)
                 if count == 0:
                     continue
                 found_anywhere = True
                 tag = fn if in_chado else f'{fn} {SENTINEL_NOT_IN_CHADO}'
-                out.write(f'{allele}\t{tag}\t{count}\n')
+                out.write(f'{uname}\t{tag}\t{count}\n')
                 per_file_unique[fn] += 1
             if in_chado and not found_anywhere:
-                out.write(f'{allele}\t{SENTINEL_NO_TSV}\t0\n')
+                out.write(f'{uname}\t{SENTINEL_NO_TSV}\t0\n')
                 in_chado_no_tsv += 1
             if in_chado and found_anywhere:
                 in_chado_and_any_tsv += 1
@@ -156,19 +216,19 @@ def write_audit(chado_alleles, counts_by_file, output_path):
                 in_tsv_not_in_chado += 1
         # Summary footer.
         out.write('# --- summary ---\n')
-        out.write(f'# total alleles in chado: {len(chado_alleles):,}\n')
-        out.write(f'# total alleles found in any TSV: {len(tsv_alleles):,}\n')
-        out.write(f'# alleles in chado AND in >=1 TSV: {in_chado_and_any_tsv:,}\n')
+        out.write(f'# total allele-ingest ids in chado: {len(chado_universe):,}\n')
+        out.write(f'# total allele-ingest ids in any TSV: {len(tsv_ids):,}\n')
+        out.write(f'# ids in chado AND in >=1 TSV: {in_chado_and_any_tsv:,}\n')
         out.write(
-            f'# alleles in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
+            f'# ids in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
         out.write(
-            f'# alleles in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
+            f'# ids in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
             f'(orphaned references)\n')
-        out.write('# per-file unique-allele totals:\n')
+        out.write('# per-file unique-id totals:\n')
         for fn in file_names:
             out.write(f'#   {fn}: {per_file_unique[fn]:,}\n')
 
-    log.info(f'Wrote audit with {len(universe):,} alleles to {output_path}.')
+    log.info(f'Wrote audit with {len(universe):,} ids to {output_path}.')
     log.info(
         f'  in-chado-and-any-tsv={in_chado_and_any_tsv:,}, '
         f'in-chado-no-tsv={in_chado_no_tsv:,}, '
@@ -181,11 +241,11 @@ def main():
     log.info('Started main function.')
     session = Session()
     try:
-        chado_alleles = query_chado_alleles(session)
+        chado_universe = query_chado_alleles(session)
     finally:
         session.close()
     counts_by_file = collect_tsv_counts(args.tsv_dir)
-    write_audit(chado_alleles, counts_by_file, output_filename)
+    write_audit(chado_universe, counts_by_file, output_filename)
     log.info('Ended main function.\n')
 
 

--- a/src/audit_alleles_in_curation_tsvs.py
+++ b/src/audit_alleles_in_curation_tsvs.py
@@ -107,7 +107,10 @@ def collect_tsv_counts(tsv_dir):
         counter = Counter()
         with path.open() as fh:
             for line in fh:
-                for m in FBAL_RE.findall(line):
+                if not line or line.startswith('#'):
+                    continue
+                first_col = line.split('\t', 1)[0]
+                for m in FBAL_RE.findall(first_col):
                     counter[m] += 1
         counts_by_file[path.name] = counter
         log.info(

--- a/src/audit_cassettes_in_curation_tsvs.py
+++ b/src/audit_cassettes_in_curation_tsvs.py
@@ -85,6 +85,10 @@ TSV_GLOB = '*_curation*.tsv'
 EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses', 'curation_tsvs')
 SENTINEL_NO_TSV = '<not in any tsv>'
 SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
+# Used in place of SENTINEL_NOT_IN_CHADO when the TSV row carried
+# internal=True (likely an obsolete-in-chado entity that the chado query
+# filtered out via is_obsolete=False).
+SENTINEL_OBSOLETE_IN_CHADO = '<obsolete_in_chado>'
 
 
 def query_chado_cassettes_universe(session):
@@ -122,6 +126,7 @@ def collect_tsv_counts(tsv_dir):
     """Walk *_curation*.tsv files and count FBal/FBti occurrences per file (column 0 only)."""
     log.info(f'Walk TSV files matching "{TSV_GLOB}" under {tsv_dir}.')
     counts_by_file = {}
+    internal_ids = set()
     all_paths = sorted(Path(tsv_dir).glob(TSV_GLOB))
     paths = [p for p in all_paths
              if not any(sub in p.name for sub in EXCLUDE_SUBSTRINGS)]
@@ -138,17 +143,24 @@ def collect_tsv_counts(tsv_dir):
             for line in fh:
                 if not line or line.startswith('#'):
                     continue
-                first_col = line.split('\t', 1)[0]
+                parts = line.rstrip('\n').split('\t')
+                first_col = parts[0]
+                # The 'internal' flag is the last column on rows produced by
+                # the curation retrieval scripts; older TSVs without that
+                # column will fall through as 'not internal'.
+                row_is_internal = (parts[-1].strip() == 'True' and len(parts) > 1)
                 for m in CASSETTE_RE.findall(first_col):
                     counter[m] += 1
+                    if row_is_internal:
+                        internal_ids.add(m)
         counts_by_file[path.name] = counter
         log.info(
             f'  {path.name}: {len(counter):,} unique FBal/FBti ids, '
             f'{sum(counter.values()):,} occurrences.')
-    return counts_by_file
+    return counts_by_file, internal_ids
 
 
-def write_audit(chado_universe, counts_by_file, output_path):
+def write_audit(chado_universe, counts_by_file, internal_ids, output_path):
     """Write the long-format audit TSV plus a summary footer."""
     log.info(f'Write audit output to {output_path}.')
     tsv_ids = set()
@@ -160,19 +172,23 @@ def write_audit(chado_universe, counts_by_file, output_path):
     in_chado_and_any_tsv = 0
     in_chado_no_tsv = 0
     in_tsv_not_in_chado = 0
+    in_tsv_obsolete_in_chado = 0
     per_file_unique = {fn: 0 for fn in file_names}
 
     with open(output_path, 'w') as out:
         out.write('# uniquename\tfile\tcount\n')
         for uname in universe:
             in_chado = uname in chado_universe
+            orphan_sentinel = (SENTINEL_OBSOLETE_IN_CHADO
+                               if uname in internal_ids
+                               else SENTINEL_NOT_IN_CHADO)
             found_anywhere = False
             for fn in file_names:
                 count = counts_by_file[fn].get(uname, 0)
                 if count == 0:
                     continue
                 found_anywhere = True
-                tag = fn if in_chado else f'{fn} {SENTINEL_NOT_IN_CHADO}'
+                tag = fn if in_chado else f'{fn} {orphan_sentinel}'
                 out.write(f'{uname}\t{tag}\t{count}\n')
                 per_file_unique[fn] += 1
             if in_chado and not found_anywhere:
@@ -181,7 +197,10 @@ def write_audit(chado_universe, counts_by_file, output_path):
             if in_chado and found_anywhere:
                 in_chado_and_any_tsv += 1
             if not in_chado and found_anywhere:
-                in_tsv_not_in_chado += 1
+                if uname in internal_ids:
+                    in_tsv_obsolete_in_chado += 1
+                else:
+                    in_tsv_not_in_chado += 1
         # Summary footer.
         out.write('# --- summary ---\n')
         out.write(f'# total cassette-eligible ids in chado: {len(chado_universe):,}\n')
@@ -190,8 +209,10 @@ def write_audit(chado_universe, counts_by_file, output_path):
         out.write(
             f'# ids in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
         out.write(
-            f'# ids in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
-            f'(orphaned references)\n')
+            f'# ids in TSVs but absent from chado (orphans): {in_tsv_not_in_chado:,}\n')
+        out.write(
+            f'# ids in TSVs marked internal (obsolete-in-chado): '
+            f'{in_tsv_obsolete_in_chado:,}\n')
         out.write('# per-file unique-id totals:\n')
         for fn in file_names:
             out.write(f'#   {fn}: {per_file_unique[fn]:,}\n')
@@ -200,7 +221,8 @@ def write_audit(chado_universe, counts_by_file, output_path):
     log.info(
         f'  in-chado-and-any-tsv={in_chado_and_any_tsv:,}, '
         f'in-chado-no-tsv={in_chado_no_tsv:,}, '
-        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}.')
+        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}, '
+        f'in-tsv-obsolete-in-chado={in_tsv_obsolete_in_chado:,}.')
 
 
 def main():
@@ -212,8 +234,8 @@ def main():
         chado_universe = query_chado_cassettes_universe(session)
     finally:
         session.close()
-    counts_by_file = collect_tsv_counts(args.tsv_dir)
-    write_audit(chado_universe, counts_by_file, output_filename)
+    counts_by_file, internal_ids = collect_tsv_counts(args.tsv_dir)
+    write_audit(chado_universe, counts_by_file, internal_ids, output_filename)
     log.info('Ended main function.\n')
 
 

--- a/src/audit_cassettes_in_curation_tsvs.py
+++ b/src/audit_cassettes_in_curation_tsvs.py
@@ -1,0 +1,221 @@
+# !/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Cross-reference chado cassette-eligible features against curation TSV files.
+
+Author(s):
+    Ian Longden ilongden@morgan.harvard.edu
+
+Usage:
+    audit_cassettes_in_curation_tsvs.py [-h] [-v VERBOSE] [-c CONFIG]
+    [--tsv-dir TSV_DIR]
+
+Example:
+    python audit_cassettes_in_curation_tsvs.py -v -c /path/to/config.cfg
+
+Notes:
+    Cassettes are not their own chado feature class - they are derived
+    from FBal alleles plus the FBti-suffixed anon cassettes built by the
+    FTA-136 generic-TI pipeline. So the chado universe for this audit
+    is the union of:
+
+        - non-obsolete FBal alleles (cvterm.name = 'allele'), and
+        - non-obsolete FBti insertions (cvterm.name in the insertion
+          feature_subtypes from handler.py:252).
+
+    The script walks every *_curation*.tsv file under the TSV directory
+    (default ./tsvs) and counts FBal/FBti occurrences in column 0 only.
+    Anon cassettes are stored in the cassette TSV as 'FB:FBti0xxxxxx_cas';
+    the regex \\bFBti\\d{7}\\b matches the FBti portion, so each anon
+    cassette counts under its FBti id (no double-counting vs the suffixed
+    form).
+
+    Output format mirrors src/audit_alleles_in_curation_tsvs.py: long
+    rows of (uniquename, file, count) plus sentinel rows for "in chado,
+    not in any TSV" and "in TSVs, not in chado".
+"""
+
+import argparse
+import re
+from collections import Counter
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, aliased
+from harvdev_utils.psycopg_functions import set_up_db_reading
+from harvdev_utils.reporting import Cvterm, Feature
+
+# Data types handled by this script.
+REPORT_LABEL = 'audit_cassettes_in_curation_tsvs'
+
+# Now proceed with generic setup.
+set_up_dict = set_up_db_reading(REPORT_LABEL)
+server = set_up_dict['server']
+database = set_up_dict['database']
+username = set_up_dict['username']
+password = set_up_dict['password']
+output_filename = set_up_dict['output_filename']
+log = set_up_dict['log']
+
+# Process additional input parameters not handled by the set_up_db_reading() function above.
+parser = argparse.ArgumentParser(
+    description='Audit chado cassette-eligible features (FBal + FBti) against the curation TSV files.')
+parser.add_argument('--tsv-dir', default='tsvs',
+                    help='Directory containing the *_curation*.tsv files (default: tsvs).')
+args, extra_args = parser.parse_known_args()
+log.info(f'These args are handled by this specific script: {args}')
+log.info(f'These args are handled by modules: {extra_args}')
+
+# Create SQL Alchemy engine from environmental variables.
+engine_var_rep = 'postgresql://' + username + ':' + password + '@' + server + '/' + database
+ENGINE = create_engine(engine_var_rep)
+Session = sessionmaker(bind=ENGINE)
+
+ALLELE_REGEX = r'^FBal[0-9]{7}$'
+INSERTION_REGEX = r'^FBti[0-9]{7}$'
+# Match FBal*** or FBti*** anywhere in the cell; works for 'FB:FBal0000010'
+# and 'FB:FBti0167947_cas' alike.
+CASSETTE_RE = re.compile(r'\b(?:FBal|FBti)\d{7}\b')
+# Insertion feature_subtypes per src/handler.py:252.
+INSERTION_TYPES = (
+    'insertion_site',
+    'transposable_element',
+    'transposable_element_insertion_site',
+)
+TSV_GLOB = '*_curation*.tsv'
+EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses', 'curation_tsvs')
+SENTINEL_NO_TSV = '<not in any tsv>'
+SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
+
+
+def query_chado_cassettes_universe(session):
+    """Return the union of non-obsolete FBal alleles and FBti insertions from chado."""
+    log.info('Query chado for non-obsolete FBal alleles.')
+    allele_type = aliased(Cvterm, name='allele_type')
+    fbal_results = session.query(Feature.uniquename).\
+        join(allele_type, allele_type.cvterm_id == Feature.type_id).\
+        filter(
+            Feature.uniquename.op('~')(ALLELE_REGEX),
+            Feature.is_obsolete.is_(False),
+            allele_type.name == 'allele').\
+        distinct()
+    fbals = {row.uniquename for row in fbal_results}
+    log.info(f'  loaded {len(fbals):,} non-obsolete FBal alleles.')
+
+    log.info('Query chado for non-obsolete FBti insertions.')
+    insertion_type = aliased(Cvterm, name='insertion_type')
+    fbti_results = session.query(Feature.uniquename).\
+        join(insertion_type, insertion_type.cvterm_id == Feature.type_id).\
+        filter(
+            Feature.uniquename.op('~')(INSERTION_REGEX),
+            Feature.is_obsolete.is_(False),
+            insertion_type.name.in_(INSERTION_TYPES)).\
+        distinct()
+    fbtis = {row.uniquename for row in fbti_results}
+    log.info(f'  loaded {len(fbtis):,} non-obsolete FBti insertions.')
+
+    universe = fbals | fbtis
+    log.info(f'Cassette universe = {len(universe):,} ids ({len(fbals):,} FBal + {len(fbtis):,} FBti).')
+    return universe
+
+
+def collect_tsv_counts(tsv_dir):
+    """Walk *_curation*.tsv files and count FBal/FBti occurrences per file (column 0 only)."""
+    log.info(f'Walk TSV files matching "{TSV_GLOB}" under {tsv_dir}.')
+    counts_by_file = {}
+    all_paths = sorted(Path(tsv_dir).glob(TSV_GLOB))
+    paths = [p for p in all_paths
+             if not any(sub in p.name for sub in EXCLUDE_SUBSTRINGS)]
+    skipped = len(all_paths) - len(paths)
+    if skipped:
+        log.info(
+            f'Skipping {skipped} files whose names contain any of '
+            f'{EXCLUDE_SUBSTRINGS}.')
+    if not paths:
+        log.warning(f'No files matched "{TSV_GLOB}" under {tsv_dir}.')
+    for path in paths:
+        counter = Counter()
+        with path.open() as fh:
+            for line in fh:
+                if not line or line.startswith('#'):
+                    continue
+                first_col = line.split('\t', 1)[0]
+                for m in CASSETTE_RE.findall(first_col):
+                    counter[m] += 1
+        counts_by_file[path.name] = counter
+        log.info(
+            f'  {path.name}: {len(counter):,} unique FBal/FBti ids, '
+            f'{sum(counter.values()):,} occurrences.')
+    return counts_by_file
+
+
+def write_audit(chado_universe, counts_by_file, output_path):
+    """Write the long-format audit TSV plus a summary footer."""
+    log.info(f'Write audit output to {output_path}.')
+    tsv_ids = set()
+    for counter in counts_by_file.values():
+        tsv_ids.update(counter)
+    universe = sorted(chado_universe | tsv_ids)
+    file_names = sorted(counts_by_file.keys())
+
+    in_chado_and_any_tsv = 0
+    in_chado_no_tsv = 0
+    in_tsv_not_in_chado = 0
+    per_file_unique = {fn: 0 for fn in file_names}
+
+    with open(output_path, 'w') as out:
+        out.write('# uniquename\tfile\tcount\n')
+        for uname in universe:
+            in_chado = uname in chado_universe
+            found_anywhere = False
+            for fn in file_names:
+                count = counts_by_file[fn].get(uname, 0)
+                if count == 0:
+                    continue
+                found_anywhere = True
+                tag = fn if in_chado else f'{fn} {SENTINEL_NOT_IN_CHADO}'
+                out.write(f'{uname}\t{tag}\t{count}\n')
+                per_file_unique[fn] += 1
+            if in_chado and not found_anywhere:
+                out.write(f'{uname}\t{SENTINEL_NO_TSV}\t0\n')
+                in_chado_no_tsv += 1
+            if in_chado and found_anywhere:
+                in_chado_and_any_tsv += 1
+            if not in_chado and found_anywhere:
+                in_tsv_not_in_chado += 1
+        # Summary footer.
+        out.write('# --- summary ---\n')
+        out.write(f'# total cassette-eligible ids in chado: {len(chado_universe):,}\n')
+        out.write(f'# total cassette-eligible ids in any TSV: {len(tsv_ids):,}\n')
+        out.write(f'# ids in chado AND in >=1 TSV: {in_chado_and_any_tsv:,}\n')
+        out.write(
+            f'# ids in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
+        out.write(
+            f'# ids in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
+            f'(orphaned references)\n')
+        out.write('# per-file unique-id totals:\n')
+        for fn in file_names:
+            out.write(f'#   {fn}: {per_file_unique[fn]:,}\n')
+
+    log.info(f'Wrote audit with {len(universe):,} ids to {output_path}.')
+    log.info(
+        f'  in-chado-and-any-tsv={in_chado_and_any_tsv:,}, '
+        f'in-chado-no-tsv={in_chado_no_tsv:,}, '
+        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}.')
+
+
+def main():
+    """Run the audit."""
+    log.info(f'Running script "{__file__}"')
+    log.info('Started main function.')
+    session = Session()
+    try:
+        chado_universe = query_chado_cassettes_universe(session)
+    finally:
+        session.close()
+    counts_by_file = collect_tsv_counts(args.tsv_dir)
+    write_audit(chado_universe, counts_by_file, output_filename)
+    log.info('Ended main function.\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/audit_cassettes_in_curation_tsvs.py
+++ b/src/audit_cassettes_in_curation_tsvs.py
@@ -1,6 +1,6 @@
 # !/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Cross-reference chado cassette-eligible features against curation TSV files.
+r"""Cross-reference chado cassette-eligible features against curation TSV files.
 
 Author(s):
     Ian Longden ilongden@morgan.harvard.edu

--- a/src/audit_constructs_in_curation_tsvs.py
+++ b/src/audit_constructs_in_curation_tsvs.py
@@ -1,0 +1,206 @@
+# !/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Cross-reference chado constructs against curation TSV files.
+
+Author(s):
+    Ian Longden ilongden@morgan.harvard.edu
+
+Usage:
+    audit_constructs_in_curation_tsvs.py [-h] [-v VERBOSE] [-c CONFIG]
+    [--tsv-dir TSV_DIR]
+
+Example:
+    python audit_constructs_in_curation_tsvs.py -v -c /path/to/config.cfg
+
+Notes:
+    Queries chado for the set of all non-obsolete FBtp constructs, walks
+    every *_curation*.tsv file under the TSV directory (default: ./tsvs),
+    and writes a long-format audit TSV listing each (construct, file, count)
+    tuple. Constructs in chado but absent from every TSV are emitted with a
+    sentinel file value '<not in any tsv>' and count=0; FBtps appearing in
+    TSVs but absent from chado are emitted with sentinel file
+    '<not_in_chado>' so typos and stale references are surfaced.
+
+    Anonymous <FBti>_con constructs use FBti-prefixed primary_external_id
+    values and so are intentionally not matched here -- this audit covers
+    the canonical FBtp set in chado.
+"""
+
+import argparse
+import re
+from collections import Counter
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, aliased
+from harvdev_utils.psycopg_functions import set_up_db_reading
+from harvdev_utils.reporting import Cvterm, Feature
+
+# Data types handled by this script.
+REPORT_LABEL = 'audit_constructs_in_curation_tsvs'
+
+# Now proceed with generic setup.
+set_up_dict = set_up_db_reading(REPORT_LABEL)
+server = set_up_dict['server']
+database = set_up_dict['database']
+username = set_up_dict['username']
+password = set_up_dict['password']
+output_filename = set_up_dict['output_filename']
+log = set_up_dict['log']
+
+# Process additional input parameters not handled by the set_up_db_reading() function above.
+parser = argparse.ArgumentParser(
+    description='Audit chado FBtp constructs against the curation TSV files.')
+parser.add_argument('--tsv-dir', default='tsvs',
+                    help='Directory containing the *_curation*.tsv files (default: tsvs).')
+args, extra_args = parser.parse_known_args()
+log.info(f'These args are handled by this specific script: {args}')
+log.info(f'These args are handled by modules: {extra_args}')
+
+# Create SQL Alchemy engine from environmental variables.
+engine_var_rep = 'postgresql://' + username + ':' + password + '@' + server + '/' + database
+ENGINE = create_engine(engine_var_rep)
+Session = sessionmaker(bind=ENGINE)
+
+CONSTRUCT_REGEX = r'^FBtp[0-9]{7}$'
+FBTP_RE = re.compile(r'\bFBtp\d{7}\b')
+# Construct feature subtypes per src/handler.py:250.
+CONSTRUCT_TYPES = (
+    'engineered_transposable_element',
+    'engineered_region',
+    'transgenic_transposable_element',
+)
+TSV_GLOB = '*_curation*.tsv'
+# Filter out filenames whose names contain any of these substrings; these
+# are auxiliary curation TSVs (notes, association, component slots, etc.)
+# we don't want in the cross-reference audit. 'curation_tsvs' self-excludes
+# both this script's own output AND the sibling allele-audit output.
+EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses', 'curation_tsvs')
+SENTINEL_NO_TSV = '<not in any tsv>'
+SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
+
+
+def query_chado_constructs(session):
+    """Return the set of non-obsolete FBtp construct uniquenames from chado."""
+    log.info('Query chado for non-obsolete FBtp constructs.')
+    construct_type = aliased(Cvterm, name='construct_type')
+    results = session.query(Feature.uniquename).\
+        join(construct_type, construct_type.cvterm_id == Feature.type_id).\
+        filter(
+            Feature.uniquename.op('~')(CONSTRUCT_REGEX),
+            Feature.is_obsolete.is_(False),
+            construct_type.name.in_(CONSTRUCT_TYPES)).\
+        distinct()
+    chado_constructs = {row.uniquename for row in results}
+    log.info(f'Loaded {len(chado_constructs):,} non-obsolete FBtp constructs from chado.')
+    return chado_constructs
+
+
+def collect_tsv_counts(tsv_dir):
+    """Walk *_curation*.tsv files and count FBtp occurrences per file.
+
+    Skips auxiliary files whose names contain any of EXCLUDE_SUBSTRINGS
+    (notes, association, component slots, tool_uses, prior audit output).
+    Only the first tab-separated column is scanned -- so a construct is
+    only counted when the row's primary id is that construct.
+    """
+    log.info(f'Walk TSV files matching "{TSV_GLOB}" under {tsv_dir}.')
+    counts_by_file = {}
+    all_paths = sorted(Path(tsv_dir).glob(TSV_GLOB))
+    paths = [p for p in all_paths
+             if not any(sub in p.name for sub in EXCLUDE_SUBSTRINGS)]
+    skipped = len(all_paths) - len(paths)
+    if skipped:
+        log.info(
+            f'Skipping {skipped} files whose names contain any of '
+            f'{EXCLUDE_SUBSTRINGS}.')
+    if not paths:
+        log.warning(f'No files matched "{TSV_GLOB}" under {tsv_dir}.')
+    for path in paths:
+        counter = Counter()
+        with path.open() as fh:
+            for line in fh:
+                if not line or line.startswith('#'):
+                    continue
+                first_col = line.split('\t', 1)[0]
+                for m in FBTP_RE.findall(first_col):
+                    counter[m] += 1
+        counts_by_file[path.name] = counter
+        log.info(
+            f'  {path.name}: {len(counter):,} unique FBtps, '
+            f'{sum(counter.values()):,} occurrences.')
+    return counts_by_file
+
+
+def write_audit(chado_constructs, counts_by_file, output_path):
+    """Write the long-format audit TSV plus a summary footer."""
+    log.info(f'Write audit output to {output_path}.')
+    # Build the union universe so we cover both chado-only and TSV-only constructs.
+    tsv_constructs = set()
+    for counter in counts_by_file.values():
+        tsv_constructs.update(counter)
+    universe = sorted(chado_constructs | tsv_constructs)
+    file_names = sorted(counts_by_file.keys())
+
+    in_chado_and_any_tsv = 0
+    in_chado_no_tsv = 0
+    in_tsv_not_in_chado = 0
+    per_file_unique = {fn: 0 for fn in file_names}
+
+    with open(output_path, 'w') as out:
+        out.write('# uniquename\tfile\tcount\n')
+        for construct in universe:
+            in_chado = construct in chado_constructs
+            found_anywhere = False
+            for fn in file_names:
+                count = counts_by_file[fn].get(construct, 0)
+                if count == 0:
+                    continue
+                found_anywhere = True
+                tag = fn if in_chado else f'{fn} {SENTINEL_NOT_IN_CHADO}'
+                out.write(f'{construct}\t{tag}\t{count}\n')
+                per_file_unique[fn] += 1
+            if in_chado and not found_anywhere:
+                out.write(f'{construct}\t{SENTINEL_NO_TSV}\t0\n')
+                in_chado_no_tsv += 1
+            if in_chado and found_anywhere:
+                in_chado_and_any_tsv += 1
+            if not in_chado and found_anywhere:
+                in_tsv_not_in_chado += 1
+        # Summary footer.
+        out.write('# --- summary ---\n')
+        out.write(f'# total constructs in chado: {len(chado_constructs):,}\n')
+        out.write(f'# total constructs found in any TSV: {len(tsv_constructs):,}\n')
+        out.write(f'# constructs in chado AND in >=1 TSV: {in_chado_and_any_tsv:,}\n')
+        out.write(
+            f'# constructs in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
+        out.write(
+            f'# constructs in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
+            f'(orphaned references)\n')
+        out.write('# per-file unique-construct totals:\n')
+        for fn in file_names:
+            out.write(f'#   {fn}: {per_file_unique[fn]:,}\n')
+
+    log.info(f'Wrote audit with {len(universe):,} constructs to {output_path}.')
+    log.info(
+        f'  in-chado-and-any-tsv={in_chado_and_any_tsv:,}, '
+        f'in-chado-no-tsv={in_chado_no_tsv:,}, '
+        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}.')
+
+
+def main():
+    """Run the audit."""
+    log.info(f'Running script "{__file__}"')
+    log.info('Started main function.')
+    session = Session()
+    try:
+        chado_constructs = query_chado_constructs(session)
+    finally:
+        session.close()
+    counts_by_file = collect_tsv_counts(args.tsv_dir)
+    write_audit(chado_constructs, counts_by_file, output_filename)
+    log.info('Ended main function.\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/audit_constructs_in_curation_tsvs.py
+++ b/src/audit_constructs_in_curation_tsvs.py
@@ -78,6 +78,10 @@ TSV_GLOB = '*_curation*.tsv'
 EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses', 'curation_tsvs')
 SENTINEL_NO_TSV = '<not in any tsv>'
 SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
+# Used in place of SENTINEL_NOT_IN_CHADO when the TSV row carried
+# internal=True (likely an obsolete-in-chado entity that the chado query
+# filtered out via is_obsolete=False).
+SENTINEL_OBSOLETE_IN_CHADO = '<obsolete_in_chado>'
 
 
 def query_chado_constructs(session):
@@ -106,6 +110,7 @@ def collect_tsv_counts(tsv_dir):
     """
     log.info(f'Walk TSV files matching "{TSV_GLOB}" under {tsv_dir}.')
     counts_by_file = {}
+    internal_ids = set()
     all_paths = sorted(Path(tsv_dir).glob(TSV_GLOB))
     paths = [p for p in all_paths
              if not any(sub in p.name for sub in EXCLUDE_SUBSTRINGS)]
@@ -122,17 +127,24 @@ def collect_tsv_counts(tsv_dir):
             for line in fh:
                 if not line or line.startswith('#'):
                     continue
-                first_col = line.split('\t', 1)[0]
+                parts = line.rstrip('\n').split('\t')
+                first_col = parts[0]
+                # The 'internal' flag is the last column on rows produced by
+                # the curation retrieval scripts; older TSVs without that
+                # column will fall through as 'not internal'.
+                row_is_internal = (parts[-1].strip() == 'True' and len(parts) > 1)
                 for m in FBTP_RE.findall(first_col):
                     counter[m] += 1
+                    if row_is_internal:
+                        internal_ids.add(m)
         counts_by_file[path.name] = counter
         log.info(
             f'  {path.name}: {len(counter):,} unique FBtps, '
             f'{sum(counter.values()):,} occurrences.')
-    return counts_by_file
+    return counts_by_file, internal_ids
 
 
-def write_audit(chado_constructs, counts_by_file, output_path):
+def write_audit(chado_constructs, counts_by_file, internal_ids, output_path):
     """Write the long-format audit TSV plus a summary footer."""
     log.info(f'Write audit output to {output_path}.')
     # Build the union universe so we cover both chado-only and TSV-only constructs.
@@ -145,19 +157,23 @@ def write_audit(chado_constructs, counts_by_file, output_path):
     in_chado_and_any_tsv = 0
     in_chado_no_tsv = 0
     in_tsv_not_in_chado = 0
+    in_tsv_obsolete_in_chado = 0
     per_file_unique = {fn: 0 for fn in file_names}
 
     with open(output_path, 'w') as out:
         out.write('# uniquename\tfile\tcount\n')
         for construct in universe:
             in_chado = construct in chado_constructs
+            orphan_sentinel = (SENTINEL_OBSOLETE_IN_CHADO
+                               if construct in internal_ids
+                               else SENTINEL_NOT_IN_CHADO)
             found_anywhere = False
             for fn in file_names:
                 count = counts_by_file[fn].get(construct, 0)
                 if count == 0:
                     continue
                 found_anywhere = True
-                tag = fn if in_chado else f'{fn} {SENTINEL_NOT_IN_CHADO}'
+                tag = fn if in_chado else f'{fn} {orphan_sentinel}'
                 out.write(f'{construct}\t{tag}\t{count}\n')
                 per_file_unique[fn] += 1
             if in_chado and not found_anywhere:
@@ -166,7 +182,10 @@ def write_audit(chado_constructs, counts_by_file, output_path):
             if in_chado and found_anywhere:
                 in_chado_and_any_tsv += 1
             if not in_chado and found_anywhere:
-                in_tsv_not_in_chado += 1
+                if construct in internal_ids:
+                    in_tsv_obsolete_in_chado += 1
+                else:
+                    in_tsv_not_in_chado += 1
         # Summary footer.
         out.write('# --- summary ---\n')
         out.write(f'# total constructs in chado: {len(chado_constructs):,}\n')
@@ -175,8 +194,10 @@ def write_audit(chado_constructs, counts_by_file, output_path):
         out.write(
             f'# constructs in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
         out.write(
-            f'# constructs in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
-            f'(orphaned references)\n')
+            f'# constructs in TSVs but absent from chado (orphans): {in_tsv_not_in_chado:,}\n')
+        out.write(
+            f'# constructs in TSVs marked internal (obsolete-in-chado): '
+            f'{in_tsv_obsolete_in_chado:,}\n')
         out.write('# per-file unique-construct totals:\n')
         for fn in file_names:
             out.write(f'#   {fn}: {per_file_unique[fn]:,}\n')
@@ -185,7 +206,8 @@ def write_audit(chado_constructs, counts_by_file, output_path):
     log.info(
         f'  in-chado-and-any-tsv={in_chado_and_any_tsv:,}, '
         f'in-chado-no-tsv={in_chado_no_tsv:,}, '
-        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}.')
+        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}, '
+        f'in-tsv-obsolete-in-chado={in_tsv_obsolete_in_chado:,}.')
 
 
 def main():
@@ -197,8 +219,8 @@ def main():
         chado_constructs = query_chado_constructs(session)
     finally:
         session.close()
-    counts_by_file = collect_tsv_counts(args.tsv_dir)
-    write_audit(chado_constructs, counts_by_file, output_filename)
+    counts_by_file, internal_ids = collect_tsv_counts(args.tsv_dir)
+    write_audit(chado_constructs, counts_by_file, internal_ids, output_filename)
     log.info('Ended main function.\n')
 
 

--- a/src/audit_transgenic_tools_in_curation_tsvs.py
+++ b/src/audit_transgenic_tools_in_curation_tsvs.py
@@ -1,0 +1,187 @@
+# !/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Cross-reference chado transgenic tools against curation TSV files.
+
+Author(s):
+    Ian Longden ilongden@morgan.harvard.edu
+
+Usage:
+    audit_transgenic_tools_in_curation_tsvs.py [-h] [-v VERBOSE] [-c CONFIG]
+    [--tsv-dir TSV_DIR]
+
+Example:
+    python audit_transgenic_tools_in_curation_tsvs.py -v -c /path/to/config.cfg
+
+Notes:
+    Queries chado for the set of all non-obsolete FBto transgenic tools,
+    walks every *_curation*.tsv file under the TSV directory (default:
+    ./tsvs), and writes a long-format audit TSV listing each (tool, file,
+    count) tuple. Tools in chado but absent from every TSV are emitted with
+    a sentinel file value '<not in any tsv>' and count=0; FBtos appearing
+    in TSVs but absent from chado are emitted with sentinel file
+    '<not_in_chado>' so typos and stale references are surfaced.
+"""
+
+import argparse
+import re
+from collections import Counter
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, aliased
+from harvdev_utils.psycopg_functions import set_up_db_reading
+from harvdev_utils.reporting import Cvterm, Feature
+
+# Data types handled by this script.
+REPORT_LABEL = 'audit_transgenic_tools_in_curation_tsvs'
+
+# Now proceed with generic setup.
+set_up_dict = set_up_db_reading(REPORT_LABEL)
+server = set_up_dict['server']
+database = set_up_dict['database']
+username = set_up_dict['username']
+password = set_up_dict['password']
+output_filename = set_up_dict['output_filename']
+log = set_up_dict['log']
+
+# Process additional input parameters not handled by the set_up_db_reading() function above.
+parser = argparse.ArgumentParser(
+    description='Audit chado FBto transgenic tools against the curation TSV files.')
+parser.add_argument('--tsv-dir', default='tsvs',
+                    help='Directory containing the *_curation*.tsv files (default: tsvs).')
+args, extra_args = parser.parse_known_args()
+log.info(f'These args are handled by this specific script: {args}')
+log.info(f'These args are handled by modules: {extra_args}')
+
+# Create SQL Alchemy engine from environmental variables.
+engine_var_rep = 'postgresql://' + username + ':' + password + '@' + server + '/' + database
+ENGINE = create_engine(engine_var_rep)
+Session = sessionmaker(bind=ENGINE)
+
+TOOL_REGEX = r'^FBto[0-9]{7}$'
+FBTO_RE = re.compile(r'\bFBto\d{7}\b')
+# Tool feature_subtypes per src/handler.py:255.
+TOOL_TYPES = ('engineered_region',)
+TSV_GLOB = '*_curation*.tsv'
+EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses', 'curation_tsvs')
+SENTINEL_NO_TSV = '<not in any tsv>'
+SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
+
+
+def query_chado_tools(session):
+    """Return the set of non-obsolete FBto transgenic tool uniquenames from chado."""
+    log.info('Query chado for non-obsolete FBto transgenic tools.')
+    tool_type = aliased(Cvterm, name='tool_type')
+    results = session.query(Feature.uniquename).\
+        join(tool_type, tool_type.cvterm_id == Feature.type_id).\
+        filter(
+            Feature.uniquename.op('~')(TOOL_REGEX),
+            Feature.is_obsolete.is_(False),
+            tool_type.name.in_(TOOL_TYPES)).\
+        distinct()
+    chado_tools = {row.uniquename for row in results}
+    log.info(f'Loaded {len(chado_tools):,} non-obsolete FBto tools from chado.')
+    return chado_tools
+
+
+def collect_tsv_counts(tsv_dir):
+    """Walk *_curation*.tsv files and count FBto occurrences per file (column 0 only)."""
+    log.info(f'Walk TSV files matching "{TSV_GLOB}" under {tsv_dir}.')
+    counts_by_file = {}
+    all_paths = sorted(Path(tsv_dir).glob(TSV_GLOB))
+    paths = [p for p in all_paths
+             if not any(sub in p.name for sub in EXCLUDE_SUBSTRINGS)]
+    skipped = len(all_paths) - len(paths)
+    if skipped:
+        log.info(
+            f'Skipping {skipped} files whose names contain any of '
+            f'{EXCLUDE_SUBSTRINGS}.')
+    if not paths:
+        log.warning(f'No files matched "{TSV_GLOB}" under {tsv_dir}.')
+    for path in paths:
+        counter = Counter()
+        with path.open() as fh:
+            for line in fh:
+                if not line or line.startswith('#'):
+                    continue
+                first_col = line.split('\t', 1)[0]
+                for m in FBTO_RE.findall(first_col):
+                    counter[m] += 1
+        counts_by_file[path.name] = counter
+        log.info(
+            f'  {path.name}: {len(counter):,} unique FBtos, '
+            f'{sum(counter.values()):,} occurrences.')
+    return counts_by_file
+
+
+def write_audit(chado_tools, counts_by_file, output_path):
+    """Write the long-format audit TSV plus a summary footer."""
+    log.info(f'Write audit output to {output_path}.')
+    tsv_tools = set()
+    for counter in counts_by_file.values():
+        tsv_tools.update(counter)
+    universe = sorted(chado_tools | tsv_tools)
+    file_names = sorted(counts_by_file.keys())
+
+    in_chado_and_any_tsv = 0
+    in_chado_no_tsv = 0
+    in_tsv_not_in_chado = 0
+    per_file_unique = {fn: 0 for fn in file_names}
+
+    with open(output_path, 'w') as out:
+        out.write('# uniquename\tfile\tcount\n')
+        for tool in universe:
+            in_chado = tool in chado_tools
+            found_anywhere = False
+            for fn in file_names:
+                count = counts_by_file[fn].get(tool, 0)
+                if count == 0:
+                    continue
+                found_anywhere = True
+                tag = fn if in_chado else f'{fn} {SENTINEL_NOT_IN_CHADO}'
+                out.write(f'{tool}\t{tag}\t{count}\n')
+                per_file_unique[fn] += 1
+            if in_chado and not found_anywhere:
+                out.write(f'{tool}\t{SENTINEL_NO_TSV}\t0\n')
+                in_chado_no_tsv += 1
+            if in_chado and found_anywhere:
+                in_chado_and_any_tsv += 1
+            if not in_chado and found_anywhere:
+                in_tsv_not_in_chado += 1
+        # Summary footer.
+        out.write('# --- summary ---\n')
+        out.write(f'# total tools in chado: {len(chado_tools):,}\n')
+        out.write(f'# total tools found in any TSV: {len(tsv_tools):,}\n')
+        out.write(f'# tools in chado AND in >=1 TSV: {in_chado_and_any_tsv:,}\n')
+        out.write(
+            f'# tools in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
+        out.write(
+            f'# tools in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
+            f'(orphaned references)\n')
+        out.write('# per-file unique-tool totals:\n')
+        for fn in file_names:
+            out.write(f'#   {fn}: {per_file_unique[fn]:,}\n')
+
+    log.info(f'Wrote audit with {len(universe):,} tools to {output_path}.')
+    log.info(
+        f'  in-chado-and-any-tsv={in_chado_and_any_tsv:,}, '
+        f'in-chado-no-tsv={in_chado_no_tsv:,}, '
+        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}.')
+
+
+def main():
+    """Run the audit."""
+    log.info(f'Running script "{__file__}"')
+    log.info('Started main function.')
+    session = Session()
+    try:
+        chado_tools = query_chado_tools(session)
+    finally:
+        session.close()
+    counts_by_file = collect_tsv_counts(args.tsv_dir)
+    write_audit(chado_tools, counts_by_file, output_filename)
+    log.info('Ended main function.\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/audit_transgenic_tools_in_curation_tsvs.py
+++ b/src/audit_transgenic_tools_in_curation_tsvs.py
@@ -66,6 +66,10 @@ TSV_GLOB = '*_curation*.tsv'
 EXCLUDE_SUBSTRINGS = ('_notes', 'association', 'slots', 'tool_uses', 'curation_tsvs')
 SENTINEL_NO_TSV = '<not in any tsv>'
 SENTINEL_NOT_IN_CHADO = '<not_in_chado>'
+# Used in place of SENTINEL_NOT_IN_CHADO when the TSV row carried
+# internal=True (likely an obsolete-in-chado entity that the chado query
+# filtered out via is_obsolete=False).
+SENTINEL_OBSOLETE_IN_CHADO = '<obsolete_in_chado>'
 
 
 def query_chado_tools(session):
@@ -88,6 +92,7 @@ def collect_tsv_counts(tsv_dir):
     """Walk *_curation*.tsv files and count FBto occurrences per file (column 0 only)."""
     log.info(f'Walk TSV files matching "{TSV_GLOB}" under {tsv_dir}.')
     counts_by_file = {}
+    internal_ids = set()
     all_paths = sorted(Path(tsv_dir).glob(TSV_GLOB))
     paths = [p for p in all_paths
              if not any(sub in p.name for sub in EXCLUDE_SUBSTRINGS)]
@@ -104,17 +109,24 @@ def collect_tsv_counts(tsv_dir):
             for line in fh:
                 if not line or line.startswith('#'):
                     continue
-                first_col = line.split('\t', 1)[0]
+                parts = line.rstrip('\n').split('\t')
+                first_col = parts[0]
+                # The 'internal' flag is the last column on rows produced by
+                # the curation retrieval scripts; older TSVs without that
+                # column will fall through as 'not internal'.
+                row_is_internal = (parts[-1].strip() == 'True' and len(parts) > 1)
                 for m in FBTO_RE.findall(first_col):
                     counter[m] += 1
+                    if row_is_internal:
+                        internal_ids.add(m)
         counts_by_file[path.name] = counter
         log.info(
             f'  {path.name}: {len(counter):,} unique FBtos, '
             f'{sum(counter.values()):,} occurrences.')
-    return counts_by_file
+    return counts_by_file, internal_ids
 
 
-def write_audit(chado_tools, counts_by_file, output_path):
+def write_audit(chado_tools, counts_by_file, internal_ids, output_path):
     """Write the long-format audit TSV plus a summary footer."""
     log.info(f'Write audit output to {output_path}.')
     tsv_tools = set()
@@ -126,19 +138,23 @@ def write_audit(chado_tools, counts_by_file, output_path):
     in_chado_and_any_tsv = 0
     in_chado_no_tsv = 0
     in_tsv_not_in_chado = 0
+    in_tsv_obsolete_in_chado = 0
     per_file_unique = {fn: 0 for fn in file_names}
 
     with open(output_path, 'w') as out:
         out.write('# uniquename\tfile\tcount\n')
         for tool in universe:
             in_chado = tool in chado_tools
+            orphan_sentinel = (SENTINEL_OBSOLETE_IN_CHADO
+                               if tool in internal_ids
+                               else SENTINEL_NOT_IN_CHADO)
             found_anywhere = False
             for fn in file_names:
                 count = counts_by_file[fn].get(tool, 0)
                 if count == 0:
                     continue
                 found_anywhere = True
-                tag = fn if in_chado else f'{fn} {SENTINEL_NOT_IN_CHADO}'
+                tag = fn if in_chado else f'{fn} {orphan_sentinel}'
                 out.write(f'{tool}\t{tag}\t{count}\n')
                 per_file_unique[fn] += 1
             if in_chado and not found_anywhere:
@@ -147,7 +163,10 @@ def write_audit(chado_tools, counts_by_file, output_path):
             if in_chado and found_anywhere:
                 in_chado_and_any_tsv += 1
             if not in_chado and found_anywhere:
-                in_tsv_not_in_chado += 1
+                if tool in internal_ids:
+                    in_tsv_obsolete_in_chado += 1
+                else:
+                    in_tsv_not_in_chado += 1
         # Summary footer.
         out.write('# --- summary ---\n')
         out.write(f'# total tools in chado: {len(chado_tools):,}\n')
@@ -156,8 +175,10 @@ def write_audit(chado_tools, counts_by_file, output_path):
         out.write(
             f'# tools in chado but absent from every TSV: {in_chado_no_tsv:,}\n')
         out.write(
-            f'# tools in TSVs but absent from chado: {in_tsv_not_in_chado:,} '
-            f'(orphaned references)\n')
+            f'# tools in TSVs but absent from chado (orphans): {in_tsv_not_in_chado:,}\n')
+        out.write(
+            f'# tools in TSVs marked internal (obsolete-in-chado): '
+            f'{in_tsv_obsolete_in_chado:,}\n')
         out.write('# per-file unique-tool totals:\n')
         for fn in file_names:
             out.write(f'#   {fn}: {per_file_unique[fn]:,}\n')
@@ -166,7 +187,8 @@ def write_audit(chado_tools, counts_by_file, output_path):
     log.info(
         f'  in-chado-and-any-tsv={in_chado_and_any_tsv:,}, '
         f'in-chado-no-tsv={in_chado_no_tsv:,}, '
-        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}.')
+        f'in-tsv-not-in-chado={in_tsv_not_in_chado:,}, '
+        f'in-tsv-obsolete-in-chado={in_tsv_obsolete_in_chado:,}.')
 
 
 def main():
@@ -178,8 +200,8 @@ def main():
         chado_tools = query_chado_tools(session)
     finally:
         session.close()
-    counts_by_file = collect_tsv_counts(args.tsv_dir)
-    write_audit(chado_tools, counts_by_file, output_filename)
+    counts_by_file, internal_ids = collect_tsv_counts(args.tsv_dir)
+    write_audit(chado_tools, counts_by_file, internal_ids, output_filename)
     log.info('Ended main function.\n')
 
 

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -826,15 +826,22 @@ class CassetteHandler(FeatureHandler):
             # Accumulate across sources for dedup.
             rels_by_key = {}      # (rel_type, object_feature_id) -> set(pub_curies)
             tool_uses_by_acc = {}  # accession -> set(pub_curies)
-            # 1. Parent FBtp data (blank pub_curies), only if propagate.
+            # 1. Parent FBtp data, only if propagate.
+            # FTA-182 v3: if the producedby FR has exactly ONE pub, use it as
+            # the pub_curie for parent-sourced tool data; otherwise blank.
             if propagate:
+                producedby_pubs = data.get('producedby_pub_ids', [])
+                if len(producedby_pubs) == 1:
+                    parent_pub_curies = self.lookup_pub_curies(producedby_pubs)
+                else:
+                    parent_pub_curies = []
                 for rel in data.get('direct_rels', []):
                     if rel['rel_type'] not in self._tool_rel_alliance_name:
                         continue
                     key = (rel['rel_type'], rel['object_feature_id'])
-                    rels_by_key.setdefault(key, set())
+                    rels_by_key.setdefault(key, set()).update(parent_pub_curies)
                 for tu in data.get('tool_uses_data', []):
-                    tool_uses_by_acc.setdefault(tu['accession'], set())
+                    tool_uses_by_acc.setdefault(tu['accession'], set()).update(parent_pub_curies)
             # 2. Per associated FBal.
             for fbal in data.get('associated_alleles', []):
                 has_tool = bool(fbal['direct_rels']) or bool(fbal['tool_uses_data'])

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -440,7 +440,8 @@ class CassetteHandler(FeatureHandler):
                         self.log.debug(f"{entity.uniquename} has parent {rel.chado_obj.object.uniquename}")
                     gene = self.feature_lookup[rel.chado_obj.object.feature_id]
                     assoc_type = self.cassette_dto_type(gene)
-                    self.log.debug(f"{entity.uniquename} {gene} has {assoc_type} association")
+                    if self.testing:
+                        self.log.debug(f"{entity.uniquename} {gene} has {assoc_type} association")
                     # Always a gene currently BUT might in future have
                     # subset of foreign genes so check now anyway
                     if assoc_type == 'component_free_text':

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -649,6 +649,9 @@ class CassetteHandler(FeatureHandler):
         }
         counter = 0
         for data in self.anon_cassette_data:
+            # FTA-182: generic TI entries use the gated path below.
+            if data.get('is_generic_ti'):
+                continue
             cassette_id = f'FB:{data["construct_uniquename"]}_cas'
             for rel in data['direct_rels']:
                 if rel['rel_type'] not in rel_type_mapping:
@@ -686,6 +689,9 @@ class CassetteHandler(FeatureHandler):
         self.log.info('Map anonymous cassette encodes_tool relationships.')
         counter = 0
         for data in self.anon_cassette_data:
+            # FTA-182: generic TI entries use the gated path below.
+            if data.get('is_generic_ti'):
+                continue
             cassette_id = f'FB:{data["construct_uniquename"]}_cas'
             for rel in data['direct_rels']:
                 if rel['rel_type'] != 'encodes_tool':
@@ -726,6 +732,9 @@ class CassetteHandler(FeatureHandler):
         self.log.info('Map anonymous cassette tool_uses.')
         counter = 0
         for data in self.anon_cassette_data:
+            # FTA-182: generic TI entries use the gated path below.
+            if data.get('is_generic_ti'):
+                continue
             if not data['tool_uses_data']:
                 continue
             # Group pub_ids by FBcv accession.
@@ -745,6 +754,131 @@ class CassetteHandler(FeatureHandler):
                 counter += 1
         self.log.info(f'Mapped {counter} tool_uses DTOs for anonymous cassettes.')
 
+    # FTA-182: alliance-side relation names for each chado tool rel_type.
+    _tool_rel_alliance_name = {
+        'has_reg_region': 'is_regulated_by',
+        'tagged_with': 'tagged_with',
+        'carries_tool': 'contains',
+        'encodes_tool': 'expresses',
+    }
+
+    def _append_cassette_tool_dto(self, cassette_id, rel_type, object_feature_id,
+                                  pub_curies, cassette_dto):
+        """Dispatch a tool direct_rel to the right cassette DTO list.
+
+        Shared by the FTA-182 generic-TI path. Mirrors the FBto/FBgn/FBsf
+        branching in map_anon_cassette_simple_components /
+        map_anon_cassette_encodes_tool so behavior stays consistent.
+        """
+        alliance_rel = self._tool_rel_alliance_name.get(rel_type)
+        if alliance_rel is None:
+            return False
+        component = self.feature_lookup[object_feature_id]
+        component_curie = component['curie']
+        uname = component['uniquename']
+        if uname.startswith('FBto'):
+            fb_rel = fb_datatypes.FBExportEntity()
+            fb_rel.linkmldto = agr_datatypes.CassetteTransgenicToolAssociationDTO(
+                cassette_id, component_curie, pub_curies, False, alliance_rel)
+            self.anon_cassette_tool_associations.append(fb_rel)
+            return True
+        if uname.startswith('FBgn'):
+            fb_rel = fb_datatypes.FBExportEntity()
+            fb_rel.linkmldto = agr_datatypes.CassetteGenomicEntityAssociationDTO(
+                cassette_id, component_curie, pub_curies, False, alliance_rel)
+            self.anon_cassette_genomic_entity_associations.append(fb_rel)
+            return True
+        if uname.startswith('FBsf'):
+            organism_id = component['organism_id']
+            comp_dto = agr_datatypes.CassetteComponentSlotAnnotationDTO(
+                alliance_rel, component['symbol'],
+                self.organism_lookup[organism_id]['taxon_curie'],
+                self.organism_lookup[organism_id]['full_species_name'],
+                pub_curies).dict_export()
+            cassette_dto.cassette_component_dtos.append(comp_dto)
+            return True
+        return False
+
+    def map_anon_generic_ti_tool_data(self):
+        """Emit tool data for generic-TI anon cassettes per FTA-182 gating.
+
+        For each <FBti>_cas entry flagged is_generic_ti:
+          * Parent FBtp tool data (direct_rels + tool_uses) is emitted with
+            BLANK pub_curies, only if propagate_transgenic_uses is True.
+          * Per associated FBal: if is_represented_at_alliance_as passes,
+            emit FBal tool data with the FBal's own pub_curies; else attach
+            an internal_note NoteDTO and increment a warning counter.
+        Deduplicates across sources keyed by (cassette_id, rel_type,
+        object_feature_id); pub_curies are unioned when the same tool comes
+        from multiple FBals (or parent + FBal).
+        """
+        self.log.info('Map anonymous cassette tool data for generic TI insertions (FTA-182).')
+        rel_counter = 0
+        tu_counter = 0
+        ir_failures = 0
+        for data in self.anon_cassette_data:
+            if not data.get('is_generic_ti'):
+                continue
+            cassette_id = f'FB:{data["construct_uniquename"]}_cas'
+            cassette_dto = data['anon_cassette_dto']
+            propagate = data.get('propagate_transgenic_uses', True)
+            # Accumulate across sources for dedup.
+            rels_by_key = {}      # (rel_type, object_feature_id) -> set(pub_curies)
+            tool_uses_by_acc = {}  # accession -> set(pub_curies)
+            # 1. Parent FBtp data (blank pub_curies), only if propagate.
+            if propagate:
+                for rel in data.get('direct_rels', []):
+                    if rel['rel_type'] not in self._tool_rel_alliance_name:
+                        continue
+                    key = (rel['rel_type'], rel['object_feature_id'])
+                    rels_by_key.setdefault(key, set())
+                for tu in data.get('tool_uses_data', []):
+                    tool_uses_by_acc.setdefault(tu['accession'], set())
+            # 2. Per associated FBal.
+            for fbal in data.get('associated_alleles', []):
+                has_tool = bool(fbal['direct_rels']) or bool(fbal['tool_uses_data'])
+                if not has_tool:
+                    continue
+                if fbal['is_represented_at_alliance_as']:
+                    for rel in fbal['direct_rels']:
+                        if rel['rel_type'] not in self._tool_rel_alliance_name:
+                            continue
+                        key = (rel['rel_type'], rel['object_feature_id'])
+                        pub_curies = self.lookup_pub_curies(rel['pub_ids'])
+                        rels_by_key.setdefault(key, set()).update(pub_curies)
+                    for tu in fbal['tool_uses_data']:
+                        pub_curies = self.lookup_pub_curies([tu['pub_id']])
+                        tool_uses_by_acc.setdefault(tu['accession'], set()).update(pub_curies)
+                else:
+                    self.log.warning(
+                        f"Skipping tool data from {fbal['uniquename']} for "
+                        f"{cassette_id}: failed 'is_represented_at_alliance_as' "
+                        f"cross-check.")
+                    note_dto = agr_datatypes.NoteDTO(
+                        'internal_note',
+                        f"FTA: unable to add tool information from "
+                        f"{fbal['uniquename']} (failed "
+                        f"'is_represented_at_alliance_as' cross-check)",
+                        []).dict_export()
+                    cassette_dto.note_dtos.append(note_dto)
+                    ir_failures += 1
+            # 3. Emit deduped DTOs.
+            for (rel_type, obj_fid), pub_set in rels_by_key.items():
+                emitted = self._append_cassette_tool_dto(
+                    cassette_id, rel_type, obj_fid,
+                    sorted(pub_set), cassette_dto)
+                if emitted:
+                    rel_counter += 1
+            for accession, pub_set in tool_uses_by_acc.items():
+                slot_dto = agr_datatypes.CassetteUseSlotAnnotationDTO(
+                    sorted(pub_set), [f'FBcv:{accession}']).dict_export()
+                cassette_dto.cassette_use_dtos.append(slot_dto)
+                tu_counter += 1
+        self.log.info(
+            f'Generic TI anon cassettes: {rel_counter} tool component DTOs, '
+            f'{tu_counter} tool_uses DTOs, '
+            f"{ir_failures} 'is_represented_at_alliance_as' cross-check failures.")
+
     def map_anon_cassettes(self):
         """Orchestrate anonymous cassette mapping from ConstructHandler data."""
         self.log.info('Map anonymous cassettes from construct data.')
@@ -755,6 +889,8 @@ class CassetteHandler(FeatureHandler):
         self.map_anon_cassette_simple_components()
         self.map_anon_cassette_encodes_tool()
         self.map_anon_cassette_tool_uses()
+        # FTA-182: gated tool data for generic-TI anon cassettes.
+        self.map_anon_generic_ti_tool_data()
 
     def export_anon_cassettes(self):
         """Flag and export anonymous cassette data, appending to existing export dicts."""

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -763,8 +763,15 @@ class CassetteHandler(FeatureHandler):
             self.log.info('No anonymous cassette data to export.')
             return
         self.flag_internal_fb_entities('anon_cassettes')
+        self.flag_unexportable_entities(self.anon_cassettes, 'cassette_ingest_set')
         self.flag_internal_fb_entities('anon_cassette_tool_associations')
+        self.flag_unexportable_entities(
+            self.anon_cassette_tool_associations,
+            'cassette_transgenic_tool_association_ingest_set')
         self.flag_internal_fb_entities('anon_cassette_genomic_entity_associations')
+        self.flag_unexportable_entities(
+            self.anon_cassette_genomic_entity_associations,
+            'cassette_genomic_entity_association_ingest_set')
         # Append exportable anon cassettes to the existing export dicts.
         anon_count = 0
         for entity in self.anon_cassettes:

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -232,6 +232,8 @@ class CassetteHandler(FeatureHandler):
         # self.map_xrefs()
         self.map_secondary_ids('secondary_identifiers')
         self.map_cassette_associations()
+        # Cascade chado-obsolete -> internal=True (matches every other handler).
+        self.flag_internal_fb_entities('fb_data_entities')
 
     def map_secondary_ids(self, slot_name):
         """Return a list of Alliance SecondaryIdSlotAnnotationDTOs for a FlyBase entity."""

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -643,8 +643,8 @@ class ConstructHandler(FeatureHandler):
         results = session.query(
             Feature.uniquename,
             Feature.feature_id,
-            FeatureRelationship.object_id
-        ).select_from(FeatureRelationship).\
+            FeatureRelationship.object_id).\
+            select_from(FeatureRelationship).\
             join(Feature, Feature.feature_id == FeatureRelationship.subject_id).\
             join(rel_type, rel_type.cvterm_id == FeatureRelationship.type_id).\
             join(ins_type, ins_type.cvterm_id == Feature.type_id).\
@@ -653,8 +653,8 @@ class ConstructHandler(FeatureHandler):
                 rel_type.name == 'producedby',
                 Feature.uniquename.op('~')(self.regex['insertion']),
                 Feature.is_obsolete.is_(False),
-                ins_type.name.in_(self.feature_subtypes['insertion'])
-            ).distinct()
+                ins_type.name.in_(self.feature_subtypes['insertion'])).\
+            distinct()
         insertions_by_construct = {}
         for ins_uname, ins_fid, construct_fid in results:
             if construct_fid not in insertions_by_construct:
@@ -1065,4 +1065,11 @@ class ConstructHandler(FeatureHandler):
         self.flag_unexportable_entities(
             self.construct_cassette_associations, 'construct_cassette_association_ingest_set')
         self.generate_export_dict(self.construct_cassette_associations, 'construct_cassette_association_ingest_set')
+        # FTA-136: Create anonymous constructs for generic TI insertions.
+        insertions_by_construct = self.get_generic_ti_insertions(session)
+        self.attach_generic_ti_insertions(insertions_by_construct)
+        generic_ti_data = self.get_generic_ti_anon_construct_data()
+        if generic_ti_data:
+            self.map_generic_ti_anon_constructs(generic_ti_data)
+            self.export_generic_ti_anon_constructs()
         return

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -576,6 +576,20 @@ class ConstructHandler(FeatureHandler):
                       f'({excluded_counter} excluded as generic TI constructs).')
         return
 
+    def identify_generic_ti_constructs(self):
+        """Identify constructs marked as 'generic TI' style (FTA-136)."""
+        self.log.info('Identify generic TI constructs.')
+        counter = 0
+        for construct in self.fb_data_entities.values():
+            internal_notes = construct.props_by_type.get('internalnotes', [])
+            for note in internal_notes:
+                if note.chado_obj.value == 'FTA: generic TI construct':
+                    construct.is_generic_ti = True
+                    counter += 1
+                    break
+        self.log.info(f'Identified {counter} generic TI constructs.')
+        return
+
     def get_anon_cassette_data(self):
         """Return extracted data for anonymous cassette creation by CassetteHandler.
 
@@ -609,6 +623,162 @@ class ConstructHandler(FeatureHandler):
         self.log.info(f'Extracted anonymous cassette data for {len(anon_data)} constructs.')
         return anon_data
 
+    def get_generic_ti_insertions(self, session):
+        """Query insertions (FBti) for each generic TI construct via producedby relationship.
+
+        Returns a dict keyed by construct feature_id, each value is a list of
+        insertion dicts: {'uniquename': str, 'feature_id': int}.
+        """
+        self.log.info('Get insertions for generic TI constructs.')
+        generic_ti_ids = [
+            cid for cid, c in self.fb_data_entities.items()
+            if c.is_generic_ti
+        ]
+        if not generic_ti_ids:
+            self.log.info('No generic TI constructs found.')
+            return {}
+        rel_type = aliased(Cvterm, name='rel_type')
+        ins_type = aliased(Cvterm, name='ins_type')
+        results = session.query(
+            Feature.uniquename,
+            Feature.feature_id,
+            FeatureRelationship.object_id
+        ).select_from(FeatureRelationship).\
+            join(Feature, Feature.feature_id == FeatureRelationship.subject_id).\
+            join(rel_type, rel_type.cvterm_id == FeatureRelationship.type_id).\
+            join(ins_type, ins_type.cvterm_id == Feature.type_id).\
+            filter(
+                FeatureRelationship.object_id.in_(generic_ti_ids),
+                rel_type.name == 'producedby',
+                Feature.uniquename.op('~')(self.regex['insertion']),
+                Feature.is_obsolete.is_(False),
+                ins_type.name.in_(self.feature_subtypes['insertion'])
+            ).distinct()
+        insertions_by_construct = {}
+        for ins_uname, ins_fid, construct_fid in results:
+            if construct_fid not in insertions_by_construct:
+                insertions_by_construct[construct_fid] = []
+            insertions_by_construct[construct_fid].append({
+                'uniquename': ins_uname,
+                'feature_id': ins_fid,
+            })
+        total = sum(len(v) for v in insertions_by_construct.values())
+        self.log.info(
+            f'Found {total} insertions across '
+            f'{len(insertions_by_construct)} generic TI constructs.')
+        return insertions_by_construct
+
+    def attach_generic_ti_insertions(self, insertions_by_construct):
+        """Attach insertion data to generic TI construct entities.
+
+        Args:
+            insertions_by_construct: Dict from get_generic_ti_insertions().
+        """
+        for construct_fid, insertions in insertions_by_construct.items():
+            if construct_fid in self.fb_data_entities:
+                self.fb_data_entities[construct_fid].generic_ti_insertions = insertions
+
+    def get_generic_ti_anon_construct_data(self):
+        """Extract data for anonymous constructs from generic TI insertions.
+
+        For each insertion of a generic TI construct, returns data to create
+        an anonymous Construct and an anonymous Cassette. The anonymous
+        construct inherits the parent construct's direct tool relationships
+        and tool_uses data.
+
+        Returns a list of dicts:
+        {
+            'insertion_uniquename': str,
+            'construct_uniquename': str,  (parent)
+            'direct_rels': [...],
+            'tool_uses_data': [...],
+        }
+        """
+        self.log.info('Extract anonymous construct data for generic TI insertions.')
+        anon_data = []
+        for construct in self.fb_data_entities.values():
+            if not construct.is_generic_ti:
+                continue
+            if not hasattr(construct, 'generic_ti_insertions'):
+                continue
+            direct_rels = construct.recall_relationships(
+                self.log, entity_role='subject',
+                rel_types=['encodes_tool', 'has_reg_region',
+                           'tagged_with', 'carries_tool'])
+            rel_data = []
+            for rel in direct_rels:
+                rel_data.append({
+                    'rel_type': rel.chado_obj.type.name,
+                    'object_feature_id': rel.chado_obj.object_id,
+                    'pub_ids': list(rel.pubs),
+                })
+            for insertion in construct.generic_ti_insertions:
+                anon_data.append({
+                    'insertion_uniquename': insertion['uniquename'],
+                    'construct_uniquename': construct.uniquename,
+                    'direct_rels': rel_data,
+                    'tool_uses_data': construct.tool_uses_data,
+                })
+        self.log.info(
+            f'Extracted anonymous construct data for '
+            f'{len(anon_data)} generic TI insertions.')
+        return anon_data
+
+    @staticmethod
+    def generic_ti_data_for_cassette_handler(anon_data):
+        """Convert generic TI anon data to cassette handler format.
+
+        Uses the insertion uniquename as construct_uniquename so the
+        cassette handler creates IDs like FB:{FBti}_cas.
+        """
+        cassette_data = []
+        for entry in anon_data:
+            cassette_data.append({
+                'construct_uniquename': entry['insertion_uniquename'],
+                'direct_rels': entry['direct_rels'],
+                'tool_uses_data': entry['tool_uses_data'],
+            })
+        return cassette_data
+
+    def map_generic_ti_anon_constructs(self, anon_data):
+        """Create anonymous ConstructDTOs for generic TI insertions.
+
+        Args:
+            anon_data: List of dicts from get_generic_ti_anon_construct_data().
+
+        Returns:
+            List of FBExportEntity wrappers containing anonymous ConstructDTOs.
+        """
+        self.log.info('Map anonymous constructs for generic TI insertions.')
+        anon_constructs = []
+        for data in anon_data:
+            ins_uname = data['insertion_uniquename']
+            construct_id = f'FB:{ins_uname}_con'
+            agr_construct = agr_datatypes.ConstructDTO()
+            agr_construct.placeholder = True
+            agr_construct.obsolete = False
+            agr_construct.primary_external_id = construct_id
+            agr_construct.construct_symbol_dto = agr_datatypes.NameSlotAnnotationDTO(
+                'nomenclature_symbol', construct_id, construct_id, []
+            ).dict_export()
+            dp_xref = agr_datatypes.CrossReferenceDTO(
+                'FB', f'FB:{data["construct_uniquename"]}',
+                'construct', construct_id
+            ).dict_export()
+            agr_construct.data_provider_dto = agr_datatypes.DataProviderDTO(
+                dp_xref
+            ).dict_export()
+            fb_entity = fb_datatypes.FBExportEntity()
+            fb_entity.linkmldto = agr_construct
+            fb_entity.entity_desc = (
+                f'anon construct for {ins_uname} '
+                f'(from {data["construct_uniquename"]})')
+            anon_constructs.append(fb_entity)
+        self.log.info(
+            f'Created {len(anon_constructs)} anonymous ConstructDTOs '
+            f'for generic TI insertions.')
+        return anon_constructs
+
     # Elaborate on synthesize_info() for the ConstructHandler.
     def synthesize_info(self):
         """Extend the method for the ConstructHandler."""
@@ -629,6 +799,7 @@ class ConstructHandler(FeatureHandler):
             self.log.info('ADD_CASS_TO_CONSTRUCT=YES: skipping synthesize_component_genes and '
                           'synthesize_redundant_tool_genes (cassettes handle this data).')
         self.identify_constructs_needing_anon_cassettes()
+        self.identify_generic_ti_constructs()
         return
 
     # Add methods to be run by map_fb_data_to_alliance() below.
@@ -637,7 +808,7 @@ class ConstructHandler(FeatureHandler):
         self.log.info('Map basic construct info to Alliance object.')
         for construct in self.fb_data_entities.values():
             agr_construct = self.agr_export_type()
-            agr_construct.obsolete = construct.chado_obj.is_obsolete
+            agr_construct.obsolete = construct.chado_obj.is_obsolete or construct.is_generic_ti
             agr_construct.primary_external_id = f'FB:{construct.uniquename}'
             # agr_construct.mod_internal_id = f'FB.feature_id={construct.chado_obj.feature_id}'
             construct.linkmldto = agr_construct

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -781,10 +781,10 @@ class ConstructHandler(FeatureHandler):
         self.flag_internal_fb_entities('generic_ti_anon_constructs')
         self.flag_unexportable_entities(
             self.generic_ti_anon_constructs,
-            'generic_ti_anon_construct_ingest_set')
+            'construct_ingest_set')
         self.generate_export_dict(
             self.generic_ti_anon_constructs,
-            'generic_ti_anon_construct_ingest_set')
+            'construct_ingest_set')
 
     # Elaborate on synthesize_info() for the ConstructHandler.
     def synthesize_info(self):

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -474,8 +474,9 @@ class ConstructHandler(FeatureHandler):
                     construct.regulating_features[reg_region_id].extend(cons_reg_region_rel.pubs)
                 except KeyError:
                     construct.regulating_features[reg_region_id] = cons_reg_region_rel.pubs
-            self.log.debug(f'For {construct}, found {len(construct.regulating_features.keys())} '
-                           'encoded reg_regions via direct relationships.')
+            if self.testing:
+                self.log.debug(f'For {construct}, found {len(construct.regulating_features.keys())} '
+                                'encoded reg_regions via direct relationships.')
             # Direct relationships to regulatory_regions (old implementation).
             old_cons_reg_region_rels = construct.recall_relationships(
                 self.log, entity_role='object',

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -475,8 +475,9 @@ class ConstructHandler(FeatureHandler):
                 except KeyError:
                     construct.regulating_features[reg_region_id] = cons_reg_region_rel.pubs
             if self.testing:
-                self.log.debug(f'For {construct}, found {len(construct.regulating_features.keys())} '
-                                'encoded reg_regions via direct relationships.')
+                self.log.debug(f'For {construct}, '
+                               f'found {len(construct.regulating_features.keys())} '
+                               'encoded reg_regions via direct relationships.')
             # Direct relationships to regulatory_regions (old implementation).
             old_cons_reg_region_rels = construct.recall_relationships(
                 self.log, entity_role='object',

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -1332,18 +1332,24 @@ class ConstructHandler(FeatureHandler):
         self.flag_unexportable_entities(self.construct_associations, 'construct_genomic_entity_association_ingest_set')
         self.generate_export_dict(self.construct_associations, 'construct_genomic_entity_association_ingest_set')
         # FTA-136: Create anonymous constructs for generic TI insertions.
-        insertions_by_construct = self.get_generic_ti_insertions(session)
-        self.attach_generic_ti_insertions(insertions_by_construct)
-        # FTA-182 v3: load pubs on the producedby rel (FBti -> generic-TI FBtp).
-        self.get_generic_ti_producedby_pubs(session)
-        # FTA-182: load associated-allele tool data before building anon_data.
-        self.get_associated_allele_tool_data(session)
-        generic_ti_data = self.get_generic_ti_anon_construct_data()
-        if generic_ti_data:
-            self.map_generic_ti_anon_constructs(generic_ti_data)
-            # FTA-183: marker associations for anonymous TI constructs.
-            self.map_generic_ti_anon_marker_associations(generic_ti_data)
-            self.export_generic_ti_anon_constructs()
+        # Gated by ADD_CASS_TO_CONSTRUCT=YES (same gate as the rest of the
+        # cassette-related ConstructHandler work, e.g. lines 1041, 1312).
+        dump_cass_assoc = getenv('ADD_CASS_TO_CONSTRUCT', None)
+        if dump_cass_assoc == 'YES':
+            insertions_by_construct = self.get_generic_ti_insertions(session)
+            self.attach_generic_ti_insertions(insertions_by_construct)
+            # FTA-182 v3: load pubs on the producedby rel (FBti -> generic-TI FBtp).
+            self.get_generic_ti_producedby_pubs(session)
+            # FTA-182: load associated-allele tool data before building anon_data.
+            self.get_associated_allele_tool_data(session)
+            generic_ti_data = self.get_generic_ti_anon_construct_data()
+            if generic_ti_data:
+                self.map_generic_ti_anon_constructs(generic_ti_data)
+                # FTA-183: marker associations for anonymous TI constructs.
+                self.map_generic_ti_anon_marker_associations(generic_ti_data)
+                self.export_generic_ti_anon_constructs()
+        else:
+            self.log.info('ADD_CASS_TO_CONSTRUCT not set to "YES"; skipping generic-TI anon construct pipeline.')
         # Export cassette associations LAST so anon marker rels are included.
         self.flag_unexportable_entities(
             self.construct_cassette_associations, 'construct_cassette_association_ingest_set')

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -33,6 +33,11 @@ class ConstructHandler(FeatureHandler):
         self.primary_export_set = 'construct_ingest_set'
         self.generic_ti_anon_constructs = []  # FBExportEntity wrappers for anonymous constructs.
 
+    # FBals whose marked_with relationship maps to 'has_transcriptional_unit'
+    # instead of the default 'has_selectable_marker' (FTA-139, reused by FTA-183).
+    has_transcriptional_unit_list = ['FBal0345196', 'FBal0345198', 'FBal0407180',
+                                     'FBal0407181', 'FBal0407182', 'FBal0368073']
+
     test_set = {
         # FBtp corresponding to 'cassette FBal that are associated_with at least one FBtp' in cassette_handler.py
         'FBtp0006749': 'P{UAS-wg.flu}',                           # associated_with FBal0055793
@@ -693,6 +698,8 @@ class ConstructHandler(FeatureHandler):
             'construct_uniquename': str,  (parent)
             'direct_rels': [...],
             'tool_uses_data': [...],
+            'marker_alleles': [...],  (FTA-183: parent's marked_with FBals)
+            'parent_is_obsolete': bool,
         }
         """
         self.log.info('Extract anonymous construct data for generic TI insertions.')
@@ -713,12 +720,26 @@ class ConstructHandler(FeatureHandler):
                     'object_feature_id': rel.chado_obj.object_id,
                     'pub_ids': list(rel.pubs),
                 })
+            # FTA-183: collect marker alleles from parent's marked_with rels.
+            marked_with_rels = construct.recall_relationships(
+                self.log, entity_role='subject',
+                rel_types='marked_with', rel_entity_types='allele')
+            marker_data = []
+            for rel in marked_with_rels:
+                feature_id = rel.chado_obj.object_id
+                marker_data.append({
+                    'feature_id': feature_id,
+                    'uniquename': self.feature_lookup[feature_id]['uniquename'],
+                    'is_obsolete': self.feature_lookup[feature_id]['is_obsolete'],
+                })
             for insertion in construct.generic_ti_insertions:
                 anon_data.append({
                     'insertion_uniquename': insertion['uniquename'],
                     'construct_uniquename': construct.uniquename,
                     'direct_rels': rel_data,
                     'tool_uses_data': construct.tool_uses_data,
+                    'marker_alleles': marker_data,
+                    'parent_is_obsolete': construct.is_obsolete,
                 })
         self.log.info(
             f'Extracted anonymous construct data for '
@@ -910,8 +931,6 @@ class ConstructHandler(FeatureHandler):
         """Map construct cassette relations to ConstructCassetteAssociationDTO."""
         self.log.info('Map construct cassette associations.')
         counter = 0
-        has_transcriptional_unit_list = ['FBal0345196', 'FBal0345198', 'FBal0407180',
-                                         'FBal0407181', 'FBal0407182', 'FBal0368073']
         for construct in self.fb_data_entities.values():
             cons_curie = f'FB:{construct.uniquename}'
             # Handle marked_with relationships (FTA-139).
@@ -923,7 +942,7 @@ class ConstructHandler(FeatureHandler):
                 cassette_curie = f'FB:{cassette_uniquename}'
                 pub_curies = self.lookup_pub_curies(rel.pubs)
                 # has_transcriptional_unit_list are special cases per FTA-139.
-                if cassette_uniquename in has_transcriptional_unit_list:
+                if cassette_uniquename in self.has_transcriptional_unit_list:
                     relation_name = 'has_transcriptional_unit'
                 else:
                     relation_name = 'has_selectable_marker'
@@ -1026,6 +1045,32 @@ class ConstructHandler(FeatureHandler):
         self.log.info(f'Created {counter} ConstructCassetteAssociationDTOs for anonymous cassettes.')
         return
 
+    def map_generic_ti_anon_marker_associations(self, anon_data):
+        """Emit marked_with cassette associations for anonymous TI constructs (FTA-183)."""
+        self.log.info('Map marker associations for anonymous generic TI constructs.')
+        counter = 0
+        for data in anon_data:
+            if not data['marker_alleles']:
+                continue
+            cons_curie = f'FB:{data["insertion_uniquename"]}_con'
+            for marker in data['marker_alleles']:
+                cassette_curie = f'FB:{marker["uniquename"]}'
+                if marker['uniquename'] in self.has_transcriptional_unit_list:
+                    relation_name = 'has_transcriptional_unit'
+                else:
+                    relation_name = 'has_selectable_marker'
+                fb_rel = fb_datatypes.FBExportEntity()
+                rel_dto = agr_datatypes.ConstructCassetteAssociationDTO(
+                    cons_curie, relation_name, cassette_curie, [])
+                if data['parent_is_obsolete'] or marker['is_obsolete']:
+                    rel_dto.obsolete = True
+                    rel_dto.internal = True
+                fb_rel.linkmldto = rel_dto
+                self.construct_cassette_associations.append(fb_rel)
+                counter += 1
+        self.log.info(f'Created {counter} anon TI marker ConstructCassetteAssociationDTOs.')
+        return
+
     # Elaborate on map_fb_data_to_alliance() for the ConstructHandler.
     def map_fb_data_to_alliance(self):
         """Extend the method for the ConstructHandler."""
@@ -1062,14 +1107,17 @@ class ConstructHandler(FeatureHandler):
         super().query_chado_and_export(session)
         self.flag_unexportable_entities(self.construct_associations, 'construct_genomic_entity_association_ingest_set')
         self.generate_export_dict(self.construct_associations, 'construct_genomic_entity_association_ingest_set')
-        self.flag_unexportable_entities(
-            self.construct_cassette_associations, 'construct_cassette_association_ingest_set')
-        self.generate_export_dict(self.construct_cassette_associations, 'construct_cassette_association_ingest_set')
         # FTA-136: Create anonymous constructs for generic TI insertions.
         insertions_by_construct = self.get_generic_ti_insertions(session)
         self.attach_generic_ti_insertions(insertions_by_construct)
         generic_ti_data = self.get_generic_ti_anon_construct_data()
         if generic_ti_data:
             self.map_generic_ti_anon_constructs(generic_ti_data)
+            # FTA-183: marker associations for anonymous TI constructs.
+            self.map_generic_ti_anon_marker_associations(generic_ti_data)
             self.export_generic_ti_anon_constructs()
+        # Export cassette associations LAST so anon marker rels are included.
+        self.flag_unexportable_entities(
+            self.construct_cassette_associations, 'construct_cassette_association_ingest_set')
+        self.generate_export_dict(self.construct_cassette_associations, 'construct_cassette_association_ingest_set')
         return

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -797,9 +797,7 @@ class ConstructHandler(FeatureHandler):
                 FeatureRelationshipPub.feature_relationship_id,
                 FeatureRelationshipPub.pub_id).\
                 select_from(FeatureRelationshipPub).\
-                join(FeatureRelationship,
-                     FeatureRelationship.feature_relationship_id
-                     == FeatureRelationshipPub.feature_relationship_id).\
+                join(FeatureRelationship, FeatureRelationship.feature_relationship_id == FeatureRelationshipPub.feature_relationship_id).\
                 join(pub_type, pub_type.cvterm_id == FeatureRelationship.type_id).\
                 filter(
                     FeatureRelationship.subject_id.in_(fbal_ids_list),
@@ -818,9 +816,7 @@ class ConstructHandler(FeatureHandler):
         prop_type = aliased(Cvterm, name='prop_type')
         tu_results = session.query(FeatureCvterm, FeatureCvtermprop).\
             select_from(FeatureCvterm).\
-            join(FeatureCvtermprop,
-                 FeatureCvtermprop.feature_cvterm_id
-                 == FeatureCvterm.feature_cvterm_id).\
+            join(FeatureCvtermprop, FeatureCvtermprop.feature_cvterm_id == FeatureCvterm.feature_cvterm_id).\
             join(prop_type, prop_type.cvterm_id == FeatureCvtermprop.type_id).\
             filter(
                 FeatureCvterm.feature_id.in_(fbal_ids_list),

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -798,8 +798,8 @@ class ConstructHandler(FeatureHandler):
                 FeatureRelationshipPub.pub_id).\
                 select_from(FeatureRelationshipPub).\
                 join(FeatureRelationship,
-                     FeatureRelationship.feature_relationship_id ==
-                     FeatureRelationshipPub.feature_relationship_id).\
+                     FeatureRelationship.feature_relationship_id
+                     == FeatureRelationshipPub.feature_relationship_id).\
                 join(pub_type, pub_type.cvterm_id == FeatureRelationship.type_id).\
                 filter(
                     FeatureRelationship.subject_id.in_(fbal_ids_list),
@@ -819,8 +819,8 @@ class ConstructHandler(FeatureHandler):
         tu_results = session.query(FeatureCvterm, FeatureCvtermprop).\
             select_from(FeatureCvterm).\
             join(FeatureCvtermprop,
-                 FeatureCvtermprop.feature_cvterm_id ==
-                 FeatureCvterm.feature_cvterm_id).\
+                 FeatureCvtermprop.feature_cvterm_id
+                 == FeatureCvterm.feature_cvterm_id).\
             join(prop_type, prop_type.cvterm_id == FeatureCvtermprop.type_id).\
             filter(
                 FeatureCvterm.feature_id.in_(fbal_ids_list),

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -32,6 +32,12 @@ class ConstructHandler(FeatureHandler):
         self.agr_export_type = agr_datatypes.ConstructDTO
         self.primary_export_set = 'construct_ingest_set'
         self.generic_ti_anon_constructs = []  # FBExportEntity wrappers for anonymous constructs.
+        # FTA-182: caches for associated-allele tool data on generic TI insertions.
+        self.ti_associated_alleles = {}       # {ti_fid: [fbal_fid, ...]}
+        self.fbal_block_propagation = set()   # fbal_fids with 'propagate_transgenic_uses' featureprop
+        self.fbal_ti_represented = set()      # (fbal_fid, ti_fid) pairs for 'is_represented_at_alliance_as'
+        self.fbal_tool_rels = {}              # {fbal_fid: [{rel_type, object_feature_id, pub_ids}, ...]}
+        self.fbal_tool_uses = {}              # {fbal_fid: [{cvterm_name, accession, pub_id}, ...]}
 
     # FBals whose marked_with relationship maps to 'has_transcriptional_unit'
     # instead of the default 'has_selectable_marker' (FTA-139, reused by FTA-183).
@@ -118,8 +124,8 @@ class ConstructHandler(FeatureHandler):
         'FBtp0017513': 'P{PTT-GB}',
         # test example for change to map_construct_cassette_associations when pub > 1
         'FBtp0040555': 'P{NIG.4696R}',  # associated_with FBal0220378, not appearing in file pre-change
-
-
+        # test example for anon cons with has_selectsable_marker
+        'FBtp0143312': 'TI{GMR-HMS04515}',
 
     }
 
@@ -625,6 +631,8 @@ class ConstructHandler(FeatureHandler):
                 'construct_uniquename': construct.uniquename,
                 'direct_rels': rel_data,
                 'tool_uses_data': construct.tool_uses_data,
+                # FTA-182: mark this as the non-generic-TI FTA-181 path.
+                'is_generic_ti': False,
             })
         self.log.info(f'Extracted anonymous cassette data for {len(anon_data)} constructs.')
         return anon_data
@@ -684,6 +692,152 @@ class ConstructHandler(FeatureHandler):
             if construct_fid in self.fb_data_entities:
                 self.fb_data_entities[construct_fid].generic_ti_insertions = insertions
 
+    def get_associated_allele_tool_data(self, session):
+        """Load allele-side data needed for FTA-182 anon cassette tool gating.
+
+        Populates five instance caches keyed by fbal_feature_id (or (fbal_fid,
+        ti_fid) pairs) covering: associated_with FBals per FBti, the
+        propagate_transgenic_uses featureprop existence flag, the
+        is_represented_at_alliance_as relationship pairs, and the 4
+        tool-related FeatureRelationships + tool_uses FeatureCvtermprops for
+        each associated FBal.
+        """
+        self.log.info('Get associated-allele tool data for generic TI insertions.')
+        ti_feature_ids = []
+        for construct in self.fb_data_entities.values():
+            if not construct.is_generic_ti:
+                continue
+            if not hasattr(construct, 'generic_ti_insertions'):
+                continue
+            for insertion in construct.generic_ti_insertions:
+                ti_feature_ids.append(insertion['feature_id'])
+        if not ti_feature_ids:
+            self.log.info('No generic TI insertions; skipping associated-allele loads.')
+            return
+        # Query 1: associated_with FBals per FBti.
+        rel_type = aliased(Cvterm, name='rel_type')
+        allele_type = aliased(Cvterm, name='allele_type')
+        results = session.query(
+            FeatureRelationship.object_id,
+            Feature.feature_id).\
+            select_from(FeatureRelationship).\
+            join(Feature, Feature.feature_id == FeatureRelationship.subject_id).\
+            join(rel_type, rel_type.cvterm_id == FeatureRelationship.type_id).\
+            join(allele_type, allele_type.cvterm_id == Feature.type_id).\
+            filter(
+                FeatureRelationship.object_id.in_(ti_feature_ids),
+                rel_type.name == 'associated_with',
+                Feature.uniquename.op('~')(self.regex['allele']),
+                Feature.is_obsolete.is_(False),
+                allele_type.name.in_(self.feature_subtypes['allele'])).\
+            distinct()
+        fbal_ids = set()
+        for ti_fid, fbal_fid in results:
+            self.ti_associated_alleles.setdefault(ti_fid, []).append(fbal_fid)
+            fbal_ids.add(fbal_fid)
+        self.log.info(
+            f'Found {len(fbal_ids)} associated FBals across '
+            f'{len(self.ti_associated_alleles)} FBtis.')
+        if not fbal_ids:
+            return
+        fbal_ids_list = list(fbal_ids)
+        # Query 2: propagate_transgenic_uses featureprop existence per FBal.
+        fp_type = aliased(Cvterm, name='fp_type')
+        block_results = session.query(Featureprop.feature_id).\
+            join(fp_type, fp_type.cvterm_id == Featureprop.type_id).\
+            filter(
+                Featureprop.feature_id.in_(fbal_ids_list),
+                fp_type.name == 'propagate_transgenic_uses').\
+            distinct()
+        for (fbal_fid,) in block_results:
+            self.fbal_block_propagation.add(fbal_fid)
+        self.log.info(
+            f'Found {len(self.fbal_block_propagation)} FBals with '
+            f"'propagate_transgenic_uses' featureprop (block flag).")
+        # Query 3: is_represented_at_alliance_as pairs (FBal subject -> FBti object).
+        ir_type = aliased(Cvterm, name='ir_type')
+        ir_results = session.query(
+            FeatureRelationship.subject_id,
+            FeatureRelationship.object_id).\
+            join(ir_type, ir_type.cvterm_id == FeatureRelationship.type_id).\
+            filter(
+                FeatureRelationship.subject_id.in_(fbal_ids_list),
+                FeatureRelationship.object_id.in_(ti_feature_ids),
+                ir_type.name == 'is_represented_at_alliance_as').\
+            distinct()
+        for fbal_fid, ti_fid in ir_results:
+            self.fbal_ti_represented.add((fbal_fid, ti_fid))
+        self.log.info(
+            f"Found {len(self.fbal_ti_represented)} 'is_represented_at_alliance_as' pairs.")
+        # Query 4: tool-related FeatureRelationships for each FBal (subject).
+        tool_rel_names = ['encodes_tool', 'has_reg_region', 'tagged_with', 'carries_tool']
+        tr_type = aliased(Cvterm, name='tr_type')
+        tr_results = session.query(
+            FeatureRelationship.feature_relationship_id,
+            FeatureRelationship.subject_id,
+            FeatureRelationship.object_id,
+            tr_type.name).\
+            join(tr_type, tr_type.cvterm_id == FeatureRelationship.type_id).\
+            filter(
+                FeatureRelationship.subject_id.in_(fbal_ids_list),
+                tr_type.name.in_(tool_rel_names)).\
+            distinct()
+        rel_by_id = {}
+        for fr_id, fbal_fid, obj_fid, rel_name in tr_results:
+            rel_by_id[fr_id] = {
+                'fbal_fid': fbal_fid,
+                'rel_type': rel_name,
+                'object_feature_id': obj_fid,
+                'pub_ids': [],
+            }
+        # Query 4b: pubs for those tool rels.
+        if rel_by_id:
+            pub_type = aliased(Cvterm, name='pub_type')
+            pub_results = session.query(
+                FeatureRelationshipPub.feature_relationship_id,
+                FeatureRelationshipPub.pub_id).\
+                select_from(FeatureRelationshipPub).\
+                join(FeatureRelationship,
+                     FeatureRelationship.feature_relationship_id ==
+                     FeatureRelationshipPub.feature_relationship_id).\
+                join(pub_type, pub_type.cvterm_id == FeatureRelationship.type_id).\
+                filter(
+                    FeatureRelationship.subject_id.in_(fbal_ids_list),
+                    pub_type.name.in_(tool_rel_names)).\
+                distinct()
+            for fr_id, pub_id in pub_results:
+                if fr_id in rel_by_id:
+                    rel_by_id[fr_id]['pub_ids'].append(pub_id)
+        for entry in rel_by_id.values():
+            fbal_fid = entry.pop('fbal_fid')
+            self.fbal_tool_rels.setdefault(fbal_fid, []).append(entry)
+        self.log.info(
+            f'Found {len(rel_by_id)} tool-related feature_relationships '
+            f'for {len(self.fbal_tool_rels)} FBals.')
+        # Query 5: tool_uses FeatureCvtermprops per FBal.
+        prop_type = aliased(Cvterm, name='prop_type')
+        tu_results = session.query(FeatureCvterm, FeatureCvtermprop).\
+            select_from(FeatureCvterm).\
+            join(FeatureCvtermprop,
+                 FeatureCvtermprop.feature_cvterm_id ==
+                 FeatureCvterm.feature_cvterm_id).\
+            join(prop_type, prop_type.cvterm_id == FeatureCvtermprop.type_id).\
+            filter(
+                FeatureCvterm.feature_id.in_(fbal_ids_list),
+                prop_type.name == 'tool_uses').\
+            distinct()
+        tu_counter = 0
+        for fc, _fcp in tu_results:
+            self.fbal_tool_uses.setdefault(fc.feature_id, []).append({
+                'cvterm_name': fc.cvterm.name,
+                'accession': fc.cvterm.dbxref.accession,
+                'pub_id': fc.pub_id,
+            })
+            tu_counter += 1
+        self.log.info(
+            f'Found {tu_counter} tool_uses annotations for '
+            f'{len(self.fbal_tool_uses)} FBals.')
+
     def get_generic_ti_anon_construct_data(self):
         """Extract data for anonymous constructs from generic TI insertions.
 
@@ -700,6 +854,10 @@ class ConstructHandler(FeatureHandler):
             'tool_uses_data': [...],
             'marker_alleles': [...],  (FTA-183: parent's marked_with FBals)
             'parent_is_obsolete': bool,
+            # FTA-182 fields:
+            'is_generic_ti': True,
+            'associated_alleles': [...],
+            'propagate_transgenic_uses': bool,
         }
         """
         self.log.info('Extract anonymous construct data for generic TI insertions.')
@@ -733,6 +891,23 @@ class ConstructHandler(FeatureHandler):
                     'is_obsolete': self.feature_lookup[feature_id]['is_obsolete'],
                 })
             for insertion in construct.generic_ti_insertions:
+                ti_fid = insertion['feature_id']
+                associated_fbal_ids = self.ti_associated_alleles.get(ti_fid, [])
+                associated_data = []
+                block = False
+                for fbal_fid in associated_fbal_ids:
+                    if fbal_fid in self.fbal_block_propagation:
+                        block = True
+                    associated_data.append({
+                        'feature_id': fbal_fid,
+                        'uniquename': self.feature_lookup[fbal_fid]['uniquename'],
+                        'blocks_propagation': fbal_fid in self.fbal_block_propagation,
+                        'is_represented_at_alliance_as':
+                            (fbal_fid, ti_fid) in self.fbal_ti_represented,
+                        'direct_rels': self.fbal_tool_rels.get(fbal_fid, []),
+                        'tool_uses_data': self.fbal_tool_uses.get(fbal_fid, []),
+                    })
+                propagate = not block
                 anon_data.append({
                     'insertion_uniquename': insertion['uniquename'],
                     'construct_uniquename': construct.uniquename,
@@ -740,6 +915,10 @@ class ConstructHandler(FeatureHandler):
                     'tool_uses_data': construct.tool_uses_data,
                     'marker_alleles': marker_data,
                     'parent_is_obsolete': construct.is_obsolete,
+                    # FTA-182:
+                    'is_generic_ti': True,
+                    'associated_alleles': associated_data,
+                    'propagate_transgenic_uses': propagate,
                 })
         self.log.info(
             f'Extracted anonymous construct data for '
@@ -751,7 +930,9 @@ class ConstructHandler(FeatureHandler):
         """Convert generic TI anon data to cassette handler format.
 
         Uses the insertion uniquename as construct_uniquename so the
-        cassette handler creates IDs like FB:{FBti}_cas.
+        cassette handler creates IDs like FB:{FBti}_cas. Forwards FTA-182
+        fields (is_generic_ti flag, associated_alleles, propagate flag) so
+        the cassette handler can apply the gated tool-data logic.
         """
         cassette_data = []
         for entry in anon_data:
@@ -759,6 +940,10 @@ class ConstructHandler(FeatureHandler):
                 'construct_uniquename': entry['insertion_uniquename'],
                 'direct_rels': entry['direct_rels'],
                 'tool_uses_data': entry['tool_uses_data'],
+                'is_generic_ti': entry.get('is_generic_ti', True),
+                'associated_alleles': entry.get('associated_alleles', []),
+                'propagate_transgenic_uses':
+                    entry.get('propagate_transgenic_uses', True),
             })
         return cassette_data
 
@@ -1110,6 +1295,8 @@ class ConstructHandler(FeatureHandler):
         # FTA-136: Create anonymous constructs for generic TI insertions.
         insertions_by_construct = self.get_generic_ti_insertions(session)
         self.attach_generic_ti_insertions(insertions_by_construct)
+        # FTA-182: load associated-allele tool data before building anon_data.
+        self.get_associated_allele_tool_data(session)
         generic_ti_data = self.get_generic_ti_anon_construct_data()
         if generic_ti_data:
             self.map_generic_ti_anon_constructs(generic_ti_data)

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -31,6 +31,7 @@ class ConstructHandler(FeatureHandler):
         self.fb_export_type = fb_datatypes.FBConstruct
         self.agr_export_type = agr_datatypes.ConstructDTO
         self.primary_export_set = 'construct_ingest_set'
+        self.generic_ti_anon_constructs = []  # FBExportEntity wrappers for anonymous constructs.
 
     test_set = {
         # FBtp corresponding to 'cassette FBal that are associated_with at least one FBtp' in cassette_handler.py
@@ -745,12 +746,8 @@ class ConstructHandler(FeatureHandler):
 
         Args:
             anon_data: List of dicts from get_generic_ti_anon_construct_data().
-
-        Returns:
-            List of FBExportEntity wrappers containing anonymous ConstructDTOs.
         """
         self.log.info('Map anonymous constructs for generic TI insertions.')
-        anon_constructs = []
         for data in anon_data:
             ins_uname = data['insertion_uniquename']
             construct_id = f'FB:{ins_uname}_con'
@@ -773,11 +770,21 @@ class ConstructHandler(FeatureHandler):
             fb_entity.entity_desc = (
                 f'anon construct for {ins_uname} '
                 f'(from {data["construct_uniquename"]})')
-            anon_constructs.append(fb_entity)
+            self.generic_ti_anon_constructs.append(fb_entity)
         self.log.info(
-            f'Created {len(anon_constructs)} anonymous ConstructDTOs '
-            f'for generic TI insertions.')
-        return anon_constructs
+            f'Created {len(self.generic_ti_anon_constructs)} anonymous '
+            f'ConstructDTOs for generic TI insertions.')
+
+    def export_generic_ti_anon_constructs(self):
+        """Export anonymous constructs through the standard pipeline."""
+        self.log.info('Export anonymous constructs for generic TI insertions.')
+        self.flag_internal_fb_entities('generic_ti_anon_constructs')
+        self.flag_unexportable_entities(
+            self.generic_ti_anon_constructs,
+            'generic_ti_anon_construct_ingest_set')
+        self.generate_export_dict(
+            self.generic_ti_anon_constructs,
+            'generic_ti_anon_construct_ingest_set')
 
     # Elaborate on synthesize_info() for the ConstructHandler.
     def synthesize_info(self):

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -1295,6 +1295,24 @@ class ConstructHandler(FeatureHandler):
         self.log.info(f'Created {counter} anon TI marker ConstructCassetteAssociationDTOs.')
         return
 
+    def map_generic_ti_anon_construct_cassette_associations(self, anon_data):
+        """Emit <FBti>_con -> <FBti>_cas has_component associations (FTA-181)."""
+        self.log.info('Map anon construct -> anon cassette has_component associations.')
+        counter = 0
+        for data in anon_data:
+            ins_uname = data['insertion_uniquename']
+            cons_curie = f'FB:{ins_uname}_con'
+            cassette_curie = f'FB:{ins_uname}_cas'
+            pub_curies = self.lookup_pub_curies(data.get('producedby_pub_ids', []))
+            fb_rel = fb_datatypes.FBExportEntity()
+            rel_dto = agr_datatypes.ConstructCassetteAssociationDTO(
+                cons_curie, 'has_component', cassette_curie, pub_curies)
+            fb_rel.linkmldto = rel_dto
+            self.construct_cassette_associations.append(fb_rel)
+            counter += 1
+        self.log.info(f'Created {counter} anon construct->cassette ConstructCassetteAssociationDTOs.')
+        return
+
     # Elaborate on map_fb_data_to_alliance() for the ConstructHandler.
     def map_fb_data_to_alliance(self):
         """Extend the method for the ConstructHandler."""
@@ -1347,6 +1365,8 @@ class ConstructHandler(FeatureHandler):
                 self.map_generic_ti_anon_constructs(generic_ti_data)
                 # FTA-183: marker associations for anonymous TI constructs.
                 self.map_generic_ti_anon_marker_associations(generic_ti_data)
+                # FTA-181: con -> cas has_component associations.
+                self.map_generic_ti_anon_construct_cassette_associations(generic_ti_data)
                 self.export_generic_ti_anon_constructs()
         else:
             self.log.info('ADD_CASS_TO_CONSTRUCT not set to "YES"; skipping generic-TI anon construct pipeline.')

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -910,7 +910,9 @@ class ConstructHandler(FeatureHandler):
                     'direct_rels': rel_data,
                     'tool_uses_data': construct.tool_uses_data,
                     'marker_alleles': marker_data,
-                    'parent_is_obsolete': construct.is_obsolete,
+                    # FTA-179: flag anon marker associations as obsolete+internal
+                    # when the parent FBtp is generic-TI (effectively obsolete).
+                    'parent_is_obsolete': construct.is_obsolete or construct.is_generic_ti,
                     # FTA-182:
                     'is_generic_ti': True,
                     'associated_alleles': associated_data,
@@ -1099,7 +1101,8 @@ class ConstructHandler(FeatureHandler):
                     fb_rel = fb_datatypes.FBExportEntity()
                     rel_dto = agr_datatypes.ConstructGenomicEntityAssociationDTO(
                         cons_curie, rel_type, obj_curie, pub_curies)
-                    if construct.is_obsolete is True or self.feature_lookup[feature_id]['is_obsolete'] is True:
+                    # FTA-179: treat generic-TI FBtps as effectively obsolete.
+                    if construct.is_obsolete is True or construct.is_generic_ti or self.feature_lookup[feature_id]['is_obsolete'] is True:
                         rel_dto.obsolete = True
                         rel_dto.internal = True
                     fb_rel.linkmldto = rel_dto
@@ -1130,7 +1133,8 @@ class ConstructHandler(FeatureHandler):
                 fb_rel = fb_datatypes.FBExportEntity()
                 rel_dto = agr_datatypes.ConstructCassetteAssociationDTO(
                     cons_curie, relation_name, cassette_curie, pub_curies)
-                if construct.is_obsolete is True or self.feature_lookup[cassette_feature_id]['is_obsolete'] is True:
+                # FTA-179: treat generic-TI FBtps as effectively obsolete.
+                if construct.is_obsolete is True or construct.is_generic_ti or self.feature_lookup[cassette_feature_id]['is_obsolete'] is True:
                     rel_dto.obsolete = True
                     rel_dto.internal = True
                 fb_rel.linkmldto = rel_dto
@@ -1170,7 +1174,8 @@ class ConstructHandler(FeatureHandler):
                 rel_dto = agr_datatypes.ConstructCassetteAssociationDTO(
                     cons_curie, 'has_transcriptional_unit', cassette_curie, pub_curies)
                 rel_dto.note_dtos = note_dtos
-                if construct.is_obsolete is True or self.feature_lookup[allele_id]['is_obsolete'] is True:
+                # FTA-179: treat generic-TI FBtps as effectively obsolete.
+                if construct.is_obsolete is True or construct.is_generic_ti or self.feature_lookup[allele_id]['is_obsolete'] is True:
                     rel_dto.obsolete = True
                     rel_dto.internal = True
                 fb_rel.linkmldto = rel_dto

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -38,6 +38,8 @@ class ConstructHandler(FeatureHandler):
         self.fbal_ti_represented = set()      # (fbal_fid, ti_fid) pairs for 'is_represented_at_alliance_as'
         self.fbal_tool_rels = {}              # {fbal_fid: [{rel_type, object_feature_id, pub_ids}, ...]}
         self.fbal_tool_uses = {}              # {fbal_fid: [{cvterm_name, accession, pub_id}, ...]}
+        # FTA-182 v3: pubs on the producedby rel (FBti subject -> generic-TI FBtp object).
+        self.ti_producedby_pubs = {}          # {ti_fid: [pub_id, ...]}
 
     # FBals whose marked_with relationship maps to 'has_transcriptional_unit'
     # instead of the default 'has_selectable_marker' (FTA-139, reused by FTA-183).
@@ -660,7 +662,8 @@ class ConstructHandler(FeatureHandler):
         results = session.query(
             Feature.uniquename,
             Feature.feature_id,
-            FeatureRelationship.object_id).\
+            FeatureRelationship.object_id,
+            FeatureRelationship.feature_relationship_id).\
             select_from(FeatureRelationship).\
             join(Feature, Feature.feature_id == FeatureRelationship.subject_id).\
             join(rel_type, rel_type.cvterm_id == FeatureRelationship.type_id).\
@@ -673,12 +676,13 @@ class ConstructHandler(FeatureHandler):
                 ins_type.name.in_(self.feature_subtypes['insertion'])).\
             distinct()
         insertions_by_construct = {}
-        for ins_uname, ins_fid, construct_fid in results:
+        for ins_uname, ins_fid, construct_fid, fr_id in results:
             if construct_fid not in insertions_by_construct:
                 insertions_by_construct[construct_fid] = []
             insertions_by_construct[construct_fid].append({
                 'uniquename': ins_uname,
                 'feature_id': ins_fid,
+                'producedby_fr_id': fr_id,
             })
         total = sum(len(v) for v in insertions_by_construct.values())
         self.log.info(
@@ -695,6 +699,32 @@ class ConstructHandler(FeatureHandler):
         for construct_fid, insertions in insertions_by_construct.items():
             if construct_fid in self.fb_data_entities:
                 self.fb_data_entities[construct_fid].generic_ti_insertions = insertions
+
+    def get_generic_ti_producedby_pubs(self, session):
+        """Load pubs on the producedby feature_relationship (FBti -> generic-TI FBtp) (FTA-182 v3)."""
+        self.log.info('Get producedby-rel pubs for generic TI insertions.')
+        fr_ids = []
+        ti_by_fr = {}
+        for construct in self.fb_data_entities.values():
+            if not construct.is_generic_ti:
+                continue
+            for ins in getattr(construct, 'generic_ti_insertions', []):
+                fr_ids.append(ins['producedby_fr_id'])
+                ti_by_fr[ins['producedby_fr_id']] = ins['feature_id']
+        if not fr_ids:
+            self.log.info('No generic TI insertions; skipping producedby-pub load.')
+            return
+        results = session.query(
+            FeatureRelationshipPub.feature_relationship_id,
+            FeatureRelationshipPub.pub_id).\
+            filter(FeatureRelationshipPub.feature_relationship_id.in_(fr_ids)).\
+            distinct()
+        total = 0
+        for fr_id, pub_id in results:
+            ti_fid = ti_by_fr[fr_id]
+            self.ti_producedby_pubs.setdefault(ti_fid, []).append(pub_id)
+            total += 1
+        self.log.info(f'Found {total} producedby pubs across {len(self.ti_producedby_pubs)} FBtis.')
 
     def get_associated_allele_tool_data(self, session):
         """Load allele-side data needed for FTA-182 anon cassette tool gating.
@@ -921,6 +951,8 @@ class ConstructHandler(FeatureHandler):
                     'is_generic_ti': True,
                     'associated_alleles': associated_data,
                     'propagate_transgenic_uses': propagate,
+                    # FTA-182 v3: pubs for producedby rel (used when emitting parent-sourced tool data).
+                    'producedby_pub_ids': list(self.ti_producedby_pubs.get(ti_fid, [])),
                 })
         self.log.info(
             f'Extracted anonymous construct data for '
@@ -946,6 +978,8 @@ class ConstructHandler(FeatureHandler):
                 'associated_alleles': entry.get('associated_alleles', []),
                 'propagate_transgenic_uses':
                     entry.get('propagate_transgenic_uses', True),
+                # FTA-182 v3:
+                'producedby_pub_ids': list(entry.get('producedby_pub_ids', [])),
             })
         return cassette_data
 
@@ -1300,6 +1334,8 @@ class ConstructHandler(FeatureHandler):
         # FTA-136: Create anonymous constructs for generic TI insertions.
         insertions_by_construct = self.get_generic_ti_insertions(session)
         self.attach_generic_ti_insertions(insertions_by_construct)
+        # FTA-182 v3: load pubs on the producedby rel (FBti -> generic-TI FBtp).
+        self.get_generic_ti_producedby_pubs(session)
         # FTA-182: load associated-allele tool data before building anon_data.
         self.get_associated_allele_tool_data(session)
         generic_ti_data = self.get_generic_ti_anon_construct_data()

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -373,7 +373,8 @@ class ConstructHandler(FeatureHandler):
         self.log.info('Synthesize encoded components.')
         counter = 0
         for construct in self.fb_data_entities.values():
-            self.log.debug(f'Assess encoded tools for {construct}.')
+            if self.testing:
+                self.log.debug(f'Assess encoded tools for {construct}.')
             # Reference of related alleles.
             cons_al_rels = construct.recall_relationships(
                 self.log, entity_role='object', rel_types='associated_with',
@@ -389,8 +390,9 @@ class ConstructHandler(FeatureHandler):
                     construct.expressed_features[component_id].extend(cons_tool_rel.pubs)
                 except KeyError:
                     construct.expressed_features[component_id] = cons_tool_rel.pubs
-            self.log.debug(f'For {construct}, found {len(construct.expressed_features.keys())} '
-                           'encoded tools via direct relationships.')
+            if self.testing:
+                self.log.debug(f'For {construct}, found {len(construct.expressed_features.keys())} '
+                               'encoded tools via direct relationships.')
             # Indirect encodes_tool relationships.
             # self.log.debug(f'{construct} has {len(construct.al_encodes_tool_rels)} '
             #                'indirect tool relationships via alleles.')

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -1018,15 +1018,28 @@ class ConstructHandler(FeatureHandler):
             f'ConstructDTOs for generic TI insertions.')
 
     def export_generic_ti_anon_constructs(self):
-        """Export anonymous constructs through the standard pipeline."""
+        """Export anonymous constructs through the standard pipeline.
+
+        generate_export_dict resets the target list, so we save the
+        regular-FBtp entries (already exported by super().query_chado_and_export)
+        and concatenate them back after the anon export run. Without this,
+        the anon export would clobber the ~173k regular constructs and leave
+        construct_ingest_set with only the ~5k anon entries.
+        """
         self.log.info('Export anonymous constructs for generic TI insertions.')
         self.flag_internal_fb_entities('generic_ti_anon_constructs')
         self.flag_unexportable_entities(
             self.generic_ti_anon_constructs,
             'construct_ingest_set')
+        existing = list(self.export_data.get('construct_ingest_set', []))
         self.generate_export_dict(
             self.generic_ti_anon_constructs,
             'construct_ingest_set')
+        anon_entries = self.export_data['construct_ingest_set']
+        self.export_data['construct_ingest_set'] = existing + anon_entries
+        self.log.info(
+            f'construct_ingest_set: {len(existing):,} regular + '
+            f'{len(anon_entries):,} anon = {len(existing) + len(anon_entries):,} total.')
 
     # Elaborate on synthesize_info() for the ConstructHandler.
     def synthesize_info(self):

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -356,6 +356,7 @@ class FBConstruct(FBFeature):
         self.regulating_tool_genes = []   # Will be list of feature_ids for genes for which related tools are also associated in construct.targeted_features.
         # Anonymous cassette data.
         self.needs_anon_cassette = False
+        self.is_generic_ti = False  # Flag for 'generic TI' style constructs (FTA-136).
         self.tool_uses_data = []    # Will be list of dicts: {'cvterm_name', 'accession', 'pub_id'}
         self.anon_cassette_dto = None    # Will hold the CassetteDTO for the anonymous cassette.
 

--- a/src/gene_group_handler.py
+++ b/src/gene_group_handler.py
@@ -57,6 +57,9 @@ class GeneGroupHandler(PrimaryEntityHandler):
         'HGNC-GG1': 'HGNC_Group',
         'WB-GG': 'WBGeneClass',
         'ComplexPortal': 'ComplexPortal',
+        'CAZy': 'cazy',
+        'MEROPS_fam': 'merops.family',
+        'TCDB': 'tcdb',
     }
     gene_group_page_area = {
         'HGNC_Group': 'gene_group',

--- a/src/gene_group_handler.py
+++ b/src/gene_group_handler.py
@@ -65,6 +65,9 @@ class GeneGroupHandler(PrimaryEntityHandler):
         'HGNC_Group': 'gene_group',
         'WBGeneClass': 'gene_class',
         'ComplexPortal': 'default',
+        'CAZy': 'default',
+        'MEROPS_fam': 'default',
+        'TCDB': 'default',
     }
 
     # Elaborate on get_general_data() for the GeneGroupHandler.

--- a/src/gene_group_handler.py
+++ b/src/gene_group_handler.py
@@ -240,19 +240,6 @@ class GeneGroupHandler(PrimaryEntityHandler):
         self.log.info(f'Generated {counter} gene group TSV rows.')
         return
 
-    def filter_obsolete_gene_groups(self):
-        """Exclude obsolete gene groups from export when ADD_OBSOLETE=NO."""
-        self.log.info('ADD_OBSOLETE=NO: excluding obsolete gene groups.')
-        excluded = 0
-        for gene_group in self.fb_data_entities.values():
-            if gene_group.linkmldto is None:
-                continue
-            if gene_group.chado_obj.is_obsolete:
-                gene_group.linkmldto = None
-                excluded += 1
-        self.log.info(f'Excluded {excluded} obsolete gene groups.')
-        return
-
     def filter_by_grp_cvterm_type(self):
         """Exclude gene groups not typed as 'functional group' or 'gene complex group'."""
         self.log.info('Filter gene groups by grp_cvterm type.')
@@ -449,8 +436,10 @@ class GeneGroupHandler(PrimaryEntityHandler):
         super().map_fb_data_to_alliance()
         self.map_gene_group_basic()
         self.filter_by_grp_cvterm_type()
-        if environ.get('ADD_OBSOLETE') == 'NO':
-            self.filter_obsolete_gene_groups()
+        # ADD_OBSOLETE=NO only suppresses obsolete groups in the curator TSV
+        # (process_for_tsv_export); the JSON always includes them so the
+        # standard chado-obsolete -> internal=True cascade (flag_internal_fb_entities
+        # below) produces an audit trail Alliance can still hide from the public.
         self.map_gene_group_synonyms()
         self.map_data_provider_dto()
         self.map_timestamps()

--- a/src/handler.py
+++ b/src/handler.py
@@ -1074,7 +1074,8 @@ class DataHandler(object):
             if missing_info is True:
                 missing_required_info_counter += 1
             if i.for_export is False:
-                self.log.debug(f'DO NOT EXPORT {i}: {i.export_warnings}')
+                if self.testing:
+                    self.log.debug(f'DO NOT EXPORT {i}: {i.export_warnings}')
                 no_export_counter += 1
         self.log.info(f'Assessed {input_counter} objects for exportability.')
         self.log.info(f'Found {no_linkml_mapping_counter} objects with no LinkML mapping at all.')
@@ -1106,7 +1107,8 @@ class DataHandler(object):
             self.export_count += 1
             if i.linkmldto.internal is True:
                 self.internal_count += 1
-                self.log.debug(f'Export {i} but keep INTERNAL at the Alliance: {i.internal_reasons}')
+                if self.testing:
+                    self.log.debug(f'Export {i} but keep INTERNAL at the Alliance: {i.internal_reasons}')
             export_agr_dict = {}
             for attr in i.linkmldto.__dict__.keys():
                 # self.log.debug(f'Assess this attr: {attr}')

--- a/src/transgenic_tool_handler.py
+++ b/src/transgenic_tool_handler.py
@@ -89,6 +89,8 @@ class ExperimentalToolHandler(FeatureHandler):
         self.map_entity_props_to_notes('transgenic_tool_prop_to_note_mapping')
         self.map_secondary_ids('secondary_identifiers')
         self.map_tool_associations()
+        # Cascade chado-obsolete -> internal=True (matches every other handler).
+        self.flag_internal_fb_entities('fb_data_entities')
 
     # Add methods to be run by map_fb_data_to_alliance() below.
     def map_tool_basic(self):


### PR DESCRIPTION
… insertions

For constructs marked with 'FTA: generic TI construct' internal note:
- Flag them as is_generic_ti and export as obsolete (FTA-178/179)
- Query their insertions (FBti) via producedby relationship (FTA-178)
- Create anonymous Construct per insertion: FB:{FBti}_con (FTA-180)
- Create anonymous Cassette per anonymous Construct: FB:{FBti}_cas (FTA-181)
- Propagate parent construct's tool data to cassettes (FTA-182)

Gated behind existing ADD_CASS_TO_CONSTRUCT=YES env var.