### PR TITLE
refactor(FTA-209): map cassette description props to summary note type

### DIFF
--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -115,9 +115,9 @@ class CassetteHandler(FeatureHandler):
     }
 
     cassette_prop_to_note_mapping = {
-        'aminoacid_rep': ('comment', 'note_dtos'),
-        'molecular_info': ('comment', 'note_dtos'),
-        'nucleotide_sub': ('comment', 'note_dtos'),
+        'aminoacid_rep': ('summary', 'note_dtos'),
+        'molecular_info': ('summary', 'note_dtos'),
+        'nucleotide_sub': ('summary', 'note_dtos'),
         # At the moment, just for code development. (line below)
         # 'internal_notes': ('internal_note', 'note_dtos'),
     }


### PR DESCRIPTION
## Summary

Updates `cassette_prop_to_note_mapping` in `src/cassette_handler.py` so the cassette description props (`aminoacid_rep`, `molecular_info`, `nucleotide_sub`) map to the Alliance **`summary`** note type instead of **`comment`**.

This is consistent with how transgenic tools and gene groups already map their descriptions:
- `src/transgenic_tool_handler.py` → `'description': ('summary', 'note_dtos')`
- `src/gene_group_handler.py` → `'gg_description': ('summary', 'note_dtos')`

The commented-out `internal_notes` line is left unchanged.

Ref: [FTA-209](https://flybase.atlassian.net/browse/FTA-209)

## Test plan

- [x] No remaining `'comment'` note-type references in `cassette_handler.py`
- [ ] Run cassette retrieval in test mode and confirm emitted `note_dtos` carry note type `summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FTA-209]: https://flybase.atlassian.net/browse/FTA-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ