### PR TITLE
feat(FTA-211): route cassette FBal internal notes to Construct/Cassette

### DIFF
--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -146,6 +146,11 @@ def _export_primary(cassette_handler):
         raise ValueError(f'The "{set_name}" is unexpectedly empty.')
     generate_export_file(export_dict, log, output_filename)
     _write_cassette_tsvs(export_dict[set_name], set_up_dict['output_filename'])
+    # FTA-211: diagnostic report of internal_notes whose text failed clean_free_text.
+    curation_tsv.write_note_clean_failures_tsv(
+        filename=set_up_dict['output_filename'].replace('.tsv', '_internal_note_clean_failures.tsv'),
+        failures=cassette_handler.internal_note_clean_failures,
+    )
 
 
 def _export_associations(cassette_handler):

--- a/src/AGR_data_retrieval_curation_construct.py
+++ b/src/AGR_data_retrieval_curation_construct.py
@@ -131,6 +131,12 @@ def main():
             datatype='construct',
         )
         log.info(f'Generated TSV: {tsv_filename}')
+        # FTA-211: dump ConstructDTO.note_dtos (incl. matched cassette internal notes) with pub_curies.
+        curation_tsv.write_notes_tsv(
+            filename=tsv_filename.replace('.tsv', '_notes.tsv'),
+            entities=export_dict['construct_ingest_set'],
+        )
+        log.info(f"Generated TSV: {tsv_filename.replace('.tsv', '_notes.tsv')}")
 
     if not reference_session:
         # Export the construct associations to a separate file.

--- a/src/AGR_data_retrieval_curation_construct.py
+++ b/src/AGR_data_retrieval_curation_construct.py
@@ -137,6 +137,12 @@ def main():
             entities=export_dict['construct_ingest_set'],
         )
         log.info(f"Generated TSV: {tsv_filename.replace('.tsv', '_notes.tsv')}")
+        # FTA-211: diagnostic report of internal_notes whose text failed clean_free_text.
+        curation_tsv.write_note_clean_failures_tsv(
+            filename=tsv_filename.replace('.tsv', '_internal_note_clean_failures.tsv'),
+            failures=cons_handler.internal_note_clean_failures,
+        )
+        log.info(f"Generated TSV: {tsv_filename.replace('.tsv', '_internal_note_clean_failures.tsv')}")
 
     if not reference_session:
         # Export the construct associations to a separate file.

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -41,6 +41,7 @@ class SubmittedObjectDTO(AuditedObjectDTO):
         self.primary_external_id = None
         self.mod_internal_id = None
         self.data_provider_dto = None
+        self.note_dtos = []        # Inherited note_dtos slot (LinkML SubmittedObjectDTO); many subclasses redefine it.
         self.required_fields.extend(['data_provider_dto'])
 
 

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -10,10 +10,12 @@ Author(s):
 """
 
 from logging import Logger
+from os import getenv
 import copy
 import agr_datatypes
 import fb_datatypes
 from feature_handler import FeatureHandler
+from harvdev_utils.char_conversions import clean_free_text
 
 
 class CassetteHandler(FeatureHandler):
@@ -232,8 +234,63 @@ class CassetteHandler(FeatureHandler):
         # self.map_xrefs()
         self.map_secondary_ids('secondary_identifiers')
         self.map_cassette_associations()
+        self.map_cassette_internal_notes_fallback()
         # Cascade chado-obsolete -> internal=True (matches every other handler).
         self.flag_internal_fb_entities('fb_data_entities')
+
+    def map_cassette_internal_notes_fallback(self):
+        """FTA-211: route cassette FBal internal_notes that cannot be mapped to a Construct onto the Cassette.
+
+        A note's FBrf is "matched" when the cassette FBal has an associated_with link to an FBtp carrying
+        that same FBrf; those notes are added to the Construct by the ConstructHandler. Any note FBrf with
+        no such link - plus notes that carry no FBrf at all - falls back to the Cassette so data is not
+        lost. Each fallback (note text, FBrf) becomes one internal_note with that FBrf as its pub_curie.
+        Gated by ADD_CASS_TO_CONSTRUCT=YES, matching the ConstructHandler's cassette routing.
+        """
+        dump_cass_assoc = getenv('ADD_CASS_TO_CONSTRUCT', None)
+        if not (dump_cass_assoc and dump_cass_assoc == 'YES'):
+            return
+        self.log.info('FTA-211: map fallback internal_notes onto cassettes.')
+        counter = 0
+        for cassette in self.fb_data_entities.values():
+            if cassette.linkmldto is None:
+                continue
+            if 'internal_notes' not in cassette.props_by_type.keys():
+                continue
+            # Union of FBrf pub_ids across this FBal's associated_with -> construct links.
+            assoc_rels = cassette.recall_relationships(
+                self.log, entity_role='subject', rel_types='associated_with', rel_entity_types='construct')
+            assoc_pub_ids = set()
+            for rel in assoc_rels:
+                assoc_pub_ids.update(rel.pubs)
+            note_keys = set()
+            for fb_prop in cassette.props_by_type['internal_notes']:
+                free_text = clean_free_text(fb_prop.chado_obj.value)
+                note_pub_ids = set(fb_prop.pubs)
+                if note_pub_ids:
+                    # Fall back only the FBrf(s) with no matching associated_with -> construct link.
+                    for pub_id in note_pub_ids - assoc_pub_ids:
+                        note_key = (free_text, pub_id)
+                        if note_key in note_keys:
+                            continue
+                        note_keys.add(note_key)
+                        note_dto = agr_datatypes.NoteDTO(
+                            'internal_note', free_text, self.lookup_pub_curies([pub_id]))
+                        note_dto.internal = True
+                        cassette.linkmldto.note_dtos.append(note_dto.dict_export())
+                        counter += 1
+                else:
+                    # No FBrf at all - cannot route to a Construct; keep on the Cassette (no evidence).
+                    note_key = (free_text, None)
+                    if note_key in note_keys:
+                        continue
+                    note_keys.add(note_key)
+                    note_dto = agr_datatypes.NoteDTO('internal_note', free_text, [])
+                    note_dto.internal = True
+                    cassette.linkmldto.note_dtos.append(note_dto.dict_export())
+                    counter += 1
+        self.log.info(f'FTA-211: added {counter} fallback internal_note(s) to cassettes.')
+        return
 
     def map_secondary_ids(self, slot_name):
         """Return a list of Alliance SecondaryIdSlotAnnotationDTOs for a FlyBase entity."""

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -15,7 +15,6 @@ import copy
 import agr_datatypes
 import fb_datatypes
 from feature_handler import FeatureHandler
-from harvdev_utils.char_conversions import clean_free_text
 
 
 class CassetteHandler(FeatureHandler):
@@ -265,7 +264,7 @@ class CassetteHandler(FeatureHandler):
                 assoc_pub_ids.update(rel.pubs)
             note_keys = set()
             for fb_prop in cassette.props_by_type['internal_notes']:
-                free_text = clean_free_text(fb_prop.chado_obj.value)
+                free_text = self.clean_note_free_text(f'FB:{cassette.uniquename}', fb_prop.chado_obj.value)
                 note_pub_ids = set(fb_prop.pubs)
                 if note_pub_ids:
                     # Fall back only the FBrf(s) with no matching associated_with -> construct link.

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -14,7 +14,6 @@ from sqlalchemy.orm import aliased
 import agr_datatypes
 import fb_datatypes
 from feature_handler import FeatureHandler
-from harvdev_utils.char_conversions import clean_free_text
 from harvdev_utils.reporting import (
     Cvterm, Feature, FeatureCvterm, FeatureCvtermprop,
     FeatureRelationship, FeatureRelationshipPub,
@@ -359,7 +358,8 @@ class ConstructHandler(FeatureHandler):
             Cvterm.name == 'internal_notes',
         )
         results = session.query(
-            allele.feature_id, Featureprop.featureprop_id, Featureprop.value, FeaturepropPub.pub_id).\
+            allele.feature_id, allele.uniquename,
+            Featureprop.featureprop_id, Featureprop.value, FeaturepropPub.pub_id).\
             join(Featureprop, (Featureprop.feature_id == allele.feature_id)).\
             join(Cvterm, (Cvterm.cvterm_id == Featureprop.type_id)).\
             outerjoin(FeaturepropPub, (FeaturepropPub.featureprop_id == Featureprop.featureprop_id)).\
@@ -371,7 +371,7 @@ class ConstructHandler(FeatureHandler):
         for row in results:
             note = note_by_prop_id.get(row.featureprop_id)
             if note is None:
-                note = {'text': clean_free_text(row.value), 'pub_ids': set()}
+                note = {'text': self.clean_note_free_text(f'FB:{row.uniquename}', row.value), 'pub_ids': set()}
                 note_by_prop_id[row.featureprop_id] = note
                 self.allele_internal_notes.setdefault(row.feature_id, []).append(note)
             if row.pub_id is not None:

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import aliased
 import agr_datatypes
 import fb_datatypes
 from feature_handler import FeatureHandler
+from harvdev_utils.char_conversions import clean_free_text
 from harvdev_utils.reporting import (
     Cvterm, Feature, FeatureCvterm, FeatureCvtermprop,
     FeatureRelationship, FeatureRelationshipPub,
@@ -344,6 +345,41 @@ class ConstructHandler(FeatureHandler):
         self.log.info(f'Found {counter} molecular_info featureprop pub links for alleles.')
         return
 
+    def get_allele_internal_notes(self, session):
+        """Get internal_notes featureprops (text + pubs) for cassette alleles, keyed by allele feature_id (FTA-211).
+
+        Populates self.allele_internal_notes[allele_feature_id] = [{'text': str, 'pub_ids': set()}, ...],
+        one entry per featureprop (internal note), so notes can be routed per-FBrf to the correct Construct.
+        """
+        self.log.info('Get internal_notes featureprops for alleles.')
+        allele = aliased(Feature, name='allele')
+        filters = (
+            allele.is_obsolete.is_(False),
+            allele.uniquename.op('~')(self.regex['allele']),
+            Cvterm.name == 'internal_notes',
+        )
+        results = session.query(
+            allele.feature_id, Featureprop.featureprop_id, Featureprop.value, FeaturepropPub.pub_id).\
+            join(Featureprop, (Featureprop.feature_id == allele.feature_id)).\
+            join(Cvterm, (Cvterm.cvterm_id == Featureprop.type_id)).\
+            outerjoin(FeaturepropPub, (FeaturepropPub.featureprop_id == Featureprop.featureprop_id)).\
+            filter(*filters).\
+            distinct()
+        self.allele_internal_notes = {}
+        note_by_prop_id = {}    # featureprop_id -> note dict (to group multiple pubs of one prop).
+        counter = 0
+        for row in results:
+            note = note_by_prop_id.get(row.featureprop_id)
+            if note is None:
+                note = {'text': clean_free_text(row.value), 'pub_ids': set()}
+                note_by_prop_id[row.featureprop_id] = note
+                self.allele_internal_notes.setdefault(row.feature_id, []).append(note)
+            if row.pub_id is not None:
+                note['pub_ids'].add(row.pub_id)
+            counter += 1
+        self.log.info(f'Found {len(note_by_prop_id)} internal_notes featureprops for alleles.')
+        return
+
     def get_datatype_data(self, session):
         """Extend the method for the ConstructHandler."""
         super().get_datatype_data(session)
@@ -364,9 +400,11 @@ class ConstructHandler(FeatureHandler):
         # Because the Alliance is not yet able to handle cassettes we do not want to add these
         # associations. For testing set the env ADD_CASS_TO_CONSTRUCT which will then do this
         self.allele_molecular_info_pubs = {}
+        self.allele_internal_notes = {}
         dump_cass_assoc = getenv('ADD_CASS_TO_CONSTRUCT', None)
         if dump_cass_assoc and dump_cass_assoc == 'YES':
             self.get_allele_molecular_info_pubs(session)
+            self.get_allele_internal_notes(session)
         return
 
     # Add methods to be run by synthesize_info() below.
@@ -1168,6 +1206,8 @@ class ConstructHandler(FeatureHandler):
         counter = 0
         for construct in self.fb_data_entities.values():
             cons_curie = f'FB:{construct.uniquename}'
+            # FTA-211: dedup key set for internal notes attached to this Construct (text, pub_id).
+            construct_note_keys = set()
             # Handle marked_with relationships (FTA-139).
             marked_with_rels = construct.recall_relationships(
                 self.log, entity_role='subject', rel_types='marked_with', rel_entity_types='allele')
@@ -1198,6 +1238,21 @@ class ConstructHandler(FeatureHandler):
                 allele_id = rel.chado_obj.subject_id
                 allele_uniquename = self.feature_lookup[allele_id]['uniquename']
                 cassette_curie = f'FB:{allele_uniquename}'
+                # FTA-211: attach matched cassette-FBal internal notes directly to this Construct.
+                # A note's FBrf matches when it is also on this associated_with link (rel.pubs); each
+                # matched (note text, FBrf) becomes one internal_note with that FBrf as its pub_curie.
+                if construct.linkmldto is not None:
+                    rel_pub_ids = set(rel.pubs)
+                    for note in self.allele_internal_notes.get(allele_id, []):
+                        for pub_id in note['pub_ids'] & rel_pub_ids:
+                            note_key = (note['text'], pub_id)
+                            if note_key in construct_note_keys:
+                                continue
+                            construct_note_keys.add(note_key)
+                            note_dto = agr_datatypes.NoteDTO(
+                                'internal_note', note['text'], self.lookup_pub_curies([pub_id]))
+                            note_dto.internal = True
+                            construct.linkmldto.note_dtos.append(note_dto.dict_export())
                 # Pub filtering logic.
                 if len(rel.pubs) == 1:
                     filtered_pub_ids = rel.pubs

--- a/src/curation_tsv.py
+++ b/src/curation_tsv.py
@@ -29,6 +29,7 @@ GENE_CHANGE_EVENTS_TSV_HEADER = (
 SKIPPED_IDENTITY_SOURCE_TSV_HEADER = (
     "# Primary FBid\traw_value\ttoken_count\tinternal\tobsolete\n"
 )
+NOTE_CLEAN_FAILURES_TSV_HEADER = "# Primary FBid\traw_value\terror\n"
 COMPONENTS_TSV_HEADER = "# Primary FBid\tsymbol\trelation\ttaxon\tevidence\n"
 # NB: existing tool_uses TSVs write rows as primary, tools, evidence; the
 # header preserves that historic column order verbatim.
@@ -146,6 +147,20 @@ def write_skipped_identity_source_tsv(*, filename, skipped):
                 f"{item['fb_id']}\t{item['raw_value']}\t{item['token_count']}\t"
                 f"{item['internal']}\t{item['obsolete']}\n"
             )
+
+
+def write_note_clean_failures_tsv(*, filename, failures):
+    """Write the diagnostic TSV of internal_notes whose text failed clean_free_text (FTA-211).
+
+    One row per failed note: the raw featureprop value (tabs/newlines flattened) and the
+    exception, so curators can see the offending characters (e.g. an unknown SGML entity
+    like "&3;"). Not filtered by should_skip_obsolete().
+    """
+    with open(filename, 'w') as outfile:
+        outfile.write(NOTE_CLEAN_FAILURES_TSV_HEADER)
+        for item in failures:
+            raw = item['raw_value'].replace('\t', ' ').replace('\n', ' ')
+            outfile.write(f"{item['fb_id']}\t{raw}\t{item['error']}\n")
 
 
 def write_components_tsv(*, filename, entities, datatype):

--- a/src/curation_tsv.py
+++ b/src/curation_tsv.py
@@ -101,7 +101,10 @@ def write_notes_tsv(*, filename, entities):
             primary = entity_dict["primary_external_id"]
             for note in entity_dict.get("note_dtos", []):
                 evidence = EVIDENCE_DELIMITER.join(note.get('evidence_curies', []))
-                outfile.write(f"{primary}\t{note['note_type_name']}\t{note['free_text']}\t{evidence}\n")
+                # Strip tabs/newlines just before the dump so "dirty" (unmodified) note
+                # free text cannot break the TSV row; the text is otherwise left as-is.
+                free_text = note['free_text'].replace('\t', ' ').replace('\r', ' ').replace('\n', ' ')
+                outfile.write(f"{primary}\t{note['note_type_name']}\t{free_text}\t{evidence}\n")
 
 
 def write_gene_change_events_tsv(*, filename, entities):

--- a/src/feature_handler.py
+++ b/src/feature_handler.py
@@ -11,8 +11,10 @@ Author(s):
 
 """
 
+import re
 from logging import Logger
 from sqlalchemy.orm import aliased
+from harvdev_utils.char_conversions import clean_free_text
 from harvdev_utils.reporting import (
     Cvterm, Db, Dbxref, Featureloc, Feature, FeatureDbxref, FeatureRelationship,
     FeatureCvterm, Library, LibraryFeature, LibraryFeatureprop
@@ -26,6 +28,26 @@ class FeatureHandler(PrimaryEntityHandler):
     def __init__(self, log: Logger, testing: bool):
         """Create the FeatureHandler object."""
         super().__init__(log, testing)
+        self.internal_note_clean_failures = []    # FTA-211: internal_notes whose text failed clean_free_text.
+
+    def clean_note_free_text(self, fb_id, raw_value):
+        """Clean internal-note free text, tolerating unknown SGML entities (FTA-211).
+
+        clean_free_text() raises KeyError on any &word; token not in harvdev_utils'
+        Greek dict (e.g. the junk "&3;"). On failure we strip &word; tokens and retry
+        leniently, keep the note, and record the raw value for the diagnostic report.
+        """
+        try:
+            return clean_free_text(raw_value)
+        except Exception as error:
+            stripped = re.sub(r'&\w+;', '', raw_value)
+            try:
+                cleaned = clean_free_text(stripped)
+            except Exception:
+                cleaned = stripped.replace('\n', ' ').replace('\t', ' ').replace('@', '')
+            self.internal_note_clean_failures.append(
+                {'fb_id': fb_id, 'raw_value': raw_value, 'error': str(error)})
+            return cleaned
 
     # Add methods to be run by get_general_data() below.
     # Placeholder.

--- a/src/feature_handler.py
+++ b/src/feature_handler.py
@@ -11,7 +11,6 @@ Author(s):
 
 """
 
-import re
 from logging import Logger
 from sqlalchemy.orm import aliased
 from harvdev_utils.char_conversions import clean_free_text
@@ -40,14 +39,9 @@ class FeatureHandler(PrimaryEntityHandler):
         try:
             return clean_free_text(raw_value)
         except Exception as error:
-            stripped = re.sub(r'&\w+;', '', raw_value)
-            try:
-                cleaned = clean_free_text(stripped)
-            except Exception:
-                cleaned = stripped.replace('\n', ' ').replace('\t', ' ').replace('@', '')
             self.internal_note_clean_failures.append(
                 {'fb_id': fb_id, 'raw_value': raw_value, 'error': str(error)})
-            return cleaned
+            return raw_value
 
     # Add methods to be run by get_general_data() below.
     # Placeholder.


### PR DESCRIPTION
## Summary

[FTA-211](https://flybase.atlassian.net/browse/FTA-211) — *Submit Cassette FBal internal notes to the Alliance*.

Cassette FBal `internal_notes` featureprops (provenance/source info) are now submitted to the Alliance, routed **per-FBrf**:

- A note FBrf that is **also carried by an `associated_with` link** from the FBal to an FBtp → the note is attached to that **Construct** (`ConstructDTO.note_dtos`), with the FBrf as its `pub_curie`.
- Any FBrf with **no such link** (plus notes with no FBrf at all) → falls back onto the **Cassette** (`CassetteDTO.note_dtos`) so data isn't lost.

Notes go in as type `internal_note` (`internal=True`). Both sides are gated by `ADD_CASS_TO_CONSTRUCT=YES`.

Per the team decision on the ticket (Gillian), notes go **directly on the Construct**, not on `ConstructCassetteAssociationDTO`. No Alliance schema change is needed — `note_dtos` is inherited (`ConstructDTO → ReagentDTO → SubmittedObjectDTO`).

## Changes

| File | Change |
|---|---|
| `src/agr_datatypes.py` | Add `note_dtos` to `SubmittedObjectDTO` so `ConstructDTO` inherits it (matches LinkML) |
| `src/construct_handler.py` | `get_allele_internal_notes()` query; attach matched notes to `ConstructDTO.note_dtos` in the `associated_with` loop, deduped per construct |
| `src/cassette_handler.py` | `map_cassette_internal_notes_fallback()` for unmatched FBrfs |
| `src/AGR_data_retrieval_curation_construct.py` | Emit a `_notes.tsv` (with the FTA-212 `evidence` column) for validation |

## Verification

- All modules compile.
- DTO plumbing confirmed: `ConstructDTO` inherits `note_dtos`; an `internal_note` exports with its `evidence_curies`; empty `note_dtos` is dropped from export.
- Routing set-logic confirmed disjoint & complete — every note FBrf routed exactly once (matched→Construct, unmatched→Cassette).
- **Pending (needs chado DB):** end-to-end run with `ADD_CASS_TO_CONSTRUCT=YES` for both scripts; compare counts to the ticket's `cassette_int_notes_3.tsv` (~129,033 Construct-side / ~199 fallback); inspect the new `construct..._notes.tsv` evidence column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FTA-211]: https://flybase.atlassian.net/browse/FTA-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ