### PR TITLE
fix(FTA-132): query compatible_tool both ways, export both directions

### DIFF
--- a/src/transgenic_tool_handler.py
+++ b/src/transgenic_tool_handler.py
@@ -26,6 +26,8 @@ class ExperimentalToolHandler(FeatureHandler):
         self.fb_export_type = fb_datatypes.FBTool
         self.agr_export_type = agr_datatypes.TransgenicToolDTO
         self.primary_export_set = 'transgenic_tool_ingest_set'
+        self.tool_associations = []    # FBRelationship carriers, one per exported tool-tool association.
+        self.tool_tool_rels = {}       # Lists of FBRelationship objects keyed by (subject_id, object_id).
 
     test_set = {
         'FBto0000001': 'C-Cerulean',  # First one
@@ -41,8 +43,6 @@ class ExperimentalToolHandler(FeatureHandler):
         # At the moment, just for code development. (line below)
         # 'internal_notes': ('internal_note', 'note_dtos'),
     }
-    tool_associations = []
-    tool_tool_rels = {}
 
     def get_general_data(self, session):
         """Extend the method for the AlleleHandler."""
@@ -60,8 +60,12 @@ class ExperimentalToolHandler(FeatureHandler):
         self.get_entity_synonyms(session)
         self.get_entity_fb_xrefs(session)
         self.get_entity_xrefs(session)
-        self.get_entity_relationships(session, 'object', rel_type='compatible_tool',
-                                      entity_type='engineered_region', entity_regex=self.regex['tool'])
+        # Query both directions: a compatible_tool relationship is only ever attached to the tool
+        # playing the queried role, so a single-role query leaves the other tool of the pair without
+        # the relationship (FTA-132).
+        for role in ('subject', 'object'):
+            self.get_entity_relationships(session, role, rel_type='compatible_tool',
+                                          entity_type='engineered_region', entity_regex=self.regex['tool'])
 
         # self.build_feature_lookup(session)
 
@@ -104,26 +108,32 @@ class ExperimentalToolHandler(FeatureHandler):
         return
 
     def synthesize_tool_associations(self):
-        """Get tool relationships."""
-        self.log.info('Synthesize transgenic tool.')
-        sub_tool_counter = 0
-        obj_tool_counter = 0
+        """Collect compatible_tool relationships from both directions and group them by tool pair."""
+        self.log.info('Synthesize transgenic tool associations.')
+        # Each feature_relationship is fetched once per role, producing two distinct FBRelationship
+        # objects for the same chado row, so dedupe on the feature_relationship_id.
+        rels_by_id = {}
+        rels_per_role = {'subject': 0, 'object': 0}
+        tools_with_rels = set()
         for tool in self.fb_data_entities.values():
-            relevant_tool_rels = tool.recall_relationships(self.log, entity_role='object', rel_types='compatible_tool')
-            if relevant_tool_rels:
-                sub_tool_counter += 1
-            for tool_rel in relevant_tool_rels:
-                try:
-                    tool_tool_key = (tool_rel.chado_obj.object_id, tool_rel.chado_obj.subject_id)
-                except AttributeError:
-                    self.log.error(f"problem {tool} {tool_rel}")
-                    raise
-                try:
-                    self.tool_tool_rels[tool_tool_key].append(tool_rel)
-                except KeyError:
-                    self.tool_tool_rels[tool_tool_key] = [tool_rel]
-                    obj_tool_counter += 1
-        self.log.info(f'Found {obj_tool_counter} tools for {sub_tool_counter} tools.')
+            for role in rels_per_role.keys():
+                role_rels = tool.recall_relationships(self.log, entity_role=role, rel_types='compatible_tool')
+                rels_per_role[role] += len(role_rels)
+                if role_rels:
+                    tools_with_rels.add(tool.db_primary_id)
+                for tool_rel in role_rels:
+                    rels_by_id[tool_rel.db_primary_id] = tool_rel
+        for role, role_count in rels_per_role.items():
+            self.log.info(f'Recalled {role_count} compatible_tool relationships where the tool is the {role}.')
+        for tool_rel in rels_by_id.values():
+            tool_tool_key = (tool_rel.chado_obj.subject_id, tool_rel.chado_obj.object_id)
+            try:
+                self.tool_tool_rels[tool_tool_key].append(tool_rel)
+            except KeyError:
+                self.tool_tool_rels[tool_tool_key] = [tool_rel]
+        msg = f'Found {len(rels_by_id)} distinct compatible_tool feature_relationships in '
+        msg += f'{len(self.tool_tool_rels)} subject-object combinations, for {len(tools_with_rels)} tools.'
+        self.log.info(msg)
         return
 
     # Elaborate on synthesize_info() for the Handler.
@@ -134,50 +144,95 @@ class ExperimentalToolHandler(FeatureHandler):
         self.synthesize_secondary_ids()
         self.synthesize_tool_associations()
 
+    def build_tool_association(self, chado_obj, subject_curie, object_curie, pub_ids, pub_curies, is_obsolete):
+        """Build an FBRelationship carrier holding one TransgenicToolAssociationDTO.
+
+        Each exported association needs its own carrier object, because generate_export_dict() reads
+        linkmldto (and for_export/internal_reasons/export_warnings) off one object per output row.
+
+        Args:
+            chado_obj (FeatureRelationship): The chado relationship the association derives from.
+            subject_curie (str): The FB curie of the subject tool.
+            object_curie (str): The FB curie of the object tool.
+            pub_ids (list): The chado pub_ids supporting the association.
+            pub_curies (list): The FB curies of the supporting pubs.
+            is_obsolete (bool): True if either tool of the pair is obsolete in chado.
+
+        Returns:
+            An FBRelationship object with its linkmldto set.
+
+        """
+        carrier = fb_datatypes.FBRelationship(chado_obj, 'feature_relationship')
+        carrier.pubs = pub_ids
+        rel_dto = agr_datatypes.TransgenicToolAssociationDTO(
+            subject_curie, object_curie,
+            pub_curies, False, 'compatible_tool')
+        if is_obsolete is True:
+            rel_dto.obsolete = True
+            rel_dto.internal = True
+        carrier.linkmldto = rel_dto
+        return carrier
+
     def map_tool_associations(self):
-        """Map transgenic tool associations to Alliance object."""
+        """Map transgenic tool associations to Alliance objects, in both directions."""
         self.log.info('Map tool associations to Alliance object.')
-        OBJECT = 0
-        SUBJECT = 1
-        counter = 0
-
-        tool_tool_counter = {}
-        for tool_tool_key in self.tool_tool_rels.keys():
-            if self.testing:
-                self.log.debug(f'Mapping {tool_tool_key} to Alliance object. {self.tool_tool_rels[tool_tool_key]}')
-            try:
-                tool_tool_counter[tool_tool_key[OBJECT]] += 1
-            except KeyError:
-                tool_tool_counter[tool_tool_key[OBJECT]] = 1
-
+        # Merge the chado rows into one record per unordered tool pair, so that a pair stored in both
+        # directions contributes a single set of pubs rather than two competing ones.
+        pair_records = {}
         for tool_tool_key, tool_tool_rels in self.tool_tool_rels.items():
-            object_feature_id = tool_tool_key[OBJECT]
-            f_object = self.fb_data_entities[object_feature_id]
-            object_curie = f'FB:{f_object.uniquename}'
-            subject = self.feature_lookup[tool_tool_key[SUBJECT]]
-            subject_curie = f'FB:{subject["uniquename"]}'
-            first_feat_rel = tool_tool_rels[0]
-            all_pub_ids = []
+            pair_key = tuple(sorted(tool_tool_key))
+            try:
+                pair_record = pair_records[pair_key]
+            except KeyError:
+                pair_record = {'rels': [], 'pub_ids': [], 'chado_directions': set()}
+                pair_records[pair_key] = pair_record
+            pair_record['rels'].extend(tool_tool_rels)
+            pair_record['chado_directions'].add(tool_tool_key)
             for tool_tool_rel in tool_tool_rels:
-                all_pub_ids.extend(tool_tool_rel.pubs)
-            first_feat_rel.pubs = all_pub_ids
+                pair_record['pub_ids'].extend(tool_tool_rel.pubs)
+
+        exported_pairs = set()    # (subject_curie, object_curie) tuples already exported.
+        both_ways_in_chado = 0
+        reciprocal_counter = 0
+        skipped_counter = 0
+        for pair_key, pair_record in pair_records.items():
+            if self.testing:
+                self.log.debug(f'Mapping {pair_key} to Alliance object. {pair_record["rels"]}')
+            try:
+                feat_a = self.feature_lookup[pair_key[0]]
+                feat_b = self.feature_lookup[pair_key[1]]
+            except KeyError:
+                self.log.warning(f'Skip compatible_tool pair {pair_key}: a feature is missing from the tool lookup.')
+                skipped_counter += 1
+                continue
+            curie_a = f'FB:{feat_a["uniquename"]}'
+            curie_b = f'FB:{feat_b["uniquename"]}'
+            is_obsolete = feat_a['is_obsolete'] is True or feat_b['is_obsolete'] is True
+            all_pub_ids = pair_record['pub_ids']
             # NOTE: pub 383755 | FlyBase Experimental Tool information Is the only one used
             # for tools. But not in lookup pub curies!
             # So pub_curies will be empty.
             pub_curies = self.lookup_pub_curies(all_pub_ids)
-
-            # Adjust allele-gene relation_type as needed.
-            rel_type_name = 'compatible_tool'
-            rel_dto = agr_datatypes.TransgenicToolAssociationDTO(
-                subject_curie, object_curie,
-                pub_curies, False, rel_type_name)
-            if f_object.is_obsolete is True or subject['is_obsolete'] is True:
-                rel_dto.obsolete = True
-                rel_dto.internal = True
-            first_feat_rel.linkmldto = rel_dto
-            self.tool_associations.append(first_feat_rel)
-            counter += 1
-        self.log.info(f'Generated {counter} tool-tool unique associations.')
+            if len(pair_record['chado_directions']) == 2:
+                both_ways_in_chado += 1
+            elif curie_a != curie_b:
+                reciprocal_counter += 1
+            chado_obj = pair_record['rels'][0].chado_obj
+            # Export both directions: the Alliance model treats the association as directed, so a
+            # tool only shows its compatible partner if it is named as the subject (FTA-132).
+            for subject_curie, object_curie in ((curie_a, curie_b), (curie_b, curie_a)):
+                if (subject_curie, object_curie) in exported_pairs:
+                    continue
+                self.tool_associations.append(
+                    self.build_tool_association(chado_obj, subject_curie, object_curie,
+                                                all_pub_ids, pub_curies, is_obsolete))
+                exported_pairs.add((subject_curie, object_curie))
+        self.log.info(f'Found {len(pair_records)} unique tool-tool pairs, {both_ways_in_chado} of which chado '
+                      'stores in both directions.')
+        self.log.info(f'Synthesized {reciprocal_counter} reciprocal associations not present in chado.')
+        if skipped_counter:
+            self.log.warning(f'Skipped {skipped_counter} tool-tool pairs missing from the tool lookup.')
+        self.log.info(f'Generated {len(self.tool_associations)} tool-tool unique associations.')
         return
 
     # Elaborate on query_chado_and_export() for the TransgenicToolHandler.


### PR DESCRIPTION
[FTA-132](https://flybase.atlassian.net/browse/FTA-132)

> Tool association has different results for 'compatible_tool' depending on whether you query by the object or subject. The FB web code uses both when displaying, alliance does not show anything currently. So we may want to query both object and subject and create a set before creating json to ensure all data is there in case alliance does not do both ways.

## Problem

`ExperimentalToolHandler.get_datatype_data()` queried `compatible_tool` with role `'object'` only. A relationship is attached solely to the tool playing the queried role (`entity_handler.py` Phase 4 keys off `getattr(rel.chado_obj, f'{role}_id')`), so the other tool of every pair never received it. In testing mode rows were dropped outright, because the primary-entity filter restricts to `test_set` — a test tool appearing only as a *subject* got no relationships at all.

The Alliance model is directed: `TransgenicToolTransgenicToolAssociation` is `transgenic_tool_association_subject` → `transgenic_tool_transgenic_tool_association_object` (`agr_curation_schema/model/schema/reagent.yaml`), with no declared symmetry. So a tool only shows its compatible partner when it is named as the subject.

Note that the two role queries are *symmetric in chado* for tools — both sides filter on the FBto regex plus `engineered_region` — so in production they return the same `feature_relationship` rows. What the single-role query lost was the attachment to the other tool, not the rows themselves.

## Changes

All in `src/transgenic_tool_handler.py`.

- **`get_datatype_data`** — query both roles.
- **`synthesize_tool_associations`** — recall both roles and dedupe on `feature_relationship_id` (each role query builds a fresh `FBRelationship` for the same chado row). Key `tool_tool_rels` by `(subject_id, object_id)`, flipped from the old `(object_id, subject_id)` to match `TransgenicToolAssociationDTO`'s argument order. Dropped a dead `try/except AttributeError` block.
- **`map_tool_associations`** — merge chado rows into one record per *unordered* pair, so a pair stored both ways contributes one merged pub list instead of two competing ones, then emit both ordered directions deduped through a `set`. Resolve both sides from `feature_lookup` rather than `fb_data_entities`; the old code would raise `KeyError` for any tool that isn't a primary export entity, which subject-role rels make reachable.
- **New `build_tool_association()`** — each output row needs its own carrier, since `generate_export_dict()` reads `linkmldto`/`for_export`/`internal_reasons` off one object per row.
- **`tool_associations` / `tool_tool_rels` moved into `__init__`** — they were mutable *class* attributes that `map_tool_associations` appends to, leaking state across handler instances.
- **Diagnostics** — log per-role rel counts, pairs chado stores in both directions, and reciprocals synthesized.

## Verification

- `flake8 --max-line-length=160` clean.
- 13/13 logic checks pass against hand-built fake chado rows: one-way row → both directions once; chado storing both ways → collapses to 2 rows not 4; duplicate same-direction rows → still 2; obsolete cascade applied to both directions; self-relationship not duplicated; missing-from-lookup pair warns and skips instead of crashing; no state leak between instances; distinct carriers/DTOs per row. Diagnostic counters verified in each case.

**Draft because this has not been run against chado.** Still outstanding:

1. Test-mode run: `python AGR_data_retrieval_curation_transgenic_tool.py -v -t -c <config> -l <version>` — test tools that previously had no associations should now have them.
2. Confirm the exported pair count equals distinct unordered pairs × 2, and get the real "stored both ways in chado" number.
3. Full run, then check both output files for both directions of a known pair.
4. `python validate_agr_schema.py <association_json>` — `TransgenicToolTransgenicToolAssociationDTO` declares no `unique_keys`, so reciprocal rows should validate, but confirm.

## Reviewer note

Association count roughly doubles. If the Alliance persistent store *already* renders `compatible_tool` bidirectionally, this trades the current missing data for duplicate display — the new log lines give the numbers to take to them. Out of scope here: the empty `evidence_curies` / pub 383755 lookup gap, which is pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FTA-132]: https://flybase.atlassian.net/browse/FTA-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ