### PR TITLE
feat(FTA-218): aberration carries/breakpoint_allele allele associations (gated, dormant)

### DIFF
--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -143,6 +143,13 @@ def main():
         curation_tsv.write_notes_tsv(
             filename=tsv_filename.replace('.tsv', '_notes.tsv'), entities=entities,
         )
+        # FTA-221: diagnostic TSV of note props whose text could not be cleaned (NULL, blank, or bad
+        # SGML), so curators can find and fix the offending rows. Mirrors the construct/cassette
+        # scripts. Combined across both handlers, since each collects its own failures.
+        note_failures = allele_handler.internal_note_clean_failures + aberration_handler.internal_note_clean_failures
+        failures_filename = tsv_filename.replace('.tsv', '_internal_note_clean_failures.tsv')
+        curation_tsv.write_note_clean_failures_tsv(filename=failures_filename, failures=note_failures)
+        log.info(f'Generated TSV: {failures_filename} ({len(note_failures)} uncleanable note props)')
 
     if not reference_session:
         # Export the gene-allele associations to a separate file.

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -22,6 +22,7 @@ Notes:
 """
 
 import argparse
+from os import getenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from harvdev_utils.psycopg_functions import set_up_db_reading
@@ -34,6 +35,7 @@ import curation_tsv
 _ALLELE_ASSOC_SECOND_FIELDS = {
     'allele_gene_association_ingest_set': 'gene_identifier',
     'allele_construct_association_ingest_set': 'construct_identifier',
+    'allele_allele_association_ingest_set': 'object_allele_identifier',
 }
 # Allele association TSVs include an extra 'internal' boolean column.
 _ALLELE_ASSOC_EXTRAS = [('internal', 'internal', False)]
@@ -60,9 +62,12 @@ parser = argparse.ArgumentParser(
     description='Export FlyBase allele data to Alliance LinkML JSON.',
     epilog="""
 Environment variables:
-  SERVER              Database server (e.g. flysql25)
-  DATABASE            Database name (e.g. production_chado)
-  ADD_OBSOLETE        Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
+  SERVER                    Database server (e.g. flysql25)
+  DATABASE                  Database name (e.g. production_chado)
+  ADD_OBSOLETE              Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
+  ADD_ALLELE_ALLELE_ASSOC   Set to 'YES' to emit the FTA-218 'allele_allele_association_ingest_set' (aberration
+                            'carries'/'breakpoint_allele' relations). Off by default: the Alliance schema has no
+                            such ingest set and lacks the two CV terms, so the data cannot yet be loaded.
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
@@ -159,11 +164,25 @@ def main():
         if len(association_export_dict['allele_construct_association_ingest_set']) == 0:
             log.error('The "allele_construct_association_ingest_set" is unexpectedly empty.')
             raise ValueError('The "allele_construct_association_ingest_set" is unexpectedly empty.')
+        # Allele-allele associations (FTA-218). Gated by ADD_ALLELE_ALLELE_ASSOC=YES because the Alliance schema has
+        # no "allele_allele_association_ingest_set" and lacks the "carries"/"breakpoint_allele" CV terms, so including
+        # this set would make the file unloadable.
+        association_ingest_names = ['allele_gene_association_ingest_set',
+                                    'allele_construct_association_ingest_set']
+        if getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES':
+            association_export_dict['allele_allele_association_ingest_set'] = []
+            association_export_dict['allele_allele_association_ingest_set'].extend(
+                aberration_handler.export_data['allele_allele_association_ingest_set'])
+            if len(association_export_dict['allele_allele_association_ingest_set']) == 0:
+                log.error('The "allele_allele_association_ingest_set" is unexpectedly empty.')
+                raise ValueError('The "allele_allele_association_ingest_set" is unexpectedly empty.')
+            association_ingest_names.append('allele_allele_association_ingest_set')
+        else:
+            log.info('ADD_ALLELE_ALLELE_ASSOC not set to "YES"; omitting the "allele_allele_association_ingest_set".')
         # Print the output file.
         generate_export_file(association_export_dict, log, association_output_filename)
         # Per-association-set TSV files for easy curator review.
-        for ingest_name in ('allele_gene_association_ingest_set',
-                            'allele_construct_association_ingest_set'):
+        for ingest_name in association_ingest_names:
             set_name = ingest_name.replace('_ingest_set', '')
             assoc_tsv_filename = set_up_dict['output_filename'].replace('allele', set_name)
             assoc_tsv_filename = assoc_tsv_filename.replace('.tsv', '_associations.tsv')

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -384,6 +384,26 @@ class AlleleGeneAssociationDTO(AlleleGenomicEntityAssociationDTO):
         self.required_fields.extend(['gene_identifier'])
 
 
+class AlleleAlleleAssociationDTO(AlleleGenomicEntityAssociationDTO):
+    """AlleleAlleleAssociationDTO class."""
+    def __init__(self, allele_id: str, rel_type: str, object_allele_id: str, evidence_curies: list):
+        """Create AlleleAlleleAssociationDTO for FlyBase object.
+
+        Args:
+            allele_id (str): The FB:FBab curie for the aberration subject.
+            rel_type (str): A CV term: "carries" or "breakpoint_allele".
+            object_allele_id (str): The FB:FBal or FB:FBti curie for the allele object.
+            evidence_curies (list): A list of FB:FBrf or PMID:### curies.
+
+        """
+        super().__init__(evidence_curies)
+        self.allele_identifier = allele_id
+        self.relation_name = rel_type
+        self.object_allele_identifier = object_allele_id
+        self.evidence_curies = evidence_curies
+        self.required_fields.extend(['object_allele_identifier'])
+
+
 class ConstructGenomicEntityAssociationDTO(EvidenceAssociationDTO):
     """ConstructGenomicEntityAssociationDTO class."""
     def __init__(self, construct_id: str, rel_type: str, genomic_id: str, evidence_curies: list):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -332,9 +332,12 @@ class AlleleHandler(MetaAlleleHandler):
             filter(*filters).\
             distinct()
         for result in results:
-            allele_str = f'{result.allele.name} ({result.allele.uniquename})'
-            insertion_str = f'{result.insertion.name} ({result.insertion.uniquename})'
-            self.log.debug(f'The transgenic allele {allele_str} is related to the generic insertion {insertion_str}.')
+            # Only log the per-row detail for the test set: in a full run this is one line per
+            # FBal-FBti pair, which swamps the debug log (and builds the strings needlessly).
+            if self.testing:
+                allele_str = f'{result.allele.name} ({result.allele.uniquename})'
+                insertion_str = f'{result.insertion.name} ({result.insertion.uniquename})'
+                self.log.debug(f'The transgenic allele {allele_str} is related to the generic insertion {insertion_str}.')
             try:
                 self.transgenic_fbal_fbti_dict[result.allele.feature_id].append(result.insertion.feature_id)
             except KeyError:
@@ -434,7 +437,10 @@ class AlleleHandler(MetaAlleleHandler):
         except KeyError:
             self.log.warning(f'Could not find insertion feature_id={allele.superseded_by_at_locus_insertion}')
             return
-        self.log.debug(f'Merge {allele} data into {insertion} data.')
+        # Per-allele/per-attribute detail below is only logged for the test set: in a full run this is
+        # ~14 lines per superseded allele, which swamps the debug log.
+        if self.testing:
+            self.log.debug(f'Merge {allele} data into {insertion} data.')
         insertion.alt_fb_ids.append(f'FB:{allele.uniquename}')
         lists_to_extend = [
             'dbxrefs',
@@ -469,30 +475,36 @@ class AlleleHandler(MetaAlleleHandler):
         for attr_name in lists_to_extend:
             allele_list = getattr(allele, attr_name)
             insertion_list = getattr(insertion, attr_name)
-            self.log.debug(f'For {attr_name}, add {len(allele_list)} elements from the allele to {len(insertion_list)} elements from the insertion.')
+            if self.testing:
+                self.log.debug(f'For {attr_name}, add {len(allele_list)} elements from the allele to {len(insertion_list)} elements from the insertion.')
             insertion_list.extend(allele_list)
-            self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_list)} elements.')
+            if self.testing:
+                self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_list)} elements.')
         # Add to ID-keyed dict of single chado annotations (key is unique for FBCVtermAnnotation or FBRelationship).
         for attr_name in dicts_of_elements_to_add:
             allele_dict = getattr(allele, attr_name)
             insertion_dict = getattr(insertion, attr_name)
-            self.log.debug(f'For {attr_name}, add {len(allele_dict)} elements from the allele to {len(insertion_dict)} elements from the insertion.')
+            if self.testing:
+                self.log.debug(f'For {attr_name}, add {len(allele_dict)} elements from the allele to {len(insertion_dict)} elements from the insertion.')
             for k, v in allele_dict.items():
                 if k not in insertion_dict.keys():
                     insertion_dict[k] = v
-            self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_dict)} elements.')
+            if self.testing:
+                self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_dict)} elements.')
         # Combine lists of annotations.
         for attr_name in dicts_of_lists_to_add:
             allele_dict = getattr(allele, attr_name)
             insertion_dict = getattr(insertion, attr_name)
-            self.log.debug(f'For {attr_name}, add {len(allele_dict)} lists from the allele to {len(insertion_dict)} lists from the insertion.')
+            if self.testing:
+                self.log.debug(f'For {attr_name}, add {len(allele_dict)} lists from the allele to {len(insertion_dict)} lists from the insertion.')
             for k, v in allele_dict.items():
                 try:
                     insertion_dict[k].extend(v)
                 except KeyError:
                     insertion_dict[k] = []
                     insertion_dict[k].extend(v)
-            self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_dict)} lists.')
+            if self.testing:
+                self.log.debug(f'For {attr_name}, the insertion now has {len(insertion_dict)} lists.')
         return
 
     def merge_fbti_fbal(self):
@@ -505,17 +517,22 @@ class AlleleHandler(MetaAlleleHandler):
         classical_counter = 0
         fbti_counter = 0
         for allele in self.fb_data_entities.values():
-            self.log.debug(f'Assess FBti replacement for allele {allele}')
+            # Per-allele detail only for the test set: this loop covers every allele in the database.
+            # NB - the log.error() below is deliberately left ungated; it reports a real data problem.
+            if self.testing:
+                self.log.debug(f'Assess FBti replacement for allele {allele}')
             if allele.db_primary_id in self.at_locus_fbal_fbti_dict.keys() and allele.db_primary_id in self.transgenic_fbal_fbti_dict.keys():
                 self.log.error(f'Allele {allele} unexpectedly has both at-locus and transgenic unspecified FBti insertions.')
                 prob_counter += 1
             elif allele.db_primary_id in self.at_locus_fbal_fbti_dict.keys():
-                self.log.debug(f'Allele {allele} is superseded by an at-locus FBti insertion.')
+                if self.testing:
+                    self.log.debug(f'Allele {allele} is superseded by an at-locus FBti insertion.')
                 allele.superseded_by_at_locus_insertion = self.at_locus_fbal_fbti_dict[allele.db_primary_id][0]
                 self.add_fbal_to_fbti(allele)
                 at_locus_counter += 1
             elif allele.db_primary_id in self.transgenic_fbal_fbti_dict.keys():
-                self.log.debug(f'Allele {allele} is superseded by unspecified FBti insertion(s).')
+                if self.testing:
+                    self.log.debug(f'Allele {allele} is superseded by unspecified FBti insertion(s).')
                 allele.superseded_by_transgnc_insertions = self.transgenic_fbal_fbti_dict[allele.db_primary_id]
                 self.add_fbal_to_fbti(allele)
                 unspecified_ins_counter += len(allele.superseded_by_transgnc_insertions)
@@ -540,7 +557,9 @@ class AlleleHandler(MetaAlleleHandler):
         has_dmel_insertion_counter = 0
         has_non_dmel_insertion_counter = 0
         for allele in self.fb_data_entities.values():
-            self.log.debug(f'Assess {allele}, feature_id={allele.db_primary_id}')
+            # Per-allele detail only for the test set: this loop covers every allele in the database.
+            if self.testing:
+                self.log.debug(f'Assess {allele}, feature_id={allele.db_primary_id}')
             # Assess relationships to ARGs.
             relevant_rels = allele.recall_relationships(self.log, entity_role='object', rel_types='partof', rel_entity_types=self.feature_subtypes['variation'])
             # self.log.debug(f'For {allele}, found {len(relevant_rels)} partof relationships to ARGs.')
@@ -554,7 +573,8 @@ class AlleleHandler(MetaAlleleHandler):
             # Assess relationships to current constructs.
             relevant_cons_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types=['derived_tp_assoc_alleles', 'producedby'],
                                                              rel_entity_types=self.feature_subtypes['construct'])
-            self.log.debug(f'For {allele}, found {len(relevant_cons_rels)} cons rels to review.')
+            if self.testing:
+                self.log.debug(f'For {allele}, found {len(relevant_cons_rels)} cons rels to review.')
             for cons_rel in relevant_cons_rels:
                 construct = self.feature_lookup[cons_rel.chado_obj.object_id]
                 if construct['is_obsolete'] is False and construct['uniquename'].startswith('FBtp'):
@@ -595,7 +615,8 @@ class AlleleHandler(MetaAlleleHandler):
             # self.log.debug(f'Have these f_r sbj types: {allele.sbj_rel_ids_by_type.keys()}')
             # self.log.debug(f'Have these f_r obj types: {allele.obj_rel_ids_by_type.keys()}')
             relevant_rels = allele.recall_relationships(self.log, entity_role='subject', rel_types='alleleof', rel_entity_types='gene')
-            self.log.debug(f'For {allele}, found {len(relevant_rels)} alleleof relationships to genes.')
+            if self.testing:
+                self.log.debug(f'For {allele}, found {len(relevant_rels)} alleleof relationships to genes.')
             for allele_gene_rel in relevant_rels:
                 parent_gene = self.feature_lookup[allele_gene_rel.chado_obj.object_id]
                 if parent_gene['is_obsolete'] is False:
@@ -654,8 +675,9 @@ class AlleleHandler(MetaAlleleHandler):
             # For truly non-Dmel alleles, revert organism_id to that of the related allele chado object.
             if is_non_dmel_classical is True:
                 allele.organism_id = allele.chado_obj.organism_id
-                adj_org_abbr = self.organism_lookup[allele.organism_id]['abbreviation']
-                self.log.debug(f'Non-Dmel allele: id={allele.uniquename}, name={allele.name}, org_abbr={adj_org_abbr}')
+                if self.testing:
+                    adj_org_abbr = self.organism_lookup[allele.organism_id]['abbreviation']
+                    self.log.debug(f'Non-Dmel allele: id={allele.uniquename}, name={allele.name}, org_abbr={adj_org_abbr}')
                 counter += 1
         self.log.info(f'Adjusted organism to be "non-Dmel" for {counter} alleles.')
         return

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -19,7 +19,7 @@ from fb_datatypes import (
 )
 from feature_handler import FeatureHandler
 from harvdev_utils.reporting import (
-    Cvterm, Feature, FeatureGenotype, FeatureRelationship,
+    Cvterm, Feature, FeatureCvterm, FeatureGenotype, FeatureRelationship,
     Featureprop, Genotype, Phenotype, PhenotypeCvterm, Phenstatement, Pub
 )
 from utils import export_chado_data
@@ -1208,6 +1208,59 @@ class AberrationHandler(MetaAlleleHandler):
     chr_del_terms = []        # A list of cvterm_ids for child terms of "chromosomal_deletion" (SO:1000029).
 
     # Additional sub-methods for get_general_data().
+    def get_cassette_allele_ids(self, session):
+        """Get feature_ids of FBal alleles that are construct cassettes (FTA-218).
+
+        Cassette FBal features share the "allele" cvterm but are excluded from the allele export by the
+        AlleleHandler (see its self.ignore_list), so aberration-allele associations must not point at them.
+        NB - FeatureHandler.cassette_feature_ids() cannot be reused here: it resolves self.regex[self.datatype]
+        and self.feature_subtypes[self.datatype], which for this handler are the aberration values, so it would
+        return FBab features rather than cassette FBal features. It also restricts to self.test_set in testing
+        mode, which for this handler is a set of FBab IDs. This lookup is deliberately never limited to the
+        test set, since it is reference data used to validate partners, like the feature_lookup.
+        """
+        self.log.info('Get feature_ids of FBal alleles that are construct cassettes.')
+        cassette_ids = set()
+        # First, cassettes flagged with the "in vitro construct" CV term.
+        in_vitro_filters = (
+            Feature.is_obsolete.is_(False),
+            Feature.uniquename.op('~')(self.regex['allele']),
+            Cvterm.name == 'in vitro construct',
+        )
+        in_vitro_results = session.query(Feature.feature_id).\
+            select_from(Feature).\
+            join(FeatureCvterm, (FeatureCvterm.feature_id == Feature.feature_id)).\
+            join(Cvterm, (Cvterm.cvterm_id == FeatureCvterm.cvterm_id)).\
+            filter(*in_vitro_filters).\
+            distinct()
+        for result in in_vitro_results:
+            cassette_ids.add(result.feature_id)
+        self.log.info(f'Found {len(cassette_ids)} "in vitro construct" cassette FBal alleles.')
+        # Second, cassettes related to an FBtp construct.
+        construct = aliased(Feature, name='cassette_construct')
+        rel_type = aliased(Cvterm, name='cassette_rel_type')
+        feat_type = aliased(Cvterm, name='cassette_feat_type')
+        main_filters = (
+            Feature.is_obsolete.is_(False),
+            Feature.uniquename.op('~')(self.regex['allele']),
+            feat_type.name.in_((self.feature_subtypes['allele'])),
+            construct.is_obsolete.is_(False),
+            construct.uniquename.op('~')(self.regex['construct']),
+            rel_type.name == 'associated_with',
+        )
+        main_results = session.query(Feature.feature_id).\
+            select_from(Feature).\
+            join(feat_type, (feat_type.cvterm_id == Feature.type_id)).\
+            join(FeatureRelationship, (FeatureRelationship.subject_id == Feature.feature_id)).\
+            join(construct, (construct.feature_id == FeatureRelationship.object_id)).\
+            join(rel_type, (rel_type.cvterm_id == FeatureRelationship.type_id)).\
+            filter(*main_filters).\
+            distinct()
+        for result in main_results:
+            cassette_ids.add(result.feature_id)
+        self.log.info(f'Found {len(cassette_ids)} cassette FBal alleles in total.')
+        return cassette_ids
+
     def get_key_cvterm_sets_for_aberrations(self, session):
         """Get key CV term sets for aberrations from chado."""
         self.log.info('Get key CV term sets for aberrations from chado.')
@@ -1229,7 +1282,7 @@ class AberrationHandler(MetaAlleleHandler):
         # look up partner uniquenames. Gated so that production runs make no extra queries until the Alliance is ready.
         if getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES':
             self.build_feature_lookup(session, feature_types=['gene', 'allele', 'insertion'])
-            self.cassette_ignore_list = set(self.cassette_feature_ids(session))
+            self.cassette_ignore_list = self.get_cassette_allele_ids(session)
         else:
             self.build_feature_lookup(session, feature_types=['gene'])
             self.log.info('ADD_ALLELE_ALLELE_ASSOC not set to "YES"; not adding allele/insertion features to the '

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1174,6 +1174,8 @@ class AberrationHandler(MetaAlleleHandler):
         'FBab0010504': 'T(2;3)G16DTE35B-3P',    # Unusual annotation: assortment_derived_deficiency_plus_duplication (SO:0000801).
         'FBab0004789': 'In(2LR)Px[4]',          # FTA-207 note props: internal_notes, misc, new_order, origin_comment.
         'FBab0001546': 'Df(2L)Sco[rv10]',  # FTA-207 note props: complementation, internal_notes, misc, origin_comment.
+        'FBab0004410': 'In(2L)Cy',              # FTA-218: all 3 mappings - 2 A24a FBti, 6 A24b FBal, 1 GA10g FBal.
+        'FBab0045412': 'Df(3L)sina[SH]',        # FTA-218: all 3 mappings - 1 A24a FBti, 1 A24b FBal, 2 GA10g FBal.
     }
 
     # Simple mapping of props to Alliance note types, for cases where it is one-to-one correspondence.
@@ -1194,6 +1196,10 @@ class AberrationHandler(MetaAlleleHandler):
     # Additional export sets.
     aberration_gene_rels = {}            # Will be (FBab feature_id, FBgn feature_id, AGR_rel_type, ECO) tuples keying lists of FBRelationships.
     aberration_gene_associations = []    # Will be the final list of gene-aberration FBRelationships to export (AlleleGeneAssociationDTO under linkmldto attr).
+    # FTA-218: aberration-to-allele associations ("carries" and "breakpoint_allele").
+    aberration_allele_rels = {}          # Will be (FBab feature_id, FBal/FBti feature_id, AGR_rel_type) tuples keying lists of FBRelationships.
+    aberration_allele_associations = []  # Will be the final list of aberration-allele FBRelationships (AlleleAlleleAssociationDTO under linkmldto attr).
+    cassette_ignore_list = set()         # FTA-218: FBal feature_ids that are construct cassettes, and so are never exported as alleles.
 
     # Additional reference info.
     chr_str_var_terms = []    # A list of cvterm_ids for child terms of "chromosome_structure_variation" (SO:0000240).
@@ -1218,7 +1224,16 @@ class AberrationHandler(MetaAlleleHandler):
         self.build_bibliography(session)
         self.build_cvterm_lookup(session)
         self.build_organism_lookup(session)
-        self.build_feature_lookup(session, feature_types=['gene'])
+        # FTA-218: aberration-allele associations need FBal and FBti features in the feature_lookup, both so that
+        # get_entity_relationships() can bucket relationships by related feature type, and so that the map step can
+        # look up partner uniquenames. Gated so that production runs make no extra queries until the Alliance is ready.
+        if getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES':
+            self.build_feature_lookup(session, feature_types=['gene', 'allele', 'insertion'])
+            self.cassette_ignore_list = set(self.cassette_feature_ids(session))
+        else:
+            self.build_feature_lookup(session, feature_types=['gene'])
+            self.log.info('ADD_ALLELE_ALLELE_ASSOC not set to "YES"; not adding allele/insertion features to the '
+                          'feature_lookup (no aberration-allele associations will be emitted).')
         self.build_allele_gene_lookup(session)
         self.get_key_cvterm_sets_for_aberrations(session)
         return
@@ -1365,6 +1380,61 @@ class AberrationHandler(MetaAlleleHandler):
         self.log.info(f'Found {gene_rel_counter} aberration-gene relationships for {aberration_counter} aberrations.')
         return
 
+    def synthesize_aberration_allele_associations(self):
+        """Synthesize aberration-to-allele associations (FTA-218).
+
+        Three chado feature_relationships map onto two Alliance allele-allele association relations. In every case the
+        Alliance direction is FBab (subject) -> FBti/FBal (object), so the "carried_on" relationship below has to be
+        flipped relative to how it is stored in chado.
+            1. type="associated_with", subject=FBab, object=FBti (proforma A24a) -> "carries"
+            2. type="carried_on",      subject=FBal, object=FBab (proforma A24b) -> "carries"
+            3. type="associated_with", subject=FBab, object=FBal (proforma GA10g) -> "breakpoint_allele"
+        """
+        self.log.info('Synthesize aberration-to-allele associations.')
+        # Each entry is (entity_role of the aberration, chado rel type, related feature types, AGR relation).
+        # The partner feature_id is read from the side of the relationship that the aberration is NOT on.
+        rel_specs = [
+            ('subject', 'associated_with', self.feature_subtypes['insertion'], 'carries'),
+            ('subject', 'associated_with', self.feature_subtypes['allele'], 'breakpoint_allele'),
+            ('object', 'carried_on', self.feature_subtypes['allele'], 'carries'),
+        ]
+        # When the aberration is the subject the partner is the object, and vice versa.
+        partner_attr = {'subject': 'object_id', 'object': 'subject_id'}
+        aberration_counter = 0
+        allele_rel_counter = 0
+        cassette_skipped = 0
+        rel_type_tally = {}
+        for aberration in self.fb_data_entities.values():
+            found_any = False
+            for entity_role, fb_rel_type, rel_entity_types, agr_rel_type in rel_specs:
+                relevant_rels = aberration.recall_relationships(self.log, entity_role=entity_role, rel_types=fb_rel_type,
+                                                                rel_entity_types=rel_entity_types)
+                for feat_rel in relevant_rels:
+                    partner_id = getattr(feat_rel.chado_obj, partner_attr[entity_role])
+                    # Cassettes are FBal features sharing the "allele" cvterm, but they are never exported as alleles,
+                    # so an association pointing at one would dangle at the Alliance.
+                    if partner_id in self.cassette_ignore_list:
+                        cassette_skipped += 1
+                        continue
+                    found_any = True
+                    rel_key = (aberration.db_primary_id, partner_id, agr_rel_type)
+                    try:
+                        self.aberration_allele_rels[rel_key].append(feat_rel)
+                    except KeyError:
+                        self.aberration_allele_rels[rel_key] = [feat_rel]
+                        allele_rel_counter += 1
+                        try:
+                            rel_type_tally[agr_rel_type] += 1
+                        except KeyError:
+                            rel_type_tally[agr_rel_type] = 1
+            if found_any:
+                aberration_counter += 1
+        self.log.info(f'Found {allele_rel_counter} aberration-allele relationships for {aberration_counter} aberrations.')
+        for agr_rel_type in sorted(rel_type_tally.keys()):
+            self.log.info(f'Found {rel_type_tally[agr_rel_type]} aberration-allele relationships of type "{agr_rel_type}".')
+        self.log.info(f'Skipped {cassette_skipped} aberration-allele relationships to cassette FBal features.')
+        return
+
     # Elaborate on synthesize_info() for the AberrationHandler.
     def synthesize_info(self):
         """Extend the method for the AberrationHandler."""
@@ -1377,6 +1447,12 @@ class AberrationHandler(MetaAlleleHandler):
         self.synthesize_ncbi_taxon_id()
         self.flag_deletions()
         self.synthesize_aberration_gene_associations()
+        # FTA-218: gated until the Alliance schema has an "allele_allele_association_ingest_set" and the
+        # "carries"/"breakpoint_allele" CV terms.
+        if getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES':
+            self.synthesize_aberration_allele_associations()
+        else:
+            self.log.info('ADD_ALLELE_ALLELE_ASSOC not set to "YES"; skipping aberration-allele association synthesis.')
         self.qc_aberration_mutation_types()
         return
 
@@ -1434,6 +1510,40 @@ class AberrationHandler(MetaAlleleHandler):
         self.log.info(f'Generated {counter} aberration-gene unique associations.')
         return
 
+    def map_aberration_allele_associations(self):
+        """Map aberration-allele associations to Alliance object (FTA-218)."""
+        self.log.info('Map aberration-allele associations to Alliance object.')
+        ABERRATION_ID = 0
+        PARTNER_ID = 1
+        REL_TYPE_NAME = 2
+        counter = 0
+        obsolete_counter = 0
+        for rel_key, aberration_allele_rels in self.aberration_allele_rels.items():
+            aberration = self.fb_data_entities[rel_key[ABERRATION_ID]]
+            aberration_curie = f'FB:{aberration.uniquename}'
+            partner = self.feature_lookup[rel_key[PARTNER_ID]]
+            partner_curie = f'FB:{partner["uniquename"]}'
+            agr_rel_type_name = rel_key[REL_TYPE_NAME]
+            all_pub_ids = []
+            for aberration_allele_rel in aberration_allele_rels:
+                all_pub_ids.extend(aberration_allele_rel.pubs)
+            pub_curies = self.lookup_pub_curies(all_pub_ids)
+            rel_dto = agr_datatypes.AlleleAlleleAssociationDTO(aberration_curie, agr_rel_type_name, partner_curie, pub_curies)
+            # An FBal superseded by an FBti insertion is marked obsolete by the AlleleHandler's merge_fbti_fbal(), so
+            # some partners here are obsolete alleles. Follow the aberration-gene precedent and report these as internal.
+            if aberration.is_obsolete is True or partner['is_obsolete'] is True:
+                rel_dto.obsolete = True
+                rel_dto.internal = True
+                obsolete_counter += 1
+            first_feat_rel = aberration_allele_rels[0]
+            first_feat_rel.pubs = all_pub_ids
+            first_feat_rel.linkmldto = rel_dto
+            self.aberration_allele_associations.append(first_feat_rel)
+            counter += 1
+        self.log.info(f'Generated {counter} aberration-allele unique associations.')
+        self.log.info(f'Of these, {obsolete_counter} involve an obsolete aberration or allele, and are flagged internal.')
+        return
+
     # Elaborate on map_fb_data_to_alliance() for the AberrationHandler.
     def map_fb_data_to_alliance(self):
         """Extend the method for the AberrationHandler."""
@@ -1454,6 +1564,13 @@ class AberrationHandler(MetaAlleleHandler):
         self.map_secondary_ids('allele_secondary_id_dtos')
         self.flag_internal_fb_entities('fb_data_entities')
         # self.flag_internal_fb_entities('aberration_gene_associations')
+        # FTA-218: gated until the Alliance schema has an "allele_allele_association_ingest_set" and the
+        # "carries"/"breakpoint_allele" CV terms.
+        if getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES':
+            self.map_aberration_allele_associations()
+            self.flag_internal_fb_entities('aberration_allele_associations')
+        else:
+            self.log.info('ADD_ALLELE_ALLELE_ASSOC not set to "YES"; skipping aberration-allele association mapping.')
         return
 
     # Elaborate on query_chado_and_export() for the AberrationHandler.
@@ -1462,6 +1579,14 @@ class AberrationHandler(MetaAlleleHandler):
         super().query_chado_and_export(session)
         self.flag_unexportable_entities(self.aberration_gene_associations, 'allele_gene_association_ingest_set')
         self.generate_export_dict(self.aberration_gene_associations, 'allele_gene_association_ingest_set')
+        # FTA-218: gated until the Alliance schema has an "allele_allele_association_ingest_set" and the
+        # "carries"/"breakpoint_allele" CV terms. When the gate is off, no such key is added to self.export_data.
+        if getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES':
+            self.flag_unexportable_entities(self.aberration_allele_associations, 'allele_allele_association_ingest_set')
+            self.generate_export_dict(self.aberration_allele_associations, 'allele_allele_association_ingest_set')
+        else:
+            self.log.info('ADD_ALLELE_ALLELE_ASSOC not set to "YES"; not exporting an '
+                          '"allele_allele_association_ingest_set".')
         return
 
 

--- a/src/curation_tsv.py
+++ b/src/curation_tsv.py
@@ -29,7 +29,7 @@ GENE_CHANGE_EVENTS_TSV_HEADER = (
 SKIPPED_IDENTITY_SOURCE_TSV_HEADER = (
     "# Primary FBid\traw_value\ttoken_count\tinternal\tobsolete\n"
 )
-NOTE_CLEAN_FAILURES_TSV_HEADER = "# Primary FBid\traw_value\terror\n"
+NOTE_CLEAN_FAILURES_TSV_HEADER = "# Primary FBid\tprop_type\tprop_id\traw_value\terror\n"
 COMPONENTS_TSV_HEADER = "# Primary FBid\tsymbol\trelation\ttaxon\tevidence\n"
 # NB: existing tool_uses TSVs write rows as primary, tools, evidence; the
 # header preserves that historic column order verbatim.
@@ -153,17 +153,21 @@ def write_skipped_identity_source_tsv(*, filename, skipped):
 
 
 def write_note_clean_failures_tsv(*, filename, failures):
-    """Write the diagnostic TSV of internal_notes whose text failed clean_free_text (FTA-211).
+    """Write the diagnostic TSV of note props whose text could not be cleaned (FTA-211, FTA-221).
 
-    One row per failed note: the raw featureprop value (tabs/newlines flattened) and the
-    exception, so curators can see the offending characters (e.g. an unknown SGML entity
-    like "&3;"). Not filtered by should_skip_obsolete().
+    One row per failed note: the prop type and prop table primary key that identify the offending
+    row, the raw value (tabs/newlines flattened), and the reason. The prop type tells a curator
+    which field to fix; the prop_id pins down which row when the value is NULL or blank and there
+    is therefore no text to recognise it by. Not filtered by should_skip_obsolete().
+
+    NB - prop_type/prop_id are read with .get() because callers that predate FTA-221
+    (construct_handler, cassette_handler) do not supply them.
     """
     with open(filename, 'w') as outfile:
         outfile.write(NOTE_CLEAN_FAILURES_TSV_HEADER)
         for item in failures:
-            raw = item['raw_value'].replace('\t', ' ').replace('\n', ' ')
-            outfile.write(f"{item['fb_id']}\t{raw}\t{item['error']}\n")
+            raw = str(item.get('raw_value', '')).replace('\t', ' ').replace('\n', ' ')
+            outfile.write(f"{item['fb_id']}\t{item.get('prop_type', '')}\t{item.get('prop_id', '')}\t{raw}\t{item['error']}\n")
 
 
 def write_components_tsv(*, filename, entities, datatype):

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -52,7 +52,7 @@ class PrimaryEntityHandler(DataHandler):
         self.ignore_list = []
         self.internal_note_clean_failures = []    # FTA-211/FTA-221: note props whose text could not be cleaned.
 
-    def clean_note_free_text(self, fb_id, raw_value):
+    def clean_note_free_text(self, fb_id, raw_value, prop_type=None, prop_id=None):
         """Clean note free text, tolerating NULL values and unknown SGML entities (FTA-211, FTA-221).
 
         Two ways the raw featureprop value breaks clean_free_text():
@@ -63,18 +63,34 @@ class PrimaryEntityHandler(DataHandler):
         Either way, record the offender for the diagnostic report rather than aborting the export.
         Returns None for a value with no usable text, so callers can skip it.
 
+        Args:
+            fb_id (str): The FB curie of the entity owning the prop, e.g. "FB:FBal0050505".
+            raw_value: The raw prop value, which may be None.
+            prop_type (str): The cvterm.name of the prop, so curators know which field to fix.
+            prop_id (int): The prop table primary key, to pin down which row when the value is
+                blank and there is therefore no text to identify it by.
+
         NB - raw_value is coerced to a string in the failure record, because
         curation_tsv.write_note_clean_failures_tsv() calls .replace() on it.
         """
-        if raw_value is None or not str(raw_value).strip():
-            self.internal_note_clean_failures.append(
-                {'fb_id': fb_id, 'raw_value': '', 'error': 'featureprop.value is NULL or blank; note skipped'})
+        def record(raw, error):
+            self.internal_note_clean_failures.append({
+                'fb_id': fb_id,
+                'prop_type': prop_type if prop_type is not None else '',
+                'prop_id': prop_id if prop_id is not None else '',
+                'raw_value': raw,
+                'error': error,
+            })
+        if raw_value is None:
+            record('', 'prop value is NULL; note skipped')
+            return None
+        if not str(raw_value).strip():
+            record('', 'prop value is blank/whitespace-only; note skipped')
             return None
         try:
             return clean_free_text(raw_value)
         except Exception as error:
-            self.internal_note_clean_failures.append(
-                {'fb_id': fb_id, 'raw_value': str(raw_value), 'error': str(error)})
+            record(str(raw_value), str(error))
             return raw_value
 
     # Conversion of FB datatype to "page_area".
@@ -1312,8 +1328,14 @@ class PrimaryEntityHandler(DataHandler):
         prop_list = fb_entity.props_by_type[fb_prop_type]
         for fb_prop in prop_list:
             # FTA-221: tolerate NULL/blank and uncleanable values instead of aborting the whole export.
-            # A prop with no usable text yields no note, so skip it.
-            free_text = self.clean_note_free_text(fb_entity.uniquename, fb_prop.chado_obj.value)
+            # A prop with no usable text yields no note, so skip it. Report the prop type and the prop
+            # table primary key, so a curator can find the exact row to fix; a blank value has no text
+            # to identify it by. props_by_type can hold Featureprop, Strainprop, Genotypeprop, etc., so
+            # derive the pkey attribute from the mapped table name (as FBRelationship does).
+            prop_table = getattr(type(fb_prop.chado_obj), '__tablename__', None)
+            prop_id = getattr(fb_prop.chado_obj, f'{prop_table}_id', None) if prop_table else None
+            free_text = self.clean_note_free_text(f'FB:{fb_entity.uniquename}', fb_prop.chado_obj.value,
+                                                  prop_type=fb_prop_type, prop_id=prop_id)
             if free_text is None:
                 continue
             if free_text not in text_keyed_props.keys():
@@ -1356,8 +1378,15 @@ class PrimaryEntityHandler(DataHandler):
         new_failures = self.internal_note_clean_failures[failures_before:]
         if new_failures:
             self.log.warning(f'Skipped or kept unmodified {len(new_failures)} "{self.datatype}" note props that could not be cleaned.')
+            type_tally = {}
+            for failure in new_failures:
+                key = f'{failure["prop_type"]}: {failure["error"]}'
+                type_tally[key] = type_tally.get(key, 0) + 1
+            for key in sorted(type_tally.keys()):
+                self.log.warning(f'Uncleanable note props - {key} ({type_tally[key]} of them).')
             for failure in new_failures[:20]:
-                self.log.warning(f'Uncleanable note prop: fb_id={failure["fb_id"]}, error={failure["error"]}')
+                self.log.warning(f'Uncleanable note prop: fb_id={failure["fb_id"]}, '
+                                 f'prop_type={failure["prop_type"]}, prop_id={failure["prop_id"]}, error={failure["error"]}')
             if len(new_failures) > 20:
-                self.log.warning(f'...and {len(new_failures) - 20} more (see the diagnostic TSV where the script emits one).')
+                self.log.warning(f'...and {len(new_failures) - 20} more; see the *_internal_note_clean_failures.tsv for the full list.')
         return


### PR DESCRIPTION
Closes [FTA-218](https://flybase.atlassian.net/browse/FTA-218). Also carries a follow-up to [FTA-221](https://flybase.atlassian.net/browse/FTA-221) — see [Scope](#scope) below.

**Safe to merge with the gate off.** All FTA-218 code sits behind `ADD_ALLELE_ALLELE_ASSOC=YES`, which is not set in the GoCD pipeline. Merging changes nothing about production output; the feature lies dormant until the Alliance can accept the data. See [Do not enable yet](#do-not-enable-yet).

## What it does

FB aberrations (FBab) are submitted to the Alliance using the allele LinkML model. Three chado `feature_relationship` types map onto two Alliance allele-allele relations, with FBab always the subject — per the ticket and Gillian's confirmation that "bigger thing = subject" matches the construct → cassette → component convention.

| chado | proforma | rows in `fb_2026_02` | Alliance relation |
|---|---|---|---|
| `associated_with`, FBab → FBti | A24a | 4,441 | `carries` |
| `carried_on`, FBal → FBab | A24b | 990 | `carries` (direction flipped) |
| `associated_with`, FBab → FBal | GA10g | 4,042 | `breakpoint_allele` |

Counts came from querying `fb_2026_02_reporting_audit` directly rather than trusting the transcribed Field Mapping Table. Two findings shaped the implementation: FBti partners arrive as **two** feature subtypes (`transposable_element_insertion_site` 4,200 and `insertion_site` 241), so the code keys off `feature_subtypes['insertion']` rather than a single cvterm; and there are **zero** `associated_with` rows with FBab as object, so the two `associated_with` mappings are separated unambiguously by object feature type.

## The gate

Every entry point is behind `getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES'`, including the data-gathering step — so with it unset there are no extra chado queries, no new `export_data` key, and no new output file:

| location | gated step |
|---|---|
| `allele_handlers.py:1283` | `build_feature_lookup` extension + cassette lookup |
| `allele_handlers.py:1505` | `synthesize_aberration_allele_associations()` |
| `allele_handlers.py:1622` | `map_aberration_allele_associations()` |
| `allele_handlers.py:1637` | `generate_export_dict(...)` |
| `AGR_data_retrieval_curation_allele.py:179` | ingest set + TSV emission |

Follows the existing `ADD_CASS_TO_CONSTRUCT` pattern, which exists for exactly this reason.

## Implementation notes

- **No new relationship query was needed.** `AberrationHandler.get_datatype_data` already calls `get_entity_relationships` for both roles unfiltered. The actual enabler was extending `build_feature_lookup` to `['gene', 'allele', 'insertion']` — without the partners in `feature_lookup`, `get_entity_relationships` silently drops them from its by-feature-type buckets and `recall_relationships(rel_entity_types=...)` finds nothing.
- **Cassette FBal are skipped** (`get_cassette_allele_ids`). They share the `allele` cvterm but are never exported as alleles, so an association pointing at one would dangle. The first attempt reused `FeatureHandler.cassette_feature_ids()`, which resolves `self.regex[self.datatype]` and therefore returned **FBab** features under this handler — fixed in `bc38a82` with an explicit, datatype-independent query. Measured impact: 2 partners, both `in vitro construct`.
- **Obsolete partners are flagged internal**, following the `map_aberration_gene_associations` precedent. Measured: 20/187 A24b and 165/4,039 GA10g partners are superseded by an FBti, so ~185 rows (~4.5%) come out internal. Substituting the replacement FBti curie instead would require plumbing `at_locus_fbal_fbti_dict` over from `AlleleHandler`.
- **Scoped to FBab only**, matching the ticket wording. `BalancerHandler` is untouched and still disabled in the driver.
- **Test set**: added `FBab0004410` (In(2L)Cy) and `FBab0045412` (Df(3L)sina[SH]) — only 4 aberrations in the whole database have all three relationship types, and these are the richest. Note the previous test set exercised **none** of the `carries` paths, so a testing-mode run would have produced zero `carries` associations and looked fine.

## Scope

Three changesets, at the maintainer's request rather than as separate PRs:

**FTA-218 (gated, inert):** `agr_datatypes.py`, `allele_handlers.py`, and the gated block in `AGR_data_retrieval_curation_allele.py`.

**FTA-221 follow-up (ungated — runs on every export):** `entity_handler.py`, `curation_tsv.py`, and the new TSV emission in the allele script. This makes the note-clean diagnostic report *which* prop was blank, not just which entity — the record previously couldn't distinguish `internal_notes` from `misc` from `origin_type`. Adds `prop_type` and the prop-table primary key (needed because a blank value has no text to recognise the row by), splits NULL from blank, normalises `fb_id` to the `FB:` prefix, and emits `*_internal_note_clean_failures.tsv` from the allele script.

**Debug logging (`6cd5ccd`, no ticket):** `allele_handlers.py` only. Several `log.debug()` calls in `AlleleHandler` fired once per allele — or ~14 times per superseded allele — across the whole database rather than just the test set, making debug-level runs unusable. Guarded with `if self.testing:`, matching the pattern already used in `get_fbal_fbti_replacements`. Locals built purely to be logged (display strings, `len()` calls, `adj_org_abbr`) moved inside the guards, so a full run no longer builds strings it discards.

All `log.warning()` and `log.error()` calls are deliberately untouched — including the "unexpectedly has both at-locus and transgenic FBti insertions" error, which reports real data corruption and must surface in a full run. Four `log.debug()` calls in `AberrationHandler` are also left as-is: they are aberration-scale rather than allele-scale. No functional change; only logging and the locals feeding it.

⚠️ **Reviewers: the FTA-221 part is the higher-risk half.** `convert_prop_to_note` lives on `PrimaryEntityHandler`, so it is shared by every handler and datatype — gene, allele, construct, cassette, agm. `curation_tsv.py` also widens that TSV by two columns for the construct and cassette scripts; new columns are read with `.get()` so their existing records still write, with the columns empty. Nothing is known to parse those files positionally.

## Verification

Done:
- [x] Chado mapping and row counts verified by direct query
- [x] Cassette and superseded-partner exposure quantified by query (see above)
- [x] All five gate points confirmed by inspection
- [x] flake8 clean with the project `.flake8` config
- [x] FTA-221 follow-up unit-tested without a database: NULL / blank / bad-SGML props each yield a record with the right `prop_type` and `prop_id`; the TSV writes both new-style and legacy (no `prop_type`) records; `convert_prop_to_note` given `[NULL, 'real text', NULL]` returns one note instead of raising

Not done — **no full export run has been completed against a database**:
- [ ] Gate-off run byte-identical to a pre-change baseline
- [ ] Gate-on run: relation names, curie prefixes, direction flip, internal counts
- [ ] Every `object_allele_identifier` present as a `primary_external_id` in the same run's `allele_ingest_set`
- [ ] The ungated FTA-221 code exercised by a real export

Local verification was defeated by [FTA-220](https://flybase.atlassian.net/browse/FTA-220): `build_cvterm_lookup` triggers ~316k single-row lazy loads, which measured at ~90 round trips/sec over a port-forward — projecting to ~58 minutes for that one step. Negligible in production, prohibitive remotely. A server-side run remains the way to close these out.

## Do not enable yet

`AlleleAlleleAssociationDTO` exists in `agr_curation_schema/model/schema/allele.yaml` but is an **orphan class**: there is no `allele_allele_association_ingest_set` in `ingest.yaml` on `main` or on release `v2.17.0`, nothing references the DTO as a `range`, the CV `'Allele Allele Association Relation'` has no `carries` or `breakpoint_allele` terms, and `agr_curation` (`alpha`) has no `AlleleAlleleAssociation` entity, DAO, service, validator, bulk-load wiring, or table.

So setting `ADD_ALLELE_ALLELE_ASSOC=YES` before the Alliance side lands will produce a file that fails schema validation — and the driver raises `ValueError` if the new set comes out empty. Documented in the script's `--help` epilog and on FTA-218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FTA-218]: https://flybase.atlassian.net/browse/FTA-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-221]: https://flybase.atlassian.net/browse/FTA-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-220]: https://flybase.atlassian.net/browse/FTA-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
