### PR TITLE
fix(FTA-221): tolerate NULL featureprop values in note mapping

### DIFF
--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -50,6 +50,32 @@ class PrimaryEntityHandler(DataHandler):
         """Create the generic PrimaryEntityHandler object."""
         super().__init__(log, testing)
         self.ignore_list = []
+        self.internal_note_clean_failures = []    # FTA-211/FTA-221: note props whose text could not be cleaned.
+
+    def clean_note_free_text(self, fb_id, raw_value):
+        """Clean note free text, tolerating NULL values and unknown SGML entities (FTA-211, FTA-221).
+
+        Two ways the raw featureprop value breaks clean_free_text():
+          - FTA-221: chado allows featureprop.value to be NULL, and clean_free_text() calls
+            .replace() on it, raising AttributeError on None.
+          - FTA-211: clean_free_text() raises KeyError on any &word; token not in harvdev_utils'
+            Greek dict (e.g. the junk "&3;").
+        Either way, record the offender for the diagnostic report rather than aborting the export.
+        Returns None for a value with no usable text, so callers can skip it.
+
+        NB - raw_value is coerced to a string in the failure record, because
+        curation_tsv.write_note_clean_failures_tsv() calls .replace() on it.
+        """
+        if raw_value is None or not str(raw_value).strip():
+            self.internal_note_clean_failures.append(
+                {'fb_id': fb_id, 'raw_value': '', 'error': 'featureprop.value is NULL or blank; note skipped'})
+            return None
+        try:
+            return clean_free_text(raw_value)
+        except Exception as error:
+            self.internal_note_clean_failures.append(
+                {'fb_id': fb_id, 'raw_value': str(raw_value), 'error': str(error)})
+            return raw_value
 
     # Conversion of FB datatype to "page_area".
     page_area_conversion = {
@@ -1285,7 +1311,11 @@ class PrimaryEntityHandler(DataHandler):
             return note_dtos
         prop_list = fb_entity.props_by_type[fb_prop_type]
         for fb_prop in prop_list:
-            free_text = clean_free_text(fb_prop.chado_obj.value)
+            # FTA-221: tolerate NULL/blank and uncleanable values instead of aborting the whole export.
+            # A prop with no usable text yields no note, so skip it.
+            free_text = self.clean_note_free_text(fb_entity.uniquename, fb_prop.chado_obj.value)
+            if free_text is None:
+                continue
             if free_text not in text_keyed_props.keys():
                 text_keyed_props[free_text] = []
             text_keyed_props[free_text].extend(fb_prop.pubs)
@@ -1304,6 +1334,7 @@ class PrimaryEntityHandler(DataHandler):
         NOTE_TYPE_NAME = 0
         NOTE_SLOT_NAME = 1
         mapping_dict = getattr(self, mapping_dict_name)
+        failures_before = len(self.internal_note_clean_failures)
         for fb_prop_type, note_specs in mapping_dict.items():
             entity_counter = 0
             prop_counter = 0
@@ -1320,4 +1351,13 @@ class PrimaryEntityHandler(DataHandler):
                     entity_counter += 1
                 prop_counter += len(agr_notes)
             self.log.info(f'For "{fb_prop_type}", mapped {prop_counter} props for {entity_counter} {self.datatype}s.')
+        # FTA-221: surface uncleanable note props in the log. Without this the failures are collected
+        # and never reported, since only the construct and cassette scripts emit the diagnostic TSV.
+        new_failures = self.internal_note_clean_failures[failures_before:]
+        if new_failures:
+            self.log.warning(f'Skipped or kept unmodified {len(new_failures)} "{self.datatype}" note props that could not be cleaned.')
+            for failure in new_failures[:20]:
+                self.log.warning(f'Uncleanable note prop: fb_id={failure["fb_id"]}, error={failure["error"]}')
+            if len(new_failures) > 20:
+                self.log.warning(f'...and {len(new_failures) - 20} more (see the diagnostic TSV where the script emits one).')
         return

--- a/src/feature_handler.py
+++ b/src/feature_handler.py
@@ -13,7 +13,6 @@ Author(s):
 
 from logging import Logger
 from sqlalchemy.orm import aliased
-from harvdev_utils.char_conversions import clean_free_text
 from harvdev_utils.reporting import (
     Cvterm, Db, Dbxref, Featureloc, Feature, FeatureDbxref, FeatureRelationship,
     FeatureCvterm, Library, LibraryFeature, LibraryFeatureprop
@@ -27,21 +26,9 @@ class FeatureHandler(PrimaryEntityHandler):
     def __init__(self, log: Logger, testing: bool):
         """Create the FeatureHandler object."""
         super().__init__(log, testing)
-        self.internal_note_clean_failures = []    # FTA-211: internal_notes whose text failed clean_free_text.
 
-    def clean_note_free_text(self, fb_id, raw_value):
-        """Clean internal-note free text, tolerating unknown SGML entities (FTA-211).
-
-        clean_free_text() raises KeyError on any &word; token not in harvdev_utils'
-        Greek dict (e.g. the junk "&3;"). On failure we strip &word; tokens and retry
-        leniently, keep the note, and record the raw value for the diagnostic report.
-        """
-        try:
-            return clean_free_text(raw_value)
-        except Exception as error:
-            self.internal_note_clean_failures.append(
-                {'fb_id': fb_id, 'raw_value': raw_value, 'error': str(error)})
-            return raw_value
+    # NB - clean_note_free_text() and internal_note_clean_failures moved up to PrimaryEntityHandler (FTA-221),
+    # so that convert_prop_to_note() can use them for every primary entity type, not just features.
 
     # Add methods to be run by get_general_data() below.
     # Placeholder.


### PR DESCRIPTION
Closes [FTA-221](https://flybase.atlassian.net/browse/FTA-221).

A NULL `featureprop.value` aborts the **entire allele export** after ~1h17m of work. `clean_free_text()` calls `.replace()` on whatever it is given, so one NULL-valued prop of any type in `allele_prop_to_note_mapping` raises `AttributeError` and takes the whole script down.

```
File "/src/entity_handler.py", line 1288, in convert_prop_to_note
    free_text = clean_free_text(fb_prop.chado_obj.value)
  File ".../harvdev_utils/char_conversions/clean_free_text.py", line 38, in clean_free_text
    cleaned_string = cleaned_string.replace('\n', ' ')
AttributeError: 'NoneType' object has no attribute 'replace'
```

## Why FTA-211 didn't already cover this

FTA-211 (`c7c1224`) added a tolerant `clean_note_free_text()` wrapper for exactly this class of problem, but:

- it was placed on `FeatureHandler`, while the failing `convert_prop_to_note()` lives on its **parent** `PrimaryEntityHandler`; and
- it was only wired into the construct and cassette `internal_notes` call sites.

So the allele/insertion/aberration note path added by FTA-207 still called bare `clean_free_text()` and had no protection — against NULL values *or* against FTA-211's own bad-SGML case. That second gap is fixed here too.

## Changes

- **`entity_handler.py`** — move `clean_note_free_text()` and `internal_note_clean_failures` up to `PrimaryEntityHandler` so every primary entity type is covered. Treat NULL/blank as "no usable text": return `None`, record the offender, and have `convert_prop_to_note()` skip the prop rather than emit an empty note.
- **`entity_handler.py`** — coerce `raw_value` to `str` in the failure record. The old code stored `None`, which would then crash `curation_tsv.write_note_clean_failures_tsv()` because that calls `.replace()` on it. A latent second bug on the same path.
- **`entity_handler.py`** — log a warning summary of uncleanable props in `map_entity_props_to_notes()`. Only the construct and cassette scripts emit the diagnostic TSV, so without this the allele failures would be collected and never surfaced.
- **`feature_handler.py`** — drop the moved members and the now-unused `clean_free_text` import. Existing construct/cassette call sites keep working unchanged via inheritance.

Behaviour for non-NULL values is unchanged, including FTA-211's keep-the-note-unmodified-on-`KeyError` path.

## Verification

Unit-tested without a database:

| input | result |
|---|---|
| `None` | `None`, recorded |
| `'   '` / `''` | `None`, recorded |
| `'a note\nwith newline'` | cleaned to `'a note with newline'` |
| `'junk &3; here'` | kept unmodified, recorded (FTA-211 behaviour preserved) |

Plus: `convert_prop_to_note()` given `[NULL, 'real text', NULL]` returns exactly one note instead of raising — the reproduction of the production crash. And `write_note_clean_failures_tsv()` writes all resulting records without error.

- [x] flake8 clean with the project `.flake8` config
- [ ] Full allele export run confirming the pipeline completes — **not yet done**

## Note

This blocks #92 (FTA-218) verification, since `AlleleHandler` runs before `AberrationHandler` and takes the script down first. Raised as a standalone PR off `main` rather than folded into that branch, because it's an unrelated production-blocking fix that should ship on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FTA-221]: https://flybase.atlassian.net/browse/FTA-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ