### PR TITLE
feat(FTA-217): flag FBab entities with the is_aberration boolean

### DIFF
--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -63,6 +63,8 @@ Environment variables:
   SERVER              Database server (e.g. flysql25)
   DATABASE            Database name (e.g. production_chado)
   ADD_OBSOLETE        Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
+  ADD_IS_ABERRATION   Set to 'YES' to emit the 'is_aberration' boolean for FBab entities.
+                      Requires a LinkML release containing the slot (absent from v2.17.0).
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -39,6 +39,25 @@ _ALLELE_ASSOC_SECOND_FIELDS = {
 _ALLELE_ASSOC_EXTRAS = [('internal', 'internal', False)]
 
 
+def _is_aberration_cell(entity_dict):
+    """Return 'true' for FBab aberrations, else '' (FTA-217).
+
+    Derived from the primary ID rather than read from the exported 'is_aberration' key so that the
+    curator TSV is populated even when ADD_IS_ABERRATION is unset. That env var gates the JSON only,
+    to protect Alliance schema validation; it says nothing about which entities are aberrations. The
+    two can never disagree: FTA-217 defines an aberration as an entry whose primary ID starts 'FBab'.
+    """
+    return 'true' if entity_dict.get('primary_external_id', '').startswith('FB:FBab') else ''
+
+
+# Allele primary TSV carries the FTA-217 aberration flags for curator review.
+# 'is_balancer' is read straight from the DTO slot and stays blank until something populates it.
+_ALLELE_PRIMARY_EXTRAS = [
+    ('is_aberration', _is_aberration_cell, ''),
+    ('is_balancer', 'is_balancer', ''),
+]
+
+
 # Data types handled by this script.
 REPORT_LABEL = 'allele_curation'
 
@@ -136,6 +155,7 @@ def main():
         entities = export_dict['allele_ingest_set']
         curation_tsv.write_primary_tsv(
             log=log, filename=tsv_filename, entities=entities, datatype='allele',
+            extra_fields=_ALLELE_PRIMARY_EXTRAS,
         )
         curation_tsv.write_notes_tsv(
             filename=tsv_filename.replace('.tsv', '_notes.tsv'), entities=entities,

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -50,11 +50,9 @@ def _is_aberration_cell(entity_dict):
     return 'true' if entity_dict.get('primary_external_id', '').startswith('FB:FBab') else ''
 
 
-# Allele primary TSV carries the FTA-217 aberration flags for curator review.
-# 'is_balancer' is read straight from the DTO slot and stays blank until something populates it.
+# Allele primary TSV carries the FTA-217 aberration flag for curator review.
 _ALLELE_PRIMARY_EXTRAS = [
     ('is_aberration', _is_aberration_cell, ''),
-    ('is_balancer', 'is_balancer', ''),
 ]
 
 

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -106,6 +106,7 @@ class AlleleDTO(GenomicEntityDTO):
         self.allele_synonym_dtos = []                          # Many NameSlotAnnotationDTO objects.
         self.in_collection_name = None                         # Will be the name of a FlyBase library/collection.
         self.is_extinct = None                                 # Make True if extinction reported; make False is stock exists; leave as None otherwise.
+        self.is_aberration = None                              # Make True only for FBab aberrations; leave as None otherwise (FTA-217).
         self.allele_mutation_type_dtos = []                    # AlleleMutationTypeSlotAnnotationDTOs.
         self.allele_inheritance_mode_dtos = []                 # AlleleInheritanceModeSlotAnnotationDTOs.
         self.allele_database_status_dto = None                 # AlleleDatabaseStatusSlotAnnotationDTOs.

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -107,7 +107,6 @@ class AlleleDTO(GenomicEntityDTO):
         self.in_collection_name = None                         # Will be the name of a FlyBase library/collection.
         self.is_extinct = None                                 # Make True if extinction reported; make False is stock exists; leave as None otherwise.
         self.is_aberration = None                              # Make True only for FBab aberrations; leave as None otherwise (FTA-217).
-        self.is_balancer = None                                # ToDo - no chado signal identified yet for which aberrations are balancers (FTA-217).
         self.allele_mutation_type_dtos = []                    # AlleleMutationTypeSlotAnnotationDTOs.
         self.allele_inheritance_mode_dtos = []                 # AlleleInheritanceModeSlotAnnotationDTOs.
         self.allele_database_status_dto = None                 # AlleleDatabaseStatusSlotAnnotationDTOs.

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -107,6 +107,7 @@ class AlleleDTO(GenomicEntityDTO):
         self.in_collection_name = None                         # Will be the name of a FlyBase library/collection.
         self.is_extinct = None                                 # Make True if extinction reported; make False is stock exists; leave as None otherwise.
         self.is_aberration = None                              # Make True only for FBab aberrations; leave as None otherwise (FTA-217).
+        self.is_balancer = None                                # ToDo - no chado signal identified yet for which aberrations are balancers (FTA-217).
         self.allele_mutation_type_dtos = []                    # AlleleMutationTypeSlotAnnotationDTOs.
         self.allele_inheritance_mode_dtos = []                 # AlleleInheritanceModeSlotAnnotationDTOs.
         self.allele_database_status_dto = None                 # AlleleDatabaseStatusSlotAnnotationDTOs.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1434,11 +1434,31 @@ class AberrationHandler(MetaAlleleHandler):
         self.log.info(f'Generated {counter} aberration-gene unique associations.')
         return
 
+    def map_aberration_flag(self):
+        """Flag FBab entities with the LinkML "is_aberration" boolean (FTA-217).
+
+        The slot was added to the Alliance schema by agr_curation_schema PR #327, which is merged to
+        "main" but absent from the latest LinkML release (v2.17.0). Emitting it would fail schema
+        validation for the whole allele file, so the mapping is gated behind ADD_IS_ABERRATION until
+        a LinkML release containing the slot is available.
+        """
+        if getenv('ADD_IS_ABERRATION', None) != 'YES':
+            self.log.info('ADD_IS_ABERRATION not set to "YES"; skipping the "is_aberration" flag.')
+            return
+        self.log.info('Flag aberrations with the "is_aberration" boolean.')
+        counter = 0
+        for aberration in self.fb_data_entities.values():
+            aberration.linkmldto.is_aberration = True
+            counter += 1
+        self.log.info(f'Flagged {counter} aberrations with is_aberration=True.')
+        return
+
     # Elaborate on map_fb_data_to_alliance() for the AberrationHandler.
     def map_fb_data_to_alliance(self):
         """Extend the method for the AberrationHandler."""
         super().map_fb_data_to_alliance()
         self.map_metaallele_basic()
+        self.map_aberration_flag()
         self.map_metaallele_database_status()
         self.map_internal_metaallele_status()
         self.map_aberration_mutation_types()

--- a/src/curation_tsv.py
+++ b/src/curation_tsv.py
@@ -45,16 +45,25 @@ def _is_excluded(entity_dict):
     return entity_dict.get('internal') or entity_dict.get('obsolete')
 
 
-def write_primary_tsv(*, log, filename, entities, datatype):
-    """Write the primary identifier TSV (used by every curation script)."""
+def write_primary_tsv(*, log, filename, entities, datatype, extra_fields=None):
+    """Write the primary identifier TSV (used by every curation script).
+
+    `extra_fields` appends datatype-specific columns after the shared ones. It is a list of
+    `(header_label, source, default_when_missing)` tuples, where `source` is either a key into the
+    exported entity dict or a callable taking that dict and returning the cell value. List/tuple
+    values are joined with EVIDENCE_DELIMITER; None and missing keys fall back to the default.
+    Scripts that pass nothing get the historic six-column output unchanged.
+    """
     skip = should_skip_obsolete()
     if skip:
         log.info(f'ADD_OBSOLETE=NO: excluding obsolete/internal {datatype}s from TSV.')
     full_name_key = f'{datatype}_full_name_dto'
     symbol_key = f'{datatype}_symbol_dto'
     synonym_key = f'{datatype}_synonym_dtos'
+    extras = extra_fields or []
+    extra_headers = "".join(f"\t{label}" for label, _, _ in extras)
     with open(filename, 'w') as outfile:
-        outfile.write(PRIMARY_TSV_HEADER)
+        outfile.write(PRIMARY_TSV_HEADER.rstrip('\n') + extra_headers + '\n')
         for entity_dict in entities:
             if skip and _is_excluded(entity_dict):
                 continue
@@ -75,9 +84,19 @@ def write_primary_tsv(*, log, filename, entities, datatype):
             internal = entity_dict.get("internal", False)
             secondary_str = EVIDENCE_DELIMITER.join(secondary)
             syns_str = EVIDENCE_DELIMITER.join(syns)
+            extra_parts = []
+            for _label, source, default in extras:
+                value = source(entity_dict) if callable(source) else entity_dict.get(source)
+                if value is None:
+                    extra_parts.append(default)
+                elif isinstance(value, (list, tuple)):
+                    extra_parts.append(EVIDENCE_DELIMITER.join(value))
+                else:
+                    extra_parts.append(str(value))
+            extras_str = "".join(f"\t{p}" for p in extra_parts)
             try:
                 outfile.write(
-                    f"{primary}\t{symbol}\t{name}\t{secondary_str}\t{syns_str}\t{internal}\n"
+                    f"{primary}\t{symbol}\t{name}\t{secondary_str}\t{syns_str}\t{internal}{extras_str}\n"
                 )
             except TypeError:
                 log.error(f"entity_dict: {entity_dict}")
@@ -87,6 +106,7 @@ def write_primary_tsv(*, log, filename, entities, datatype):
                 log.error(f"name: {name}")
                 log.error(f"syns: {syns}")
                 log.error(f"internal: {internal}")
+                log.error(f"extras: {extra_parts}")
                 raise
 
 


### PR DESCRIPTION
Closes [FTA-217](https://flybase.atlassian.net/browse/FTA-217).

## What

Flags FlyBase aberrations (`FBab`) with the Alliance LinkML `is_aberration` boolean, in both the submission JSON and the curator TSV. The flag is absent for every other entity in `allele_ingest_set` (FBal alleles, merged FBti insertions).

| File | Change |
| --- | --- |
| `src/agr_datatypes.py` | Declare `AlleleDTO.is_aberration = None`, alongside the other `is_*` booleans. |
| `src/allele_handlers.py` | New `AberrationHandler.map_aberration_flag()`, called from `map_fb_data_to_alliance()` immediately after `map_metaallele_basic()`. |
| `src/curation_tsv.py` | Optional `extra_fields` parameter on the shared `write_primary_tsv()`. |
| `src/AGR_data_retrieval_curation_allele.py` | Adds the `is_aberration` TSV column; documents the new env var in `--help`. |

## Why the JSON is gated behind `ADD_IS_ABERRATION`

The slot comes from [agr_curation_schema PR #327](https://github.com/alliance-genome/agr_curation_schema/pull/327), merged to `main` on 2026-07-06. The latest tagged release is **v2.17.0** (2026-06-15) and does **not** contain it — confirmed by diffing `model/schema/allele.yaml` between `main` and the `v2.17.0` tag.

`generate_export_dict()` (`src/handler.py:1113-1119`) serialises `linkmldto.__dict__` wholesale, so any new `AlleleDTO` attribute lands in the production allele JSON immediately and would fail `validate_agr_schema.py`, blocking the whole allele upload. The mapping is therefore gated behind `ADD_IS_ABERRATION=YES`, following the existing `ADD_CASS_TO_CONSTRUCT` pattern. **Default is off, so the submitted JSON is unchanged by this PR.**

Follow-up once a LinkML release containing the slot ships: set `ADD_IS_ABERRATION=YES` in the `Alliance_LinkML_Submission` pipeline, verify the upload, then drop the gate.

## TSV changes

`write_primary_tsv()` is shared by all five curation scripts, so the new column is opt-in via an `extra_fields` parameter rather than a widened global header. It reuses the `(label, source, default)` tuple shape already used by `write_association_tsv()` (`_ALLELE_ASSOC_EXTRAS`), extended so `source` may also be a callable. **Only the allele script passes extras — gene, construct, cassette and transgenic_tool keep byte-identical six-column output.**

The `is_aberration` cell is derived from the `FB:FBab` primary-ID prefix rather than read from the exported `is_aberration` key. Reading through the key would leave the column blank for every row whenever the gate is off, which is useless for curator review. The two can never disagree: FTA-217 defines an aberration as an entry whose primary ID begins `FBab`.

```
# Primary FBid   Valid symbol    ...  internal  is_aberration
FB:FBab0000001   Df(2R)03072     ...  False     true
FB:FBab0004789   In(2LR)Px[4]    ...  False     true
FB:FBal0018482   wg[1]           ...  False
FB:FBti0002065   P{en1}wg[en11]  ...  True
```

## Scope: `is_balancer` deliberately excluded

PR #327 also added `is_balancer`. It was briefly added here and then removed (`6bc88c5`), because it has no subject in the current export:

- The schema makes balancers a subtype of aberration — `is_balancer` is "only applicable to alleles for which `is_aberration` is true". In FlyBase that means `FBba`, a separate ID class from the `FBab` records this PR covers.
- `BalancerHandler` is deliberately suppressed: FBba export was active from Nov 2024 (`8184faa`) until commit `fe6c34ec`, "suppress balancer reporting" (2025-06-18), which is why its calls in the allele script are commented out.
- No chado signal has been identified for which `FBab` aberrations *act as* balancers.

So the column was always blank and the DTO slot had no reader or writer. Re-enabling FBba export would reverse an explicit prior decision and belongs in its own ticket.

## Implementation notes

- Default is `None`, not `False` — the export filter is `is not None and != []`, so a `False` default would emit `"is_aberration": false` on all ~200k FBal alleles.
- Not added to `required_fields` — `flag_unexportable_entities()` drops entities whose required field is `None`, which would remove every non-aberration allele from the export.
- No `FBab` prefix check needed in the handler: `get_entities()` already filters it on `regex['aberration']` (`^FBab[0-9]{7}$`), so `fb_data_entities` is FBab-only by construction.
- Deliberately *not* in the shared `MetaAlleleHandler.map_metaallele_basic()`, which `AlleleHandler` and `BalancerHandler` also use.

## Testing

- `flake8` clean on all four files. Caveat: the local `venv` is broken and the fallback flake8 has no `flake8-docstrings` plugin, so the `--docstring-convention google` D-checks did not run locally; CI covers them.
- Exercised the real export filter against the real `AlleleDTO`: unset → key absent from JSON; `True` → `"is_aberration": true` present; slot is not required.
- Exercised the real `write_primary_tsv()` with the real extras config against representative FBab/FBal/FBti records: FBab flagged with the gate both on and off, FBal/FBti never flagged, no ragged rows, and a no-extras caller producing the unchanged six-column header.
- AST check confirms `map_aberration_flag()` is on `AberrationHandler` only, runs directly after `map_metaallele_basic()`, and that no other allele handler touches `is_aberration`.

**Still outstanding — please do not merge before this:** the end-to-end run needs a chado connection, so neither the default-off JSON regression diff nor the `ADD_IS_ABERRATION=YES` FBab-count check has been run. Hence draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FTA-217]: https://flybase.atlassian.net/browse/FTA-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ