### PR TITLE
fix: scope transgenic FBal-FBti debug logging to the test set

### DIFF
--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -332,9 +332,11 @@ class AlleleHandler(MetaAlleleHandler):
             filter(*filters).\
             distinct()
         for result in results:
-            # Only log the per-row detail for the test set: in a full run this is one line per
-            # FBal-FBti pair, which swamps the debug log (and builds the strings needlessly).
-            if self.testing:
+            # Only log the per-row detail for the test set. Unlike get_entities(), the query above
+            # is NOT narrowed by test_set, so it returns every FBal-FBti pair in the database in a
+            # testing run too (~168k rows): "self.testing" alone would swamp the debug log and build
+            # the strings needlessly. Check test_set membership as well.
+            if self.testing and result.allele.uniquename in self.test_set:
                 allele_str = f'{result.allele.name} ({result.allele.uniquename})'
                 insertion_str = f'{result.insertion.name} ({result.insertion.uniquename})'
                 self.log.debug(f'The transgenic allele {allele_str} is related to the generic insertion {insertion_str}.')


### PR DESCRIPTION
## Problem

A `-t` run floods the debug log with lines like:

```
DEBUG : allele_handlers.py : Line No 337 : The transgenic allele Scer\GAL4[FRT.Gal80.alphaTub84B]
(FBal0137365) is related to the generic insertion P{alphaTub84B(FRT.Gal80.y[+])GAL4.C}unspecified (FBti0264481).
```

The guard added in `6cd5ccd` reads `if self.testing:`, and its comment promises to "only log the per-row detail for the test set". It does not.

Unlike `get_entities()` — which adds `uniquename.in_(test_set)` to its filters in testing mode — the query in `get_fbal_fbti_replacements()` (`allele_handlers.py:313-323`) is **never narrowed by `test_set`**. It returns every FBal↔generic-FBti pair in the database regardless of `-t`. The guard therefore inverted the intent: a testing run logged the whole database, and a full run logged nothing.

## Fix

```python
if self.testing and result.allele.uniquename in self.test_set:
```

Measured against `fb_2026_02_reporting_audit`, running the exact join/filter set of the SQLAlchemy query:

| | debug lines per `-t` run |
| --- | --- |
| Before | **168,426** |
| After | **29** |

29 is the number of pairs whose allele is among the 50 IDs in `AlleleHandler.test_set` — i.e. exactly the detail the comment always promised.

## Scope

Logging only. The guard wraps the two display strings and the `log.debug` call; the `transgenic_fbal_fbti_dict` writes and `indirect_fbal_fbti_counter` stay outside it, so **export output is unchanged**. The `log.info` summary at line 348 still reports the totals.

The at-locus loop just above (line 296) has the same shape but iterates `self.fb_data_entities`, which *is* test-set-scoped, so it is correct as-is and left alone.

## Testing

- `flake8` clean.
- AST check confirms the guard body contains only the two locals and the `log.debug` — no counters or dict writes were swallowed by it.
- Both counts come from running the query's exact joins and filters against chado; the `test_set` membership list was parsed from the source rather than typed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)