### PR TITLE
perf(FTA-220): fetch cvterm lookup in one query instead of one per row

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -351,23 +351,40 @@ class DataHandler(object):
     def build_cvterm_lookup(self, session):
         """Create a cvterm_id-keyed lookup of Cvterm objects."""
         self.log.info('Create a cvterm_id-keyed dict of Cvterms.')
-        # First get all current pubs having an FBrf uniquename.
         filters = (
             Cvterm.is_obsolete == 0,
         )
-        results = session.query(Cvterm).filter(*filters).distinct()
+        # Select only the columns used below, joining cv/dbxref/db explicitly. Reading these off the
+        # ORM object instead lazy-loads dbxref once per row - cv and db are few enough to stay cached
+        # in the identity map, but dbxref is 1:1 with cvterm - which is ~87K extra round trips, i.e.
+        # over an hour on a remote connection versus under a second here (FTA-220).
+        # No DISTINCT: cvterm.cv_id and cvterm.dbxref_id are NOT NULL 1:1 FKs, so the joins can
+        # neither multiply nor drop rows, and the row set already carries a primary key.
+        results = session.query(Cvterm.cvterm_id, Cvterm.name, Cv.name,
+                                Db.name, Dbxref.accession).\
+            select_from(Cvterm).\
+            join(Cv, (Cv.cv_id == Cvterm.cv_id)).\
+            join(Dbxref, (Dbxref.dbxref_id == Cvterm.dbxref_id)).\
+            join(Db, (Db.db_id == Dbxref.db_id)).\
+            filter(*filters)
+        # Cvterm.name, Cv.name and Db.name all label as "name", so index positionally.
+        CVTERM_ID = 0
+        NAME = 1
+        CV_NAME = 2
+        DB_NAME = 3
+        ACCESSION = 4
         cvterm_counter = 0
         for result in results:
             cvterm_dict = {
-                'cvterm_id': result.cvterm_id,
-                'name': result.name,
-                'cv_name': result.cv.name,
-                'db_name': result.dbxref.db.name,
-                'curie': f'{result.dbxref.db.name}:{result.dbxref.accession}',
-                'name_plus_curie': f'{result.name} ({result.dbxref.db.name}:{result.dbxref.accession})',
+                'cvterm_id': result[CVTERM_ID],
+                'name': result[NAME],
+                'cv_name': result[CV_NAME],
+                'db_name': result[DB_NAME],
+                'curie': f'{result[DB_NAME]}:{result[ACCESSION]}',
+                'name_plus_curie': f'{result[NAME]} ({result[DB_NAME]}:{result[ACCESSION]})',
                 'slim_term_cvterm_ids': [],
             }
-            self.cvterm_lookup[result.cvterm_id] = cvterm_dict
+            self.cvterm_lookup[result[CVTERM_ID]] = cvterm_dict
             cvterm_counter += 1
         self.log.info(f'Found {cvterm_counter} current CV terms in chado.')
         return


### PR DESCRIPTION
## Summary

[FTA-220](https://flybase.atlassian.net/browse/FTA-220) — `DataHandler.build_cvterm_lookup()` queried all non-obsolete cvterms as ORM objects, then read `result.cv.name` and `result.dbxref.db.name` **inside the loop**, lazy-loading per row.

It runs in `get_general_data()`, so all ten handlers pay it before doing any work, and `-t` testing mode does not reduce it. Not a correctness bug — exported data is unaffected.

Now selects only the five columns actually used, joining `cv`/`dbxref`/`db` explicitly. This matches `build_feature_lookup()`, which already uses the same pattern, and avoids building 86,906 throwaway ORM objects.

## Correcting the ticket's arithmetic

The ticket estimates 3 lazy loads per row (~300K round trips). The measured figure is **~1 per row**: **303 queries for 300 terms**. `cv` and `db` are few enough to stay cached in SQLAlchemy's identity map; only `dbxref`, which is 1:1 with cvterm, actually reloads each row.

So the real cost is ~87K round trips, not ~300K. That is consistent with Ian's measured ~90 round trips/sec and ~58 min projection, and it explains why his `pg_stat_activity` showed the **dbxref** statement specifically. The conclusion is unchanged; the multiplier was overstated.

## Results

Measured against `fb_2026_02_reporting_audit` over a port-forward (~56 ms/query — that latency is the point):

| | Before | After |
|---|---|---|
| SQL statements (full build) | ~87,000 | **1** |
| Statements per 300-term slice | 303 | **1** |
| Full build wall-clock | ~81 min (projected) | **0.73 s** |

For reference, the throwaway `joinedload` patch used while verifying FTA-113 took 2.56 s in a real run; the column-select takes 0.80 s in the equivalent run, so it also beats the minimal fix.

## Verification

- [x] **Equivalence with the old implementation.** Both implementations run side by side **in one process on one connection**, over identical fixed `cvterm_id` samples (300 terms each from `FlyBase anatomy CV`, `FlyBase miscellaneous CV`, `SO`, `disease_ontology` — different `db_name` prefixes and `cv_name`s, including the ones `disease_handlers`/`expression_handler` key off). The resulting `cvterm_lookup` dicts are **byte-identical** for every slice. Fixed ID sets rather than `LIMIT`, so both provably see the same input rows.
- [x] **`DISTINCT` is safe to drop.** Verified against chado: 86,906 cvterms in, **86,906 rows out** after joining cv+dbxref+db, and **zero** rows with a NULL `cv_id` or `dbxref_id`. Both FKs are NOT NULL and 1:1, so the joins can neither multiply nor drop rows; `DISTINCT` over a PK-bearing row set was a no-op that only forced a sort.
- [x] **Contract preserved.** All seven keys produced identically. `slim_term_cvterm_ids` is **86,906 distinct list objects for 86,906 entries** — critical, because `expression_handler.py:255` appends to it in place and `810-824` copies it; a shared list would corrupt siblings.
- [x] **End-to-end non-regression.** Transgenic tool export (1,092 entities) with `PYTHONHASHSEED` pinned: JSON, primary TSV, associations TSV and notes TSV all **byte-identical**; `_tool_uses.tsv` data rows identical (1,365). The only delta is that file's header, which changed in `3fdbfee` (FTA-113) after the baseline was generated — unrelated to this PR.
- [x] **`flake8` clean.**

Seed pinning is required because `entity_handler.py:1021` builds `alt_fb_ids` via `list(set(...))`, so `secondary_identifiers` ordering varies per process independently of this change.

## Audit of the other lookups

The ticket asks whether the same pattern appears elsewhere. **It does not** — this was the only N+1 in `handler.py`:

| Method | Verdict |
|---|---|
| `build_cvterm_lookup` | **N+1 — fixed here** |
| `build_bibliography`, `build_organism_lookup` | Clean — own-table columns; explicit joins elsewhere |
| `build_feature_lookup` | Clean — already uses the pattern adopted here |
| `build_allele_gene_lookup`, `build_seqfeat_gene_lookup`, `build_gene_tool_lookup`, `build_allele_class_lookup` | Clean — read only aliased entities already in the SELECT |

## Notes for reviewers

- **Positional indexing is deliberate.** `Cvterm.name`, `Cv.name` and `Db.name` all label as `name`, so attribute access would be ambiguous. The named-index constants mirror `build_feature_lookup()` (`handler.py:590-595`).
- **Deliberately not narrowing the lookup.** Restricting it to fewer CVs or to the test set would cut the row count further, but handlers index it by arbitrary `cvterm_id`, so that would be a behavioural change and risk `KeyError`s. This PR only changes *how* the same data is fetched.
- Also drops a stale comment copy-pasted from `build_bibliography()` (`# First get all current pubs having an FBrf uniquename.`).

## Follow-up, not in this PR

`entity_handler.py:1021` builds `alt_fb_ids` with `list(set(...).union(set(...)))`, so `secondary_identifiers` ordering shifts between processes and consecutive production exports differ gratuitously. Surfaced by this verification work; worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FTA-220]: https://flybase.atlassian.net/browse/FTA-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ