### PR TITLE
feat(FTA-218): name the cassette FBal cases skipped by aberration-allele export

### DIFF
--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1468,12 +1468,13 @@ class AberrationHandler(MetaAlleleHandler):
             3. type="associated_with", subject=FBab, object=FBal (proforma GA10g) -> "breakpoint_allele"
         """
         self.log.info('Synthesize aberration-to-allele associations.')
-        # Each entry is (entity_role of the aberration, chado rel type, related feature types, AGR relation).
-        # The partner feature_id is read from the side of the relationship that the aberration is NOT on.
+        # Each entry is (entity_role of the aberration, chado rel type, related feature types, AGR relation,
+        # proforma field). The partner feature_id is read from the side of the relationship that the aberration
+        # is NOT on. The proforma field is only reported in the cassette warning below.
         rel_specs = [
-            ('subject', 'associated_with', self.feature_subtypes['insertion'], 'carries'),
-            ('subject', 'associated_with', self.feature_subtypes['allele'], 'breakpoint_allele'),
-            ('object', 'carried_on', self.feature_subtypes['allele'], 'carries'),
+            ('subject', 'associated_with', self.feature_subtypes['insertion'], 'carries', 'A24a'),
+            ('subject', 'associated_with', self.feature_subtypes['allele'], 'breakpoint_allele', 'GA10g'),
+            ('object', 'carried_on', self.feature_subtypes['allele'], 'carries', 'A24b'),
         ]
         # When the aberration is the subject the partner is the object, and vice versa.
         partner_attr = {'subject': 'object_id', 'object': 'subject_id'}
@@ -1483,14 +1484,19 @@ class AberrationHandler(MetaAlleleHandler):
         rel_type_tally = {}
         for aberration in self.fb_data_entities.values():
             found_any = False
-            for entity_role, fb_rel_type, rel_entity_types, agr_rel_type in rel_specs:
+            for entity_role, fb_rel_type, rel_entity_types, agr_rel_type, proforma_field in rel_specs:
                 relevant_rels = aberration.recall_relationships(self.log, entity_role=entity_role, rel_types=fb_rel_type,
                                                                 rel_entity_types=rel_entity_types)
                 for feat_rel in relevant_rels:
                     partner_id = getattr(feat_rel.chado_obj, partner_attr[entity_role])
                     # Cassettes are FBal features sharing the "allele" cvterm, but they are never exported as alleles,
-                    # so an association pointing at one would dangle at the Alliance.
+                    # so an association pointing at one would dangle at the Alliance. Curators do not expect any of
+                    # these to exist in chado, so name each one so that the underlying data can be corrected.
                     if partner_id in self.cassette_ignore_list:
+                        partner = self.feature_lookup[partner_id]
+                        self.log.warning(f'CASSETTE FBal in an aberration-allele relationship, please check the data: '
+                                         f'{aberration} -- {fb_rel_type} --> '
+                                         f'{partner["name"]} ({partner["uniquename"]}) [proforma {proforma_field}]')
                         cassette_skipped += 1
                         continue
                     found_any = True
@@ -1509,7 +1515,11 @@ class AberrationHandler(MetaAlleleHandler):
         self.log.info(f'Found {allele_rel_counter} aberration-allele relationships for {aberration_counter} aberrations.')
         for agr_rel_type in sorted(rel_type_tally.keys()):
             self.log.info(f'Found {rel_type_tally[agr_rel_type]} aberration-allele relationships of type "{agr_rel_type}".')
-        self.log.info(f'Skipped {cassette_skipped} aberration-allele relationships to cassette FBal features.')
+        if cassette_skipped == 0:
+            self.log.info('Found no aberration-allele relationships pointing at a cassette FBal feature.')
+        else:
+            self.log.warning(f'Skipped {cassette_skipped} aberration-allele relationships to cassette FBal features '
+                             f'- see the "CASSETTE FBal" warnings above.')
         return
 
     # Elaborate on synthesize_info() for the AberrationHandler.


### PR DESCRIPTION
## Why

FTA-218 is **Ready for UAT**, and Steven confirmed on 2026-08-10 that the output file looks
good — but he is holding the ticket open for one reason: Gillian's earlier request.

Gillian accepts that cassette FBal features are skipped, but notes that there *should not be
any* `carried_on FBal -> FBab` (A24b) or `associated_with FBab -> FBal` (GA10g) cases whose
FBal is a cassette, and if there are, she wants to correct the data. Her ask: *"would it be
possible for the log files to record if it actually found any of those cases?"*

The skip in `AberrationHandler.synthesize_aberration_allele_associations()` only incremented a
counter and logged one INFO line, `Skipped {n} aberration-allele relationships to cassette FBal
features.` That gives a number but no way to find the offending records, and at INFO level it
does not stand out.

## What changed

`src/allele_handlers.py`, one method:

- `rel_specs` carries the proforma field (`A24a` / `GA10g` / `A24b`) so a warning can point a
  curator at the field to check.
- Each skipped case emits a warning naming the aberration, the chado relationship type, the
  cassette FBal and the proforma field:
  ```
  CASSETTE FBal in an aberration-allele relationship, please check the data:
  In(2L)Cy (FBab0004410) -- carried_on --> cassette[two] (FBal0000500) [proforma A24b]
  ```
- The summary is a warning pointing at those lines when non-zero, and an explicit
  `Found no aberration-allele relationships pointing at a cassette FBal feature.` when zero —
  so the log answers Gillian's question either way rather than leaving a bare `0` to interpret.

`feature_lookup[partner_id]` indexing is safe here: a partner only reaches this branch if
`recall_relationships()` bucketed it under `feature_subtypes['allele']`, and
`entity_handler.py:510-516` only populates that bucket for feature_ids already in
`feature_lookup` — the same source `map_aberration_allele_associations()` uses.

## Scope

Entirely inside the existing `ADD_ALLELE_ALLELE_ASSOC=YES` gate
(`allele_handlers.py:1539`), so production runs are unaffected and no exported JSON/TSV bytes
change. The Alliance blocker is untouched: there is still no
`allele_allele_association_ingest_set` and no `carries`/`breakpoint_allele` CV terms.

## Verification

- `py_compile` clean; line lengths within `setup.cfg`'s `max-line-length = 160`, no trailing
  whitespace.
- The changed method's **real source** was extracted with `ast` and executed against
  duck-typed handler state (the repo `venv` is x86_64 with a missing interpreter, so the module
  cannot be imported on an arm64 Mac). Both branches pass: two cassette cases produce two
  correctly formatted warnings plus the counted summary and only the two non-cassette
  relationships survive into `aberration_allele_rels`; the clean case produces the "none found"
  INFO and zero warnings.

## Full-database run — the answer to Gillian's question

Run on 2026-08-10 against `production_chado` with `ADD_ALLELE_ALLELE_ASSOC=YES`, log
`allele_curation_fb_2026_02_reporting_audit.log`: 0 ERRORs, ran through to `Ended main
function`, and full data (7798 aberrations, not a reduced set — `testing=True` here only
controls transaction rollback and debug lines).

**Yes, there are cassette cases — exactly three, all A24b (`carried_on`), all white markers:**

| Aberration | Cassette FBal | Proforma |
| --- | --- | --- |
| Df(2L)BSC4 (FBab0029533) | w[+mC] (FBal0028610) | A24b |
| Df(2R)BSC3 (FBab0029423) | w[+mC] (FBal0028610) | A24b |
| Df(3L)sina[SH] (FBab0045412) | w[+mW.hs] (FBal0028611) | A24b |

Nothing was logged for GA10g (`associated_with` FBab -> FBal) or A24a, so those two paths are
clean. Surrounding counts from the same run:

- 166149 cassette FBal features identified (164908 "in vitro construct" + 1241 others).
- 9364 aberration-allele relationships kept across 7798 aberrations — 5322 `carries`, 4042
  `breakpoint_allele` — plus the 3 skipped above.
- `ALLELE_ALLELE_ASSOCIATION_INGEST_SET`: 9364 of 9364 exportable, 0 with no LinkML mapping, 0
  missing required info, 0 internal.

Not done: no byte-level diff of the association JSON/TSVs against a pre-change run (no earlier
run's output was kept to compare against), and no gate-off run. The diff only adds
`log.warning`/`log.info` calls and one extra tuple element used solely in a log string — no
data path or export logic is touched — so output is expected to be unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
