### PR TITLE
fix(FTA-234): stop merged FBal symbols rivalling the FBti symbol

### DIFF
--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -444,6 +444,10 @@ class AlleleHandler(MetaAlleleHandler):
         if self.testing:
             self.log.debug(f'Merge {allele} data into {insertion} data.')
         insertion.alt_fb_ids.append(f'FB:{allele.uniquename}')
+        # The allele has just been made obsolete, so its current symbol is no longer a current name of
+        # anything: record its synonym_ids so that synthesize_synonyms() demotes them to plain synonyms
+        # of the insertion instead of letting them rival the insertion's own current symbol.
+        insertion.merged_synonym_ids.update([i.synonym_id for i in allele.synonyms])
         lists_to_extend = [
             'dbxrefs',
             'export_warnings',

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1065,7 +1065,8 @@ class PrimaryEntityHandler(DataHandler):
                 # Demote symbols inherited from a superseded entity: an FBal absorbed by its FBti brings its own
                 # current symbol along, which is not a current name of the insertion that absorbed it. The
                 # entity's own name is exempt in case the two entities share a symbol. Only symbols are demoted:
-                # ~195 insertions take their current full name from a merged allele, which is left as it was.
+                # ~195 insertions take their current full name from a merged allele, and per Gillian (FTA-234,
+                # 2026-08-11) they should keep it, since FBti have no full names of their own to overwrite.
                 is_merged_symbol = syno_id in fb_data_entity.merged_synonym_ids and syno_dict['name_type_name'] in symbol_type_names
                 if syno_dict['is_current'] is True and is_merged_symbol and syno_dict['format_text'] != fb_data_entity.name:
                     syno_dict['is_current'] = False

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1031,6 +1031,8 @@ class PrimaryEntityHandler(DataHandler):
             'nickname': 'unspecified',
             'synonym': 'unspecified',
         }
+        # AGR name types that represent a symbol, as opposed to a full name or a plain synonym.
+        symbol_type_names = ['nomenclature_symbol', 'systematic_name']
         for fb_data_entity in self.fb_data_entities.values():
             # For each entity, gather synonym_id-keyed dict of synonym info.
             for feat_syno in fb_data_entity.synonyms:
@@ -1050,7 +1052,7 @@ class PrimaryEntityHandler(DataHandler):
                     }
                     fb_data_entity.synonym_dict[feat_syno.synonym_id] = syno_dict
             # Go back over each synonym and refine each
-            for syno_dict in fb_data_entity.synonym_dict.values():
+            for syno_id, syno_dict in fb_data_entity.synonym_dict.items():
                 # Then modify attributes as needed.
                 # Identify systematic names.
                 if (re.match(self.regex['systematic_name'], syno_dict['format_text']) and syno_dict['name_type_name'] == 'nomenclature_symbol'):
@@ -1059,6 +1061,13 @@ class PrimaryEntityHandler(DataHandler):
                 if True in syno_dict['is_current']:
                     syno_dict['is_current'] = True
                 else:
+                    syno_dict['is_current'] = False
+                # Demote symbols inherited from a superseded entity: an FBal absorbed by its FBti brings its own
+                # current symbol along, which is not a current name of the insertion that absorbed it. The
+                # entity's own name is exempt in case the two entities share a symbol. Only symbols are demoted:
+                # ~195 insertions take their current full name from a merged allele, which is left as it was.
+                is_merged_symbol = syno_id in fb_data_entity.merged_synonym_ids and syno_dict['name_type_name'] in symbol_type_names
+                if syno_dict['is_current'] is True and is_merged_symbol and syno_dict['format_text'] != fb_data_entity.name:
                     syno_dict['is_current'] = False
                 # Classify is_internal (convert list of booleans into a single boolean).
                 if False in syno_dict['is_internal']:
@@ -1269,10 +1278,22 @@ class PrimaryEntityHandler(DataHandler):
                                                                          sub_sup_sgml_to_html(sub_sup_to_sgml(fb_data_entity.name)), []).dict_export()
                 setattr(fb_data_entity.linkmldto, linkml_synonym_slots['symbol_bin'], generic_symbol_dto)
             else:
-                setattr(fb_data_entity.linkmldto, linkml_synonym_slots['symbol_bin'], linkml_synonym_bins['symbol_bin'][0])
-                if len(linkml_synonym_bins['symbol_bin']) > 1:
-                    multi_symbols = ', '.join([i['format_text'] for i in linkml_synonym_bins['symbol_bin']])
-                    self.log.warning(f'Found many current symbols for {fb_data_entity}: {multi_symbols}')
+                # An entity should have one current symbol, but the data can give several. Prefer the one that is
+                # the entity's own name, and keep any others as synonyms rather than discarding them silently.
+                symbol_dtos = linkml_synonym_bins['symbol_bin']
+                chosen_index = 0
+                for i, name_dto in enumerate(symbol_dtos):
+                    if name_dto['format_text'] == fb_data_entity.name:
+                        chosen_index = i
+                        break
+                setattr(fb_data_entity.linkmldto, linkml_synonym_slots['symbol_bin'], symbol_dtos[chosen_index])
+                if len(symbol_dtos) > 1:
+                    chosen_symbol = symbol_dtos[chosen_index]['format_text']
+                    demoted_dtos = [i for n, i in enumerate(symbol_dtos) if n != chosen_index]
+                    linkml_synonym_bins['synonym_bin'].extend(demoted_dtos)
+                    multi_symbols = ', '.join([i['format_text'] for i in demoted_dtos])
+                    self.log.warning(f'Found many current symbols for {fb_data_entity}: exporting "{chosen_symbol}" '
+                                     f'and keeping these as synonyms: {multi_symbols}')
             # 2. Fullname.
             if len(linkml_synonym_bins['full_name_bin']) == 1:
                 setattr(fb_data_entity.linkmldto, linkml_synonym_slots['full_name_bin'], linkml_synonym_bins['full_name_bin'][0])

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -92,6 +92,7 @@ class FBDataEntity(FBExportEntity):
         # These attributes apply to various FlyBase entities: e.g., gene, strain, genotype, gene group, etc.
         self.pub_associations = []        # Pub associations: e.g., FeaturePub, StrainPub.
         self.synonyms = []                # Synonym associations: e.g., FeatureSynonym.
+        self.merged_synonym_ids = set()   # synonym_ids merged in from a superseded entity; never current symbols here.
         self.fb_sec_dbxrefs = []          # 2o/non-current FlyBase xref objects: e.g., FeatureDbxref.
         self.dbxrefs = []                 # Current xref objects: e.g., FeatureDbxref.
         self.props_by_type = {}           # Lists of FBProp objects keyed by prop type name.


### PR DESCRIPTION
Jira: [FTA-234](https://flybase.atlassian.net/browse/FTA-234)

## Why

The 2026-08-10 full allele run logged **65,527** `Found many current symbols` warnings, every one of them an FBti. Ian asked whether the symbol binning was really filtering on `is_current`, because the messages looked wrong:

```
Found many current symbols for P{PZ}nanos[07117] (FBti0005580):
  P{PZ}nanos[07117], Ecol\lacZ[nanos-07117], CG11779[07117], nanos[07117]
```

They were wrong. Chado holds **exactly one** current symbol per insertion — the count of FBti with more than one is **0** on `fb_2026_02_reporting_audit`. The extra names are not even synonyms of the insertion: they belong to the FBal alleles it supersedes. FBti0005580 has precisely three `associated_with` FBal — `nanos[07117]`, `Ecol\lacZ[nanos-07117]`, `CG11779[07117]` — which are exactly the three extra "current symbols".

## Root cause

1. `'synonyms'` is in `lists_to_extend` in `add_fbal_to_fbti()`, so the superseded allele's `feature_synonym` rows are appended to the insertion with `is_current=True` untouched.
2. `merge_fbti_fbal()` runs *before* `synthesize_synonyms()`, so those rows are treated as the insertion's own.
3. `synthesize_synonyms()` collapses the per-pub flags with `if True in ...`, so each merged allele contributes one current symbol.
4. `map_synonyms()` took `symbol_bin[0]` — chado row order — and never used `symbol_bin[1:]`. The `else` that feeds `synonym_bin` was already skipped for those DTOs, so they went nowhere.

## Two bugs this caused, both verified in the exported JSON

**The merged allele's current symbol was dropped entirely.** FBti0005580 exports 10 `allele_synonym_dtos`, and all three merged current symbols are absent while their obsolete variants survive:

```
exported: nos[07117], Ecol\lacZ[nos-07117], l(3)07117, P1715, nos[7117], ...
dropped:  nanos[07117], Ecol\lacZ[nanos-07117], CG11779[07117]
```

The FBal IDs still ship as `secondary_id`s, so the Alliance kept the identifier but lost the name a curator would search on. ~65k records.

**The exported symbol was arbitrary.** 18 insertions exported the allele's symbol:

```
FBti0033230  exported  aurA[EY03490]   should be  P{EPgy2}aurA[EY03490]
FBti0010229  exported  Btk[k00206]     should be  P{lacW}Btk[k00206]
FBti0011202  exported  Cul4[EP2518]    should be  P{EP}Cul4[EP2518]
```

## What changed

- `fb_datatypes.py` — `FBDataEntity` gains `merged_synonym_ids`.
- `allele_handlers.py` — `add_fbal_to_fbti()` records the allele's synonym_ids on the insertion.
- `entity_handler.py` — `synthesize_synonyms()` demotes those to non-current, exempting the entity's own name in case the two entities share a symbol. `map_synonyms()` prefers the symbol whose `format_text` matches the entity name and extends `synonym_bin` with any remaining current symbols instead of discarding them, which protects every other datatype from the same silent loss.

`synthesize_synonyms()` already computed the right preference for `curr_fb_symbol`; `map_synonyms()` simply ignored it.

## One scoping decision that needs a curator's answer

The demotion is limited to **symbols**. 195 insertions currently take their current *full name* from a merged allele, and demoting full names too would strip those. Whether an FBti should inherit the full name of the FBal it supersedes is a curator judgement, not part of this defect, so full-name behaviour is unchanged and a test pins that. Asked on FTA-234; widening it is a one-line change.

## Verification

The repo `venv` is x86_64 with a missing interpreter, so these modules cannot be imported on an arm64 Mac. The three real methods were extracted from source with `ast` and driven against duck-typed stand-ins modelling FBti0005580 and its three superseding alleles as verified in chado.

Before the fix the harness reproduced the production log line with the same four symbols. After it, 10 assertions pass: the exported symbol is the insertion's, all three merged symbols survive as synonyms, no warning fires, reversing chado row order changes nothing, the merged full name is still exported, and a genuinely multi-current entity prefers its own name while keeping the other as a synonym.

`py_compile` clean, all changed lines within the 160-char limit, no trailing whitespace. Note that `.flake8` sets `ignore = D100,D103,D104`, which **replaces** flake8's default ignore list, so W503 and W504 are both active — multi-line boolean conditions fail CI, which is why this uses a named intermediate boolean.

## Full run with the fix — 2026-08-10 14:52-16:13

Run on this branch against `fb_2026_02_reporting_audit`. Log compared against a preserved copy of the pre-fix run:

| Check | Pre-fix | Post-fix |
| --- | --- | --- |
| `Found many current symbols` | 65,527 | **0** |
| `No current symbols found` | 5 | **5** (unchanged) |
| `Found many current full_names` | 0 | 0 |
| Total WARNING lines | 65,896 | **369** |
| ERROR lines | 0 | 0 |
| Reached `Ended main function` | yes | yes |

The warning arithmetic closes exactly — 65,896 − 65,527 = 369 — so the only change is the removal of the bad warnings; no new warning type appeared. The 369 remaining are pre-existing and unrelated (unidentified NCBITaxon IDs, uncleanable note props, and the three FTA-218 cassette warnings).

`No current symbols found` holding at 5 is the important safety result: the main risk of demoting a merged symbol was emptying an entity's `symbol_bin` and silently minting a generic symbol. That did not happen to a single record.

Export counts are identical across the board, so no records were added or lost:

| Ingest set | Pre-fix | Post-fix |
| --- | --- | --- |
| `ALLELE_INGEST_SET` | 36,842 | 36,842 |
| `ALLELE_GENE_ASSOCIATION_INGEST_SET` | 74,635 | 74,635 |
| `ALLELE_CONSTRUCT_ASSOCIATION_INGEST_SET` | 409,596 | 409,596 |
| `ALLELE_ALLELE_ASSOCIATION_INGEST_SET` | 9,364 | 9,364 |

## Export diff — verified

Both exports digested record-by-record (615,680 records each) and compared:

| Check | Result |
| --- | --- |
| FBti0005580 symbol | `P{PZ}nanos[07117]` ✔ |
| FBti0005580 synonyms | all three merged allele symbols recovered ✔ |
| The 18 previously-wrong symbols | all corrected ✔ |
| FBti symbol changes | **18** — exactly the known cases, no others |
| FBti synonym changes | **65,527** |
| non-FBti records changed | **0** |
| records added / removed | **0 / 0** |

The synonym-change count is exactly the pre-fix warning count, 65,527 — one repaired record per warning, no over- or under-reach. File grew 1,817,624,396 → 1,848,466,094 bytes (+30.8 MB), consistent with ~65k recovered synonym DTOs.

Nothing outside FBti moved: alleles, aberrations and every association set are unchanged, and no record was added or lost. Combined with the log (65,527 → 0 warnings, `No current symbols found` steady at 5, zero ERRORs), both the intended repair and the absence of collateral damage are now confirmed in the output itself rather than inferred.

Reproduce with `scratchpad/check_fta234_run.py <log> <json>`.

## Curator sign-off on the full-name question

Gillian confirmed on FTA-234 (2026-08-11) that an FBti **should** keep the full name of the FBal it supersedes: FBti have no full names of their own — nothing in `current_fullname`/`fullname_synonym(s)` in the FB2026_02 bulk synonym file, and no full-name field in the FBti proforma — so the inherited value overwrites nothing. That is what this PR already does; the demotion is limited to symbols and a test pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FTA-234]: https://flybase.atlassian.net/browse/FTA-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ