### PR TITLE
feat(FTA-224,FTA-225,FTA-226): export STR sequence features to the Alliance

### DIFF
--- a/src/AGR_data_retrieval_curation_str.py
+++ b/src/AGR_data_retrieval_curation_str.py
@@ -1,0 +1,149 @@
+# !/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Data retrieval of FlyBase sequence targeting reagents (STR) for Alliance curation database.
+
+Author(s):
+    Ian Longden ilongden@morgan.harvard.edu
+
+Usage:
+    AGR_data_retrieval_curation_str.py [-h] [-v VERBOSE] [-c CONFIG] [-t TESTING]
+    [-l LINKML_RELEASE] [-r REFERENCE_DB] (OPTIONAL)
+
+Example:
+    python AGR_data_retrieval_curation_str.py -v -t -c /path/to/config.cfg
+    -l v2.17.0
+    -r fb_2026_01_reporting
+Notes:
+    This script exports the FlyBase sequence targeting reagents - the subset of FBsf
+    sequence features whose feature.type is "RNAi_reagent" or "sgRNA" (FTA-224) - as a
+    JSON file conforming to the SequenceTargetingReagentDTO LinkML specs for the Alliance
+    persistent curation database. A chado database with a full "audit_chado" table is
+    required.
+
+"""
+
+import argparse
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from harvdev_utils.psycopg_functions import set_up_db_reading
+from str_handler import SequenceTargetingReagentHandler
+from utils import export_chado_data, generate_export_file
+import curation_tsv
+
+# Data types handled by this script.
+REPORT_LABEL = 'str_curation'
+
+# SequenceTargetingReagentDTO holds "name" and "synonyms" as plain strings rather than in the
+# "{datatype}_symbol_dto"/"{datatype}_synonym_dtos" slots that write_primary_tsv() reads, so the
+# real names are added as extra columns and the shared symbol/full name/synonyms columns stay blank.
+_STR_TSV_EXTRAS = [
+    ('name', 'name', ''),
+    ('synonyms', 'synonyms', ''),
+]
+
+# Now proceed with generic setup.
+set_up_dict = set_up_db_reading(REPORT_LABEL)
+server = set_up_dict['server']
+database = set_up_dict['database']
+username = set_up_dict['username']
+password = set_up_dict['password']
+database_release = set_up_dict['database_release']
+reference_assembly = set_up_dict['assembly']
+input_dir = set_up_dict['input_dir']
+output_filename = set_up_dict['output_filename'].replace('tsv', 'json')
+log = set_up_dict['log']
+testing = set_up_dict['testing']
+
+output_filename = os.environ.get('ALT_OUTPUT', output_filename)
+
+# Process additional input parameters not handled by the set_up_db_reading() function above.
+parser = argparse.ArgumentParser(
+    description='Export FlyBase sequence targeting reagent data to Alliance LinkML JSON.',
+    epilog="""
+Environment variables:
+  SERVER              Database server (e.g. flysql25)
+  DATABASE            Database name (e.g. production_chado)
+  SQL_PORT            Database port (default: 5432)
+  ALT_OUTPUT          Override default output file path
+  ADD_OBSOLETE        Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
+""",
+    formatter_class=argparse.RawDescriptionHelpFormatter
+)
+parser.add_argument('-l', '--linkml_release',
+                    help='The "agr_curation_schema" LinkML release number.', required=True)
+parser.add_argument('-r', '--reference_db',
+                    help='The name of a previous reference db for incremental exports.',
+                    required=False)
+
+# Use parse_known_args(), not parse_args(),
+# to handle args specific to this script (outside of set_up_db_reading()).
+args, extra_args = parser.parse_known_args()
+
+log.info(f'Parsing args specific to this script; ignoring these: {extra_args}')
+linkml_release = args.linkml_release
+reference_db = args.reference_db
+
+port = os.environ.get('SQL_PORT', '5432')
+
+# Create SQL Alchemy engines from environmental variables.
+engine_var_rep = 'postgresql://' + username + ":" + password + '@' + server + ':' + port + '/' + database
+
+print(f"Connecting to server:{server} port:{port} database:{database} username:{username}")
+
+engine = create_engine(engine_var_rep)
+Session = sessionmaker(bind=engine)
+session = Session()
+
+# Create a session to the reference db.
+if reference_db:
+    # Reference DB host defaults to the primary SERVER unless REFERENCE_SERVER overrides it.
+    reference_server = os.environ.get('REFERENCE_SERVER', server)
+    engine_var_ref = 'postgresql://' + username + ":" + password + '@' + reference_server + '/' + reference_db
+    ref_engine = create_engine(engine_var_ref)
+    RefSession = sessionmaker(bind=ref_engine)
+    reference_session = RefSession()
+else:
+    reference_session = None
+
+
+# The main process.
+def main():
+    """Run the steps for exporting LinkML-compliant FlyBase STR data."""
+    log.info(f'Running script "{__file__}"')
+    log.info('Started main function.')
+    log.info(f'Exporting data from FlyBase release: {database_release}')
+    log.info(f'Output JSON file corresponds to "agr_curation_schema" release: {linkml_release}')
+
+    # Get the data and process it.
+    str_handler = SequenceTargetingReagentHandler(log, testing)
+    if reference_session:
+        export_chado_data(session, log, str_handler, reference_session=reference_session)
+    else:
+        export_chado_data(session, log, str_handler)
+
+    # Export the data.
+    export_dict = {
+        'linkml_version': linkml_release,
+        'alliance_member_release_version': database_release,
+    }
+    set_name = str_handler.primary_export_set
+    export_dict[set_name] = str_handler.export_data[set_name]
+    if len(export_dict[set_name]) == 0:
+        if reference_session:
+            log.info('No updates to report.')
+            return
+        log.error(f'The "{set_name}" is unexpectedly empty.')
+        raise ValueError(f'The "{set_name}" is unexpectedly empty.')
+    generate_export_file(export_dict, log, output_filename)
+    curation_tsv.write_primary_tsv(
+        log=log, filename=set_up_dict['output_filename'], entities=export_dict[set_name],
+        datatype='str', extra_fields=_STR_TSV_EXTRAS,
+    )
+
+    log.info('Ended main function.\n')
+
+
+if __name__ == "__main__":
+    main()

--- a/src/AGR_data_retrieval_curation_str.py
+++ b/src/AGR_data_retrieval_curation_str.py
@@ -35,13 +35,21 @@ import curation_tsv
 # Data types handled by this script.
 REPORT_LABEL = 'str_curation'
 
-# SequenceTargetingReagentDTO holds "name" and "synonyms" as plain strings rather than in the
-# "{datatype}_symbol_dto"/"{datatype}_synonym_dtos" slots that write_primary_tsv() reads, so the
-# real names are added as extra columns and the shared symbol/full name/synonyms columns stay blank.
-_STR_TSV_EXTRAS = [
-    ('name', 'name', ''),
-    ('synonyms', 'synonyms', ''),
-]
+# SequenceTargetingReagentDTO holds its symbol in a plain "name" string and its synonyms in a plain
+# list of strings, not in the "{datatype}_symbol_dto"/"{datatype}_synonym_dtos" slots that
+# write_primary_tsv() reads by convention, so point it at the right keys. There is no full name
+# slot on this class at all, so that column is left empty.
+
+
+def _str_symbol(entity_dict):
+    """Return the STR symbol for the curator TSV."""
+    return entity_dict.get('name')
+
+
+def _str_synonyms(entity_dict):
+    """Return the STR synonym strings for the curator TSV."""
+    return entity_dict.get('synonyms', [])
+
 
 # Now proceed with generic setup.
 set_up_dict = set_up_db_reading(REPORT_LABEL)
@@ -139,7 +147,7 @@ def main():
     generate_export_file(export_dict, log, output_filename)
     curation_tsv.write_primary_tsv(
         log=log, filename=set_up_dict['output_filename'], entities=export_dict[set_name],
-        datatype='str', extra_fields=_STR_TSV_EXTRAS,
+        datatype='str', symbol_source=_str_symbol, synonym_source=_str_synonyms,
     )
 
     log.info('Ended main function.\n')

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -125,6 +125,24 @@ class AlleleDTO(GenomicEntityDTO):
         self.required_fields.extend(['allele_symbol_dto', 'primary_external_id'])
 
 
+class SequenceTargetingReagentDTO(GenomicEntityDTO):
+    """SequenceTargetingReagentDTO class."""
+    def __init__(self):
+        """Create SequenceTargetingReagentDTO for FlyBase object.
+
+        FTA-225/FTA-226. Note that "name" and "synonyms" are plain strings in the LinkML model
+        (not NameSlotAnnotationDTOs), so this DTO cannot carry per-name attribution or
+        current/non-current status, and PrimaryEntityHandler.map_synonyms() does not apply to it.
+        """
+        super().__init__()
+        self.name = None                    # Plain string: the current symbol of the FBsf.
+        self.synonyms = []                  # Plain strings: all other synonyms, unattributed.
+        self.secondary_identifiers = []     # Will be list of 2o FB curies (strings).
+        self.reference_curies = []          # Will be a list of reference curies.
+        self.note_dtos = []                 # Will be NoteDTO objects (inherited slot; unused for now).
+        self.required_fields.extend(['primary_external_id', 'name'])
+
+
 class CassetteTransgenicToolAssociationDTO(AuditedObjectDTO):
     """CassetteTransgenicToolAssociationDTO class."""
     def __init__(self, cassette_association_subject, cassette_association_object,

--- a/src/curation_tsv.py
+++ b/src/curation_tsv.py
@@ -7,10 +7,13 @@ AGR_data_retrieval_curation_construct.py (and which appear in similar form
 in the allele and transgenic_tool scripts).
 
 DTO field names are derived from a `datatype` string (e.g. "cassette",
-"construct"). All current scripts follow the regular convention
+"construct"). Most scripts follow the regular convention
 `{datatype}_full_name_dto`, `{datatype}_symbol_dto`,
-`{datatype}_synonym_dtos`, etc.; if a future script breaks that
-convention these helpers will need to be parameterized further.
+`{datatype}_synonym_dtos`, etc. A datatype that breaks the convention can
+pass `symbol_source`/`full_name_source`/`synonym_source` to
+write_primary_tsv(): STR does, because SequenceTargetingReagentDTO holds
+its symbol in a plain `name` string and its synonyms in a plain list of
+strings rather than in NameSlotAnnotationDTO slots.
 """
 
 import os
@@ -46,7 +49,8 @@ def _is_excluded(entity_dict):
     return entity_dict.get('internal') or entity_dict.get('obsolete')
 
 
-def write_primary_tsv(*, log, filename, entities, datatype, extra_fields=None):
+def write_primary_tsv(*, log, filename, entities, datatype, extra_fields=None,
+                      symbol_source=None, full_name_source=None, synonym_source=None):
     """Write the primary identifier TSV (used by every curation script).
 
     `extra_fields` appends datatype-specific columns after the shared ones. It is a list of
@@ -54,6 +58,12 @@ def write_primary_tsv(*, log, filename, entities, datatype, extra_fields=None):
     exported entity dict or a callable taking that dict and returning the cell value. List/tuple
     values are joined with EVIDENCE_DELIMITER; None and missing keys fall back to the default.
     Scripts that pass nothing get the historic six-column output unchanged.
+
+    `symbol_source`, `full_name_source` and `synonym_source` override where the symbol, full name
+    and synonym cells come from, for a datatype whose DTO does not use the
+    `{datatype}_symbol_dto`/`_full_name_dto`/`_synonym_dtos` convention. Each is a callable taking
+    the exported entity dict; the first two return a string (or None), the third a list of strings.
+    Left unset, the conventional DTO slots are read exactly as before.
     """
     skip = should_skip_obsolete()
     if skip:
@@ -73,11 +83,17 @@ def write_primary_tsv(*, log, filename, entities, datatype, extra_fields=None):
             name = ''
             secondary = []
             syns = []
-            if full_name_key in entity_dict:
+            if full_name_source is not None:
+                name = full_name_source(entity_dict) or ''
+            elif full_name_key in entity_dict:
                 name = entity_dict[full_name_key]["format_text"]
-            if symbol_key in entity_dict:
+            if symbol_source is not None:
+                symbol = symbol_source(entity_dict) or ''
+            elif symbol_key in entity_dict:
                 symbol = entity_dict[symbol_key]["format_text"]
-            if synonym_key in entity_dict:
+            if synonym_source is not None:
+                syns = list(synonym_source(entity_dict) or [])
+            elif synonym_key in entity_dict:
                 for synonym in entity_dict[synonym_key]:
                     syns.append(synonym["format_text"])
             if "secondary_identifiers" in entity_dict:

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -100,6 +100,7 @@ class PrimaryEntityHandler(DataHandler):
         'insertion': 'allele',
         'genotype': 'homepage',
         'grp': 'functional_gene_set',
+        'str': 'sequence_targeting_reagent',
     }
 
     # Mappings of main data types to chado tables with associated data

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -381,6 +381,18 @@ class FBTool(FBFeature):
         self.prop_data = {'tool_uses': []}    # list of dicts: name/type/pub/accession
 
 
+class FBStr(FBFeature):
+    """A FlyBase sequence targeting reagent (STR) entity with all its related data.
+
+    The STR subset of FBsf sequence features: those with a feature.type of "RNAi_reagent"
+    or "sgRNA" (FTA-224). The minimal Alliance submission needs no props, so prop_data
+    stays at the empty FBFeature default.
+    """
+    def __init__(self, chado_obj):
+        """Create the FBStr object."""
+        super().__init__(chado_obj)
+
+
 class FBStrain(FBDataEntity):
     """A FlyBase strain entity with all its related data."""
     def __init__(self, chado_obj):

--- a/src/handler.py
+++ b/src/handler.py
@@ -205,6 +205,7 @@ class DataHandler(object):
         'polypeptide': r'^FBpp[0-9]{7}$',
         'seqfeat': r'^FBsf[0-9]{10}$',
         'split system combination': r'^FBco[0-9]{7}$',
+        'str': r'^FBsf[0-9]{10}$',    # FTA-224: the STR subset of seqfeats; distinguished by feature.type, not by ID.
         'transcript': r'^FBtr[0-9]{7}$',
         'transposon': r'^FBte[0-9]{7}$',
         'tool': r'^FBto[0-9]{7}$',
@@ -233,6 +234,7 @@ class DataHandler(object):
         'polypeptide': False,
         'seqfeat': False,
         'split system combination': False,
+        'str': True,    # FTA-225: the RNAi_reagent/sgRNA subset of FBsf, exported as SequenceTargetingReagentDTO.
         'tool': False,
         'transcript': False,
         'transposon': False,
@@ -252,6 +254,7 @@ class DataHandler(object):
         'insertion': ['insertion_site', 'transposable_element', 'transposable_element_insertion_site'],    # Excludes internal "match" (name=FBti ID).
         'polypeptide': None,
         'seqfeat': None,    # The list is too long, so for this case let the code be flexible.
+        'str': ['RNAi_reagent', 'sgRNA'],    # FTA-224: the FBsf types that are sequence targeting reagents.
         'tool': ['engineered_region'],
         'transcript': None,
         'transposon': ['natural_transposable_element'],

--- a/src/str_handler.py
+++ b/src/str_handler.py
@@ -1,0 +1,168 @@
+"""Module:: str_handler.
+
+Synopsis:
+    A data handler that exports FlyBase sequence targeting reagent (STR) data to
+    Alliance SequenceTargetingReagent LinkML objects.
+
+    The STR data class is the subset of FlyBase sequence features (FBsf) whose
+    feature.type is "RNAi_reagent" or "sgRNA" (FTA-224). That subset is declared in
+    DataHandler.feature_subtypes['str'], so the generic PrimaryEntityHandler driver
+    query picks it up without any bespoke SQL here.
+
+Author(s):
+    Ian Longden ilongden@morgan.harvard.edu
+
+"""
+
+from logging import Logger
+import agr_datatypes
+import fb_datatypes
+from feature_handler import FeatureHandler
+
+
+class SequenceTargetingReagentHandler(FeatureHandler):
+    """This object gets, synthesizes and filters STR data for export."""
+    def __init__(self, log: Logger, testing: bool):
+        """Create the SequenceTargetingReagentHandler object."""
+        super().__init__(log, testing)
+        self.datatype = 'str'
+        self.fb_export_type = fb_datatypes.FBStr
+        self.agr_export_type = agr_datatypes.SequenceTargetingReagentDTO
+        self.primary_export_set = 'str_ingest_set'
+
+    test_set = {
+        'FBsf0000443916': 'dsRNA-HMJ22303',     # RNAi_reagent, TRiP-3 collection (see allele_handlers FBti0164639).
+        'FBsf0000078690': 'dsRNA-GD9857',       # RNAi_reagent, "encodes_tool" component of cassette FBal0198528.
+        'FBsf0000000002': 'DRSC00004',          # RNAi_reagent with a secondary FB ID.
+        'FBsf0000003641': 'DRSC03748',          # RNAi_reagent with two non-current symbols (HDC03394, HDC03690) and a 2o FB ID.
+        'FBsf0000437305': 'dsRNA-HMS01879',     # The only obsolete STR in fb_2026_02: must export as internal.
+        'FBsf0000910691': 'sgRNA-GS00469.1',    # sgRNA, "encodes_tool" component of cassette FBal0365029.
+        'FBsf0000910692': 'sgRNA-GS00469.2',    # sgRNA, "encodes_tool" component of cassette FBal0365030.
+        'FBsf0000910567': 'sgRNA-GS00055.1',    # sgRNA, one of two components of cassette FBal0365146.
+    }
+
+    # Add methods to be run by get_general_data() below.
+    def get_general_data(self, session):
+        """Extend the method for the SequenceTargetingReagentHandler."""
+        super().get_general_data(session)
+        self.build_bibliography(session)
+        self.build_organism_lookup(session)
+        self.build_cvterm_lookup(session)
+        # NB - no build_feature_lookup(): the minimal STR submission makes no
+        # associations to other features, so nothing needs the lookup.
+        return
+
+    # Add methods to be run by get_datatype_data() below.
+    def get_datatype_data(self, session):
+        """Extend the method for the SequenceTargetingReagentHandler."""
+        super().get_datatype_data(session)
+        self.get_entities(session)
+        self.get_entity_pubs(session)
+        self.get_entity_synonyms(session)
+        self.get_entity_fb_xrefs(session)
+        self.get_entity_xrefs(session)
+        self.get_entity_timestamps(session)
+        return
+
+    # Add methods to be run by synthesize_info() below.
+    def synthesize_info(self):
+        """Extend the method for the SequenceTargetingReagentHandler."""
+        super().synthesize_info()
+        self.synthesize_ncbi_taxon_id()
+        self.synthesize_synonyms()
+        self.synthesize_secondary_ids()
+        self.synthesize_pubs()
+        self.flag_new_additions_and_obsoletes()
+        return
+
+    # Add methods to be run by map_fb_data_to_alliance() below.
+    def map_fb_data_to_alliance(self):
+        """Extend the method for the SequenceTargetingReagentHandler."""
+        super().map_fb_data_to_alliance()
+        self.map_str_basic()
+        self.map_str_names()
+        self.map_timestamps()
+        self.map_pubs()
+        self.map_data_provider_dto()
+        self.map_xrefs()
+        self.map_secondary_ids('secondary_identifiers')
+        # Cascade chado-obsolete -> internal=True (matches every other handler).
+        self.flag_internal_fb_entities('fb_data_entities')
+        return
+
+    def map_str_basic(self):
+        """Map basic FlyBase STR data to the Alliance LinkML object."""
+        self.log.info('Map basic STR info to Alliance object.')
+        for str_entity in self.fb_data_entities.values():
+            agr_str = self.agr_export_type()
+            agr_str.obsolete = str_entity.chado_obj.is_obsolete
+            agr_str.primary_external_id = f'FB:{str_entity.uniquename}'
+            agr_str.taxon_curie = str_entity.ncbi_taxon_id
+            str_entity.linkmldto = agr_str
+        return
+
+    def map_str_names(self):
+        """Map the STR symbol and synonyms to the Alliance LinkML object (FTA-225, FTA-226).
+
+        SequenceTargetingReagentDTO holds "name" as a plain string and "synonyms" as a plain
+        list of strings, so PrimaryEntityHandler.map_synonyms() does not apply: it only fills
+        "*_symbol_dto"/"*_synonym_dtos" slots with NameSlotAnnotationDTOs. The consequence is
+        that neither pub attribution nor is_current status can be carried for a synonym; that
+        loss is inherent to the LinkML slot, not a shortcut taken here.
+
+        The format_text (plain) form of each name is used rather than the display_text
+        (SGML-to-HTML) form, since the target slots are bare strings.
+        """
+        self.log.info('Map STR names and synonyms to Alliance object.')
+        name_counter = 0
+        fallback_counter = 0
+        synonym_counter = 0
+        symbol_type_names = ['nomenclature_symbol', 'systematic_name']
+        for str_entity in self.fb_data_entities.values():
+            if str_entity.linkmldto is None:
+                continue
+            # 1. The one current symbol becomes "name". Every STR in fb_2026_02 has exactly one,
+            #    but prefer the symbol matching the feature's own name if the data gives several.
+            current_symbols = [i['format_text'] for i in str_entity.synonym_dict.values()
+                               if i['is_current'] is True and i['name_type_name'] in symbol_type_names]
+            if not current_symbols:
+                self.log.warning(f'No current symbol found for {str_entity}: using feature.name instead.')
+                str_entity.linkmldto.name = str_entity.name
+                fallback_counter += 1
+            else:
+                chosen_symbol = current_symbols[0]
+                if str_entity.name in current_symbols:
+                    chosen_symbol = str_entity.name
+                if len(current_symbols) > 1:
+                    other_symbols = ', '.join([i for i in current_symbols if i != chosen_symbol])
+                    self.log.warning(f'Found many current symbols for {str_entity}: exporting "{chosen_symbol}" '
+                                     f'and keeping these as synonyms: {other_symbols}')
+                str_entity.linkmldto.name = chosen_symbol
+                name_counter += 1
+            # 2. Every other name becomes an (unattributed) entry in "synonyms".
+            synonyms = {i['format_text'] for i in str_entity.synonym_dict.values()}
+            synonyms.discard(str_entity.linkmldto.name)
+            str_entity.linkmldto.synonyms = sorted(synonyms)
+            synonym_counter += len(synonyms)
+        self.log.info(f'Mapped {name_counter} STR names from a current symbol, and {fallback_counter} from feature.name.')
+        self.log.info(f'Mapped {synonym_counter} STR synonyms.')
+        return
+
+    def map_secondary_ids(self, slot_name):
+        """Map secondary FB IDs to the Alliance LinkML object.
+
+        Overrides PrimaryEntityHandler.map_secondary_ids(), which wraps each ID in a
+        SecondaryIdSlotAnnotationDTO. The "secondary_identifiers" slot on
+        SequenceTargetingReagentDTO is a plain list of curies, so the raw "FB:FBsf..."
+        strings are used instead (same approach as CassetteHandler).
+        """
+        self.log.info('Map secondary IDs to Alliance object.')
+        counter = 0
+        for fb_data_entity in self.fb_data_entities.values():
+            if fb_data_entity.linkmldto is None:
+                continue
+            sec_id_list = getattr(fb_data_entity.linkmldto, slot_name)
+            sec_id_list.extend(fb_data_entity.alt_fb_ids)
+            counter += len(fb_data_entity.alt_fb_ids)
+        self.log.info(f'Mapped {counter} secondary FB IDs for {self.datatype} entities.')
+        return


### PR DESCRIPTION
Epic: [FTA-223](https://flybase.atlassian.net/browse/FTA-223). Closes [FTA-224](https://flybase.atlassian.net/browse/FTA-224), [FTA-225](https://flybase.atlassian.net/browse/FTA-225), [FTA-226](https://flybase.atlassian.net/browse/FTA-226).

Submits the sequence targeting reagent subset of FlyBase sequence features to the Alliance as `SequenceTargetingReagentDTO`, filling the `str_ingest_set`. First half of FTA-223; the cassette-side routing is #FTA-227-231.

## What changed

| File | Why |
|---|---|
| `src/handler.py`, `src/entity_handler.py` | Register `str` as a datatype: `regex`, `feat_type_export`, `feature_subtypes` and `page_area_conversion`. Four entries, and the whole generic `PrimaryEntityHandler` pipeline then works unmodified. |
| `src/agr_datatypes.py` | New `SequenceTargetingReagentDTO`. |
| `src/fb_datatypes.py` | New `FBStr`. |
| `src/str_handler.py` | New `SequenceTargetingReagentHandler`, modelled on `transgenic_tool_handler.py`. |
| `src/AGR_data_retrieval_curation_str.py` | New export script. |

**FTA-224** is the one-line `feature_subtypes['str'] = ['RNAi_reagent', 'sgRNA']`: FBsf uniquename plus those two `feature.type` values. Registering `str` as its own datatype rather than reusing the existing `seqfeat` one is deliberate — `feature_subtypes['seqfeat']` is `None`, which `get_entities()` would pass straight into `Cvterm.name.in_(None)`.

**FTA-225** maps `primary_external_id`, the valid symbol, secondary FB IDs, `taxon_curie`, `obsolete`, `internal`, `date_created`/`date_updated` and the data provider.

**FTA-226** maps synonyms — see the caveat below.

## Two things worth a reviewer's attention

**Synonyms lose their attribution, unavoidably.** `SequenceTargetingReagentDTO` holds `name` as a plain string and `synonyms` as a plain list of strings, not `NameSlotAnnotationDTO`s. So no pub evidence and no current/non-current status can be carried per synonym. That is a property of the LinkML slot, not a shortcut — it is why `map_synonyms()` cannot be reused and `map_str_names()` exists, and why `map_secondary_ids()` is overridden to emit raw `FB:FBsf...` curies rather than `SecondaryIdSlotAnnotationDTO`s. Flagging in case curators would rather wait for name slotAnnotations on STR.

**`name` in `required_fields` is load-bearing.** `flag_unexportable_entities()` drops an entity whose required field is `None`, so a hypothetical nameless STR is excluded with a warning instead of exported as `"name": null`. No STR has a NULL `feature.name` today.

## Scope (`fb_2026_02_reporting_audit`)

| Measure | Count |
|---|---|
| STR FBsf total (`str_ingest_set` size) | 133,567 |
| RNAi_reagent / sgRNA | 116,581 (1 obsolete) / 16,986 |
| Organism | all Dmel |
| With >=1 secondary FB ID | 47,717 |
| With exactly one current symbol | 133,567 (all — so no "many current symbols" warnings expected) |

## Verification

Done here:
- `py_compile` clean; no line >160 chars, no trailing whitespace, no tabs (checked by hand against `.flake8`, since every venv on this machine points at a dead Intel-Homebrew python and `flake8` will not run).
- Every DTO slot checked against `generated/jsonschema/allianceModel.schema.json`: all exported keys are declared, all schema-required keys are set.
- The new mapping methods driven on real chado-derived cases via an `ast`-extraction harness, including the no-current-symbol and two-current-symbols fallbacks.

Still needed, and only runnable by a human:
- `flake8 src/` proper.
- `-t` testing run: all 8 `test_set` members present, one `name` each.
- Full run, count matches 133,567, then `validate_agr_schema.py`.

## Not in this PR

- **A GoCD stage** in `Alliance_LinkML_Submission` to run the script and upload `str_ingest_set`. Until that exists the script is inert in production, which is why it needs no `ADD_*` gate. Unlike FTA-217, nothing here waits on a LinkML release: `str_ingest_set` and `SequenceTargetingReagentDTO` are both in released `v2.17.0` (byte-identical on `main`).
- **Confirming the `page_area`.** It is set to `sequence_targeting_reagent`, matching the Alliance data class name as `gene_group` did with `functional_gene_set`, but I could not verify the valid FB page names offline — `resourceDescriptors.yaml` lives in `agr_curation`, not the schema repo. A bad page name is rejected at load time, not by `validate_agr_schema.py`, so this wants checking before the first upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FTA-223]: https://flybase.atlassian.net/browse/FTA-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-224]: https://flybase.atlassian.net/browse/FTA-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-225]: https://flybase.atlassian.net/browse/FTA-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-226]: https://flybase.atlassian.net/browse/FTA-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ