### PR TITLE
feat(FTA-227,FTA-228,FTA-229,FTA-231): make cassette-STR components real associations

### DIFF
--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -37,8 +37,10 @@ REPORT_LABEL = 'cassette_curation'
 _CASSETTE_ASSOC_SECOND_FIELDS = {
     'cassette_transgenic_tool_association_ingest_set': 'transgenic_tool_identifier',
     'cassette_genomic_entity_association_ingest_set': 'genomic_entity_identifier',
+    'cassette_str_association_ingest_set': 'sequence_targeting_reagent_identifier',
 }
-# Extra TSV columns specific to cassette associations.
+# Extra TSV columns specific to cassette associations. Only genomic entity associations carry
+# component_type_curies; the others fall back to the empty default for that column.
 _CASSETTE_ASSOC_EXTRAS = [('Comp type curie', 'component_type_curies', '')]
 
 # Now proceed with generic setup.
@@ -159,7 +161,7 @@ def _export_associations(cassette_handler):
         'linkml_version': linkml_release,
         'alliance_member_release_version': database_release,
     }
-    for sub_type in ('transgenic_tool', 'genomic_entity'):
+    for sub_type in ('transgenic_tool', 'genomic_entity', 'str'):
         set_name = f"cassette_{sub_type}_association"
         ingest_name = f"{set_name}_ingest_set"
         association_export_dict[ingest_name] = []

--- a/src/AGR_data_retrieval_curation_cassette.py
+++ b/src/AGR_data_retrieval_curation_cassette.py
@@ -169,6 +169,11 @@ def _export_associations(cassette_handler):
         if len(association_export_dict[ingest_name]) == 0:
             if os.getenv('ADD_CASS_TO_CONSTRUCT') == 'YES':
                 raise ValueError(f'The "{set_name}" is unexpectedly empty.')
+            # Drop the key rather than emitting an empty ingest set, so that an ungated run
+            # produces the same JSON as it did before the STR set existed. Leaving it in put a
+            # bare "cassette_str_association_ingest_set": [] into production output for a
+            # feature that is meant to be dormant until the gate is turned on.
+            del association_export_dict[ingest_name]
             log.info(
                 f'The "{set_name}" is empty (ADD_CASS_TO_CONSTRUCT not set to YES); skipping.'
             )

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -166,9 +166,14 @@ class CassetteStrAssociationDTO(AuditedObjectDTO):
         super().__init__()
         self.cassette_identifier = cassette_association_subject
         self.sequence_targeting_reagent_identifier = cassette_association_object
-        self.evidence = pub_curies
+        # NB - "evidence_curies", not "evidence": CassetteStrAssociationDTO is_a
+        # EvidenceAssociationDTO, and the schema declares no "evidence" slot at all.
+        self.evidence_curies = pub_curies
         self.obsolete = obsolete
         self.relation_name = relation
+        self.note_dtos = []    # Inherited slot; nothing populates it yet.
+        self.required_fields.extend(['cassette_identifier', 'relation_name',
+                                     'sequence_targeting_reagent_identifier'])
 
 
 class SlotAnnotationDTO(AuditedObjectDTO):

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -61,10 +61,13 @@ class CassetteHandler(FeatureHandler):
         'FBal0239883': 'sd[RNAi.N.UAS]',
         'FBal0000531': 'Amy-p[IX]',
         'FBal0028742': 'Act88F[E334K]',
-        'FBal0045138': 'Sry-delta[SDL1.lacZ]',                 # linked to an FBsf so a str association.
-        'FBal0193109': r'Avic\GFP[EGFP.rho.PE.Tag:NLS(tra)]',  # linked to an FBsf so a str association.
-        'FBal0250846': r'Scer\GAL4[GMR24E03]',                 # linked to an FBsf so a str association.
-        'FBal0041313': r'Ecol\lacZ[eve.1.55] ',                # linked to an FBsf so a str association.
+        # These four are "has_reg_region" to a regulatory_region FBsf, NOT to an STR FBsf, so they
+        # stay CassetteComponentSlotAnnotationDTO free text (FTA-224). The STR cases are the
+        # "encodes_tool" ones noted further down.
+        'FBal0045138': 'Sry-delta[SDL1.lacZ]',                 # has_reg_region FBsf0000435464 (regulatory_region).
+        'FBal0193109': r'Avic\GFP[EGFP.rho.PE.Tag:NLS(tra)]',  # has_reg_region FBsf0000435293 (regulatory_region).
+        'FBal0250846': r'Scer\GAL4[GMR24E03]',                 # has_reg_region FBsf0000162916 (regulatory_region).
+        'FBal0041313': r'Ecol\lacZ[eve.1.55] ',                # has_reg_region FBsf0000921192 (regulatory_region).
         'FBal0083005': 'dlg1[DeltaSH3.UAS.Tag:FLAG]',  # two refs for same tagged_with (FBrf0099758, FBrf0130114),
                                                        # only one for has_reg_region (tool) (FBrf0099758)
         'FBal0137284': 'cic[Tag:HA]',  # single tagged_with (FBrf0144844, FBrf0180201), single has_reg_region (gene) (FBrf0144844, FBrf0180201)
@@ -88,11 +91,13 @@ class CassetteHandler(FeatureHandler):
         'FBal0032692': 'sev[S11.Tag:MYC]',     # associated_with FBtp0000326
         'FBal0392814': r'Scer\GAL4[lush.3]',     # associated_with FBtp0161516
         'FBal0250108': r'Scer\GAL4[GMR16C10]',     # associated_with FBtp0057873
-        'FBal0210886': 'wg[GD5007]',     # associated_with FBtp0032215
-        'FBal0209903': 'lbe[GD4157]',     # associated_with FBtp0031452
-        'FBal0365146': 'wg[TOE.GS00055]',     # associated_with FBtp0145396
-        'FBal0365030': 'Alp9[TKO.GS00469]',     # associated_with FBtp0145394
-        'FBal0365029': 'Alp10[TKO.GS00469]',     # associated_with FBtp0145394
+        # The "encodes_tool"-to-STR-FBsf cases: these are the ones that become a
+        # CassetteStrAssociationDTO rather than free text (FTA-227/FTA-228).
+        'FBal0210886': 'wg[GD5007]',     # associated_with FBtp0032215; encodes_tool FBsf0000074798 (RNAi_reagent).
+        'FBal0209903': 'lbe[GD4157]',     # associated_with FBtp0031452; encodes_tool FBsf0000074310 (RNAi_reagent).
+        'FBal0365146': 'wg[TOE.GS00055]',     # associated_with FBtp0145396; encodes_tool two sgRNA FBsf.
+        'FBal0365030': 'Alp9[TKO.GS00469]',     # associated_with FBtp0145394; encodes_tool FBsf0000910692 (sgRNA).
+        'FBal0365029': 'Alp10[TKO.GS00469]',     # associated_with FBtp0145394; encodes_tool FBsf0000910691 (sgRNA).
         'FBal0392014': r'Equa\eqFP578[TagRFP.UAS.Tag:TM(hPDGFRB)]',     # associated_with FBtp0161256
         'FBal0392013': r'Avic\GFP[G-CEPIA1.UAS.Tag:TM(hPDGFRB)]',     # associated_with FBtp0161256
         'FBal0343941': r'Scer\RCR1[UAS.Tag:MYC]',     # associated_with FBtp0131348
@@ -126,12 +131,36 @@ class CassetteHandler(FeatureHandler):
     # cassette_component_free_text_associations = []
     cassette_tool_associations = []
     cassette_genomic_entity_associations = []
+    cassette_str_associations = []
     cassette_cassette_rels = {}
     # Anonymous cassette data (populated via receive_anon_cassette_data).
     anon_cassette_data = []
     anon_cassettes = []
     anon_cassette_tool_associations = []
     anon_cassette_genomic_entity_associations = []
+    anon_cassette_str_associations = []
+
+    # FTA-224: the feature.type values that make an FBsf a sequence targeting reagent.
+    STR_SEQFEAT_TYPES = ('RNAi_reagent', 'sgRNA')
+
+    def _export_str_assocs(self):
+        """Whether cassette-STR components should be exported as CassetteStrAssociationDTOs.
+
+        Gated by ADD_CASS_TO_CONSTRUCT=YES like the rest of the cassette pipeline, so that
+        ungated runs keep emitting the pre-FTA-223 free-text components unchanged.
+        """
+        return getenv('ADD_CASS_TO_CONSTRUCT', None) == 'YES'
+
+    def _is_str_seqfeat(self, feature):
+        """Whether a feature_lookup entry is an STR FBsf (FTA-224).
+
+        Args:
+            feature (dict): A self.feature_lookup entry, which carries the feature.type
+                cvterm name under "type". All FBsf are in the lookup with their real type,
+                since feature_subtypes['seqfeat'] applies no type restriction.
+
+        """
+        return feature['uniquename'].startswith('FBsf') and feature['type'] in self.STR_SEQFEAT_TYPES
 
     def get_general_data(self, session):
         """Extend the method for the CassetteHandler."""
@@ -333,9 +362,14 @@ class CassetteHandler(FeatureHandler):
             assoc_type = 'tool_association'
 
         elif feature["uniquename"].startswith('FBsf'):  # cassette component is a seqfeat (FBid is a FBsf):
-            assoc_type = 'component_free_text'  # for now, will change to a CassetteGenomicEntityAssociationDTO
-            # once we start to submit FBsf features, so keep this loop in place for then even though at the
-            # moment it's not actually changing the type !
+            # Keep this default even though it is not changing the type: once we start submitting
+            # non-STR FBsf features these become a CassetteGenomicEntityAssociationDTO.
+            assoc_type = 'component_free_text'
+            # FTA-227: STR FBsf (feature.type of RNAi_reagent or sgRNA) are submitted as
+            # SequenceTargetingReagents, so their cassette components become a
+            # CassetteStrAssociationDTO instead of inline free text.
+            if self._is_str_seqfeat(feature) and self._export_str_assocs():
+                assoc_type = 'str_association'
 
         elif feature["uniquename"].startswith('FBgn'):  # cassette component is a gene (FBid is a FBgn):
             assoc_type = 'genomic_entity_association'
@@ -392,8 +426,8 @@ class CassetteHandler(FeatureHandler):
     def query_chado_and_export(self, session):
         """Elaborate on query_chado_and_export method for the CassetteHandler."""
         super().query_chado_and_export(session)
-        # self.generate_export_dict(self.cassette_component_free_text_associations,
-        #                           'cassette_str_association_ingest_set')
+        self.generate_export_dict(self.cassette_str_associations,
+                                  'cassette_str_association_ingest_set')
         self.generate_export_dict(self.cassette_genomic_entity_associations,
                                   'cassette_genomic_entity_association_ingest_set')
         self.generate_export_dict(self.cassette_tool_associations,
@@ -625,6 +659,17 @@ class CassetteHandler(FeatureHandler):
                     # first_feat_rel.linkmldto = rel_dto
                     cassette_rel.linkmldto = rel_dto
                     self.cassette_genomic_entity_associations.append(cassette_rel)
+                elif assoc_type == 'str_association':
+                    # CassetteStrAssociationDTO (FTA-228).
+                    if self.testing:
+                        mess = "map_cassette_associations: StrAssociation cass:"
+                        mess += f"{cassette_curie} comp:{component_curie} '{rel_type_name}'"
+                        self.log.debug(mess)
+                    rel_dto = agr_datatypes.CassetteStrAssociationDTO(
+                        cassette_curie, component_curie,
+                        pub_curies, False, rel_type_name)
+                    cassette_rel.linkmldto = rel_dto
+                    self.cassette_str_associations.append(cassette_rel)
             if cassette.is_obsolete is True or component['is_obsolete'] is True:
                 self.log.error(f"{cassette_curie} {component_curie} should never be obsolete??")
             counter += 1
@@ -732,14 +777,24 @@ class CassetteHandler(FeatureHandler):
                     fb_rel.linkmldto = rel_dto
                     self.anon_cassette_genomic_entity_associations.append(fb_rel)
                 elif component['uniquename'].startswith('FBsf'):
-                    symbol = component['symbol']
-                    organism_id = component['organism_id']
-                    taxon_text = self.organism_lookup[organism_id]['full_species_name']
-                    taxon_curie = self.organism_lookup[organism_id]['taxon_curie']
-                    comp_dto = agr_datatypes.CassetteComponentSlotAnnotationDTO(
-                        alliance_rel, symbol, taxon_curie, taxon_text,
-                        pub_curies).dict_export()
-                    data['anon_cassette_dto'].cassette_component_dtos.append(comp_dto)
+                    # FTA-229: STR FBsf become a CassetteStrAssociationDTO. In fb_2026_02 no STR
+                    # FBsf reaches this method (every cassette-STR link is "encodes_tool", handled
+                    # in map_anon_cassette_encodes_tool), so this branch is defensive: it keeps the
+                    # two paths consistent if such a relationship is ever curated.
+                    if self._is_str_seqfeat(component) and self._export_str_assocs():
+                        fb_rel = fb_datatypes.FBExportEntity()
+                        fb_rel.linkmldto = agr_datatypes.CassetteStrAssociationDTO(
+                            cassette_id, component_curie, pub_curies, False, alliance_rel)
+                        self.anon_cassette_str_associations.append(fb_rel)
+                    else:
+                        symbol = component['symbol']
+                        organism_id = component['organism_id']
+                        taxon_text = self.organism_lookup[organism_id]['full_species_name']
+                        taxon_curie = self.organism_lookup[organism_id]['taxon_curie']
+                        comp_dto = agr_datatypes.CassetteComponentSlotAnnotationDTO(
+                            alliance_rel, symbol, taxon_curie, taxon_text,
+                            pub_curies).dict_export()
+                        data['anon_cassette_dto'].cassette_component_dtos.append(comp_dto)
                 counter += 1
         self.log.info(f'Mapped {counter} simple component associations for anonymous cassettes.')
 
@@ -771,14 +826,23 @@ class CassetteHandler(FeatureHandler):
                     fb_rel.linkmldto = rel_dto
                     self.anon_cassette_genomic_entity_associations.append(fb_rel)
                 elif component['uniquename'].startswith('FBsf'):
-                    symbol = component['symbol']
-                    organism_id = component['organism_id']
-                    taxon_text = self.organism_lookup[organism_id]['full_species_name']
-                    taxon_curie = self.organism_lookup[organism_id]['taxon_curie']
-                    comp_dto = agr_datatypes.CassetteComponentSlotAnnotationDTO(
-                        'expresses', symbol, taxon_curie, taxon_text,
-                        pub_curies).dict_export()
-                    data['anon_cassette_dto'].cassette_component_dtos.append(comp_dto)
+                    # FTA-229: STR FBsf are submitted as SequenceTargetingReagents, so their
+                    # cassette components become a CassetteStrAssociationDTO; non-STR FBsf keep
+                    # the inline free-text component slot annotation for now.
+                    if self._is_str_seqfeat(component) and self._export_str_assocs():
+                        fb_rel = fb_datatypes.FBExportEntity()
+                        fb_rel.linkmldto = agr_datatypes.CassetteStrAssociationDTO(
+                            cassette_id, component_curie, pub_curies, False, 'expresses')
+                        self.anon_cassette_str_associations.append(fb_rel)
+                    else:
+                        symbol = component['symbol']
+                        organism_id = component['organism_id']
+                        taxon_text = self.organism_lookup[organism_id]['full_species_name']
+                        taxon_curie = self.organism_lookup[organism_id]['taxon_curie']
+                        comp_dto = agr_datatypes.CassetteComponentSlotAnnotationDTO(
+                            'expresses', symbol, taxon_curie, taxon_text,
+                            pub_curies).dict_export()
+                        data['anon_cassette_dto'].cassette_component_dtos.append(comp_dto)
                 counter += 1
         self.log.info(f'Mapped {counter} encodes_tool associations for anonymous cassettes.')
 
@@ -848,6 +912,14 @@ class CassetteHandler(FeatureHandler):
             self.anon_cassette_genomic_entity_associations.append(fb_rel)
             return True
         if uname.startswith('FBsf'):
+            # FTA-231: STR FBsf become a CassetteStrAssociationDTO; non-STR FBsf keep the
+            # inline free-text component slot annotation for now.
+            if self._is_str_seqfeat(component) and self._export_str_assocs():
+                fb_rel = fb_datatypes.FBExportEntity()
+                fb_rel.linkmldto = agr_datatypes.CassetteStrAssociationDTO(
+                    cassette_id, component_curie, pub_curies, False, alliance_rel)
+                self.anon_cassette_str_associations.append(fb_rel)
+                return True
             organism_id = component['organism_id']
             comp_dto = agr_datatypes.CassetteComponentSlotAnnotationDTO(
                 alliance_rel, component['symbol'],
@@ -974,6 +1046,10 @@ class CassetteHandler(FeatureHandler):
         self.flag_unexportable_entities(
             self.anon_cassette_genomic_entity_associations,
             'cassette_genomic_entity_association_ingest_set')
+        self.flag_internal_fb_entities('anon_cassette_str_associations')
+        self.flag_unexportable_entities(
+            self.anon_cassette_str_associations,
+            'cassette_str_association_ingest_set')
         # Append exportable anon cassettes to the existing export dicts.
         anon_count = 0
         for entity in self.anon_cassettes:
@@ -996,6 +1072,13 @@ class CassetteHandler(FeatureHandler):
                     entity.linkmldto.dict_export())
                 ge_count += 1
         self.log.info(f'Appended {ge_count} anon cassette genomic entity associations.')
+        str_count = 0
+        for entity in self.anon_cassette_str_associations:
+            if entity.for_export is True:
+                self.export_data['cassette_str_association_ingest_set'].append(
+                    entity.linkmldto.dict_export())
+                str_count += 1
+        self.log.info(f'Appended {str_count} anon cassette STR associations.')
 
     def populate_anon_cassettes_from_constructs(self, session):
         """Run ConstructHandler, ingest anon-cassette data, map both batches, and export.


### PR DESCRIPTION
Epic: [FTA-223](https://flybase.atlassian.net/browse/FTA-223). Closes [FTA-227](https://flybase.atlassian.net/browse/FTA-227), [FTA-228](https://flybase.atlassian.net/browse/FTA-228), [FTA-229](https://flybase.atlassian.net/browse/FTA-229), [FTA-231](https://flybase.atlassian.net/browse/FTA-231).

Routes cassette components that are sequence targeting reagents to `CassetteStrAssociationDTO`, filling `cassette_str_association_ingest_set`, instead of flattening them into inline `CassetteComponentSlotAnnotationDTO` free text. Second half of FTA-223; the STR entity export itself was #100, now merged, and this branch has been updated with it.

Non-STR FBsf keep the free-text treatment for now — they become `CassetteGenomicEntityAssociationDTO`s in a later epic, and the existing comments saying so are preserved.

## What changed

An STR FBsf is one whose `feature.type` is `RNAi_reagent` or `sgRNA` (FTA-224). The test is shared as `_is_str_seqfeat()`, reading the `type` that `build_feature_lookup()` already records, and applied at all four dispatch points:

| Ticket | Method | Path |
|---|---|---|
| FTA-227 | `cassette_dto_type()` | returns a new `str_association` type |
| FTA-228 | `map_cassette_associations()` | named cassettes — where 62,948 of the 64,509 associations come from |
| FTA-229 | `map_anon_cassette_encodes_tool()` | anonymous cassettes — the other 1,561 |
| FTA-231 | `_append_cassette_tool_dto()` | the FTA-182 generic-TI path |

Plus the export wiring: `cassette_str_associations` / `anon_cassette_str_associations`, `query_chado_and_export()`, `export_anon_cassettes()`, and the association TSV/JSON in the export script.

## A latent bug this fixes

`CassetteStrAssociationDTO` set an **`evidence`** slot that exists nowhere in the Alliance schema. The class was previously unused, so nothing had exercised it. It `is_a EvidenceAssociationDTO`, whose slot is `evidence_curies`. Left alone, every association emitted here would have failed `validate_agr_schema.py`, and `write_association_tsv()` — which looks for `evidence_curies` — would have printed "NO PUBS" on all 64,509 rows.

## Verified against three full runs on `fb_2026_02_reporting_audit`

Before the branch-B run I predicted the deltas from the baseline by matching component-slot symbols against the 133,567 validated STR names (exact set membership, not a name pattern). **Every predicted number came out exactly right.**

| Measure | Baseline (pre-change, gate on) | This branch, gate on |
|---|---|---|
| Component-slot rows | 96,616 | 32,107 |
| …of which STR reagents | 64,509 | **0** |
| `cassette_str_association_ingest_set` | absent | **64,509** |

64,509 rows out, 64,509 associations in, no STR reagent left behind as free text. Across 60,010 distinct cassettes and 64,009 distinct STR.

On the association set itself:

- **0 of 64,509 schema-invalid**, validated individually against `CassetteStrAssociationDTO` in the generated Alliance jsonschema.
- **0 dangling identifiers** — every one of the 64,009 STR referenced is present in the `str_ingest_set` from #100. This validates fine but fails at load time, so it was the main risk.
- **0 records carry a bare `evidence` key; 0 lack `evidence_curies`** — the fix confirmed in real output.
- All `relation_name: expresses`; no duplicate (cassette, STR, relation) triples; nothing internal or obsolete.

Nothing else moved: `_notes.tsv`, `_tool_uses.tsv` and both other association TSVs are **byte-identical (md5)** between baseline and this branch.

## Gating, and a correction

Gated behind `ADD_CASS_TO_CONSTRUCT=YES`, tested inside `cassette_dto_type()` and each dispatch point rather than at the call sites.

An earlier version of this description claimed an ungated run emits byte-identical output. **That was wrong at the file level**, and the gate-off run caught it: the combined association JSON had gained a top-level `"cassette_str_association_ingest_set": []` that main's output does not have, because `_export_associations()` assigned the key before testing for emptiness and the skip path left it behind. The claim held for the DTO routing — which is all the offline harnesses exercised — but not for the file, so a feature meant to be dormant was changing production output.

Fixed in `1e67448` by deleting the key on the skip path. Gate off now yields exactly the two association sets it carried before the STR set existed; gate on gains the third and writes its TSV; gated on with an empty set still raises, so a silently missing set cannot hide behind the change.

Gate-off behaviour is otherwise as intended: STR components revert to free text (62,948, all named — the anonymous pipeline is skipped entirely), no association set, no TSV. The arithmetic ties out across all three runs: gate-on adds exactly the 1,565 anonymous components (1,561 STR + 4 non-STR) that gate-off skips, and 96,616 − 95,051 = 1,565.

## Two things that look like differences but are not

- `cassette_curation....tsv` differs in **462 rows, all in the "secondary FBid(s)" column only, every one the same IDs reordered**. Cause is `list(set(...))` in `synthesize_secondary_ids()` at `src/entity_handler.py:1022` — string set-iteration order varies with `PYTHONHASHSEED` between processes. This branch has **zero** diff in `entity_handler.py`; I confirmed the flip across 8 fresh interpreters.
- The **710 WARNING/ERROR lines are identical in both runs** once line numbers (shifted by the added code) and within-list ordering are normalised. That ordering comes from the same set-iteration issue in `lookup_expresses_pub_curies()`, also untouched.

Worth a separate ticket: that nondeterminism makes two runs over identical data produce different files, which muddies review diffs and could cause needless updates at the persistent store. Out of scope here — fixing it would change output for alleles and tools too.

## Two data findings the tickets could not settle

- **Every cassette-to-STR relationship is `encodes_tool`** — zero via `has_reg_region`/`tagged_with`/`carries_tool`. `map_anon_cassette_simple_components()` is changed anyway so the two anon paths cannot diverge, but it converts **0 rows today**; commented as defensive, and Gillian has confirmed on FTA-229 that this is wanted.
- **The four `test_set` FBal commented "linked to an FBsf so a str association" are not STR cases** — each is `has_reg_region` to a `regulatory_region` FBsf, so they stay free text. Those comments are corrected, and the six FBal that do exercise the new path are annotated instead.

## Remaining

- A byte-level gate-off diff needs a **`main` gate-off run** to compare against; only this branch's exists. The one file-level difference identifiable by inspection is now fixed, and behaviour is demonstrably unchanged.
- **Production merge order**: #100's STR upload must land before the associations here reference those `FB:FBsf...` curies, or they fail at load with dangling identifiers. Git-wise the branches are independent and #100 is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FTA-223]: https://flybase.atlassian.net/browse/FTA-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-227]: https://flybase.atlassian.net/browse/FTA-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-228]: https://flybase.atlassian.net/browse/FTA-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-229]: https://flybase.atlassian.net/browse/FTA-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-231]: https://flybase.atlassian.net/browse/FTA-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ