### PR TITLE
feat(FTA-240): export comment and internalnotes props as STR note_dtos

### DIFF
--- a/src/AGR_data_retrieval_curation_str.py
+++ b/src/AGR_data_retrieval_curation_str.py
@@ -145,9 +145,19 @@ def main():
         log.error(f'The "{set_name}" is unexpectedly empty.')
         raise ValueError(f'The "{set_name}" is unexpectedly empty.')
     generate_export_file(export_dict, log, output_filename)
+    tsv_filename = set_up_dict['output_filename']
     curation_tsv.write_primary_tsv(
-        log=log, filename=set_up_dict['output_filename'], entities=export_dict[set_name],
+        log=log, filename=tsv_filename, entities=export_dict[set_name],
         datatype='str', symbol_source=_str_symbol, synonym_source=_str_synonyms,
+    )
+    # FTA-240: the notes themselves, plus the diagnostic report of note text that
+    # clean_free_text() could not handle, so curators can find the rows to fix.
+    curation_tsv.write_notes_tsv(
+        filename=tsv_filename.replace('.tsv', '_notes.tsv'), entities=export_dict[set_name],
+    )
+    curation_tsv.write_note_clean_failures_tsv(
+        filename=tsv_filename.replace('.tsv', '_internal_note_clean_failures.tsv'),
+        failures=str_handler.internal_note_clean_failures,
     )
 
     log.info('Ended main function.\n')

--- a/src/str_handler.py
+++ b/src/str_handler.py
@@ -39,6 +39,18 @@ class SequenceTargetingReagentHandler(FeatureHandler):
         'FBsf0000910691': 'sgRNA-GS00469.1',    # sgRNA, "encodes_tool" component of cassette FBal0365029.
         'FBsf0000910692': 'sgRNA-GS00469.2',    # sgRNA, "encodes_tool" component of cassette FBal0365030.
         'FBsf0000910567': 'sgRNA-GS00055.1',    # sgRNA, one of two components of cassette FBal0365146.
+        # FTA-240: note-bearing entities.
+        'FBsf0000032837': 'DRSC37925',          # "comment": reagent no longer exists at the DRSC.
+        'FBsf0000407135': 'BKN28870',           # "comment" carrying both an SGML entity (&ggr;) and @symbol@ markup.
+        'FBsf0000077885': 'dsRNA-GD8893',       # "internalnotes": must export as an internal_note.
+    }
+
+    # FTA-240: FlyBase props exported as Alliance notes. Same two chado prop types, and the same
+    # Alliance note types, as construct_prop_to_note_mapping - "internalnotes" is in
+    # convert_prop_to_note()'s internal_note_types, so those notes are flagged internal for us.
+    str_prop_to_note_mapping = {
+        'comment': ('comment', 'note_dtos'),               # SF6
+        'internalnotes': ('internal_note', 'note_dtos'),   # SF8 (marked internal automatically)
     }
 
     # Add methods to be run by get_general_data() below.
@@ -57,6 +69,7 @@ class SequenceTargetingReagentHandler(FeatureHandler):
         """Extend the method for the SequenceTargetingReagentHandler."""
         super().get_datatype_data(session)
         self.get_entities(session)
+        self.get_entityprops(session)    # FTA-240: "comment" and "internalnotes" props become notes.
         self.get_entity_pubs(session)
         self.get_entity_synonyms(session)
         self.get_entity_fb_xrefs(session)
@@ -86,6 +99,7 @@ class SequenceTargetingReagentHandler(FeatureHandler):
         self.map_data_provider_dto()
         self.map_xrefs()
         self.map_secondary_ids('secondary_identifiers')
+        self.map_entity_props_to_notes('str_prop_to_note_mapping')
         # Cascade chado-obsolete -> internal=True (matches every other handler).
         self.flag_internal_fb_entities('fb_data_entities')
         return


### PR DESCRIPTION
Closes [FTA-240](https://flybase.atlassian.net/browse/FTA-240), under epic [FTA-223](https://flybase.atlassian.net/browse/FTA-223). Follows #100 (STR export) and #101 (cassette-STR associations), both merged.

Adds the free text notes Gillian asked for: featureprop `comment` (proforma SF6) → Alliance `comment` note, `internalnotes` (SF8) → `internal_note`.

## Why it's this small

`construct_handler.py` already maps the same two chado prop types to the same Alliance note types, so this is a mapping declaration rather than new machinery:

```python
str_prop_to_note_mapping = {
    'comment': ('comment', 'note_dtos'),               # SF6
    'internalnotes': ('internal_note', 'note_dtos'),   # SF8 (marked internal automatically)
}
```

`internalnotes` is already in `convert_prop_to_note()`'s `internal_note_types`, so those notes are flagged internal without extra code, and `clean_note_free_text()` already tolerates NULL, blank and uncleanable values rather than aborting the export (FTA-211/FTA-221).

The handler now calls `get_entityprops()`, which it previously skipped because nothing needed props, and the script writes the two curator TSVs that belong with notes — the notes themselves, and the `_internal_note_clean_failures.tsv` diagnostic listing text `clean_free_text()` could not handle.

## Scope and data quality

| chado prop | Props | STR affected | With pubs | NULL/blank |
|---|---|---|---|---|
| `comment` | 798 | 772 (0.6% of 133,567) | 793 | 0 |
| `internalnotes` | 38 | 38 | 38 | 0 |

Only one value contains an SGML entity, and it's a legitimate Greek gamma (`eIF-2&ggr;`) rather than the junk that broke FTA-211. Nearly all carry pubs, so the notes get `evidence_curies`.

Content is user-facing and useful — mostly "Targeted gene annotation CG11229 was removed in subsequent FlyBase update" and "This reagent no longer exists at the DRSC".

## Verification

Driven against the **real** `convert_prop_to_note` / `map_entity_props_to_notes` / `clean_note_free_text` (extracted with `ast`, since importing the module needs sqlalchemy) using the actual chado note text:

- comments export non-internal, with their evidence curies;
- `@Su(var)3-9@ and @eIF-2&ggr;@` cleans to `Su(var)3-9 and eIF-2gamma`;
- `internalnotes` export as `internal_note` with `internal: true`;
- an STR with no props gets no notes;
- uncleanable text is recorded in `internal_note_clean_failures` rather than crashing.

A note-bearing `SequenceTargetingReagentDTO` validates against `allianceModel.schema.json`. `flake8 --docstring-convention google` clean.

Three note-bearing entities added to the test set: `FBsf0000032837`, `FBsf0000407135` (SGML entity + `@symbol@` markup) and `FBsf0000077885` (internal note).

## Full run results

Run against `fb_2026_02_reporting_audit` (`/data/alliance/PERSISTENT_main_FTA-240_str` on flysql26), and the predicted counts held exactly:

| chado featureprop | Alliance `note_type_name` | Notes | STR | `internal` |
|---|---|---|---|---|
| `comment` | `comment` | 798 | 772 | all `false` |
| `internalnotes` | `internal_note` | 38 | 38 | all `true` |

**0 warnings or errors**, **0 of 133,567 records schema-invalid**, and the `_internal_note_clean_failures.tsv` report is empty — every note's free text cleaned. 831 of 836 notes carry `evidence_curies`; the 5 without are comment props with no pub in chado. The awkward value cleaned as predicted: `@Su(var)3-9@ and @eIF-2&ggr;@` → `Su(var)3-9 and eIF-2gamma`. The primary curator TSV is **byte-identical** to the pre-notes full run.

## Side effect worth a reviewer's attention

Adding notes meant calling `get_entityprops()`, which this handler previously skipped. But `synthesize_pubs()` harvests pub_ids from *every* prop type it finds, not only the two mapped here — so **672 of 133,567 records (0.5%) gained exactly one `reference_curie`**. None lost any; nothing else in any record changed. Only two curies are involved set-wide: `FBrf0255493` (671) and `FBrf0225389` (1).

| Source | Records | Expected? |
|---|---|---|
| the notes' own evidence (`comment` / `internalnotes`) | 551 | yes |
| `gen_loc_comment` props | 121 | **no — beyond this ticket's ask** |

`FBrf0255493` is "dos Santos, 2023.2.8, Assessment of genes associated with sequence targeting reagents", so it is a genuine reference for those STR rather than noise. Recommendation is to **accept**: it makes STR consistent with allele, construct, cassette and transgenic tool, all of which call `get_entityprops()` and already fold prop pubs into `reference_curies` — STR was the outlier because it loaded no props at all. Suppressing it would mean filtering `props_by_type` for STR alone. Raised on FTA-240 for Gillian.

## Before this can actually reach the Alliance

Worth confirming that the Alliance's note-type vocabulary for STR admits `comment` and `internal_note`. Constructs already submit both terms successfully, so they exist — but for STR it is unverified, and like the `page_area` question in [FTA-242](https://flybase.atlassian.net/browse/FTA-242) it is rejected at **load** time rather than by `validate_agr_schema.py`. Same trip to the Alliance can answer both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FTA-240]: https://flybase.atlassian.net/browse/FTA-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-223]: https://flybase.atlassian.net/browse/FTA-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-242]: https://flybase.atlassian.net/browse/FTA-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
