### PR TITLE
feat(FTA-235): flag balancer aberrations with the is_balancer boolean

### DIFF
--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -52,7 +52,20 @@ def _is_aberration_cell(entity_dict):
     return 'true' if entity_dict.get('primary_external_id', '').startswith('FB:FBab') else ''
 
 
-# Allele primary TSV carries the FTA-217 aberration flag for curator review.
+def _make_is_balancer_cell(balancer_ids):
+    """Return a TSV cell function reporting 'true' for balancer-flagged FBab aberrations (FTA-235).
+
+    Reads the AberrationHandler's detected ID set rather than the exported 'is_balancer' key, so the
+    curator TSV is populated even when ADD_IS_ABERRATION is unset. That env var gates the JSON only, to
+    protect Alliance schema validation; it says nothing about which aberrations are balancers.
+    """
+    def _is_balancer_cell(entity_dict):
+        return 'true' if entity_dict.get('primary_external_id', '') in balancer_ids else ''
+    return _is_balancer_cell
+
+
+# Allele primary TSV carries the FTA-217 aberration flag for curator review; the FTA-235 balancer flag is
+# appended in main(), where the AberrationHandler that detected the balancers is available.
 _ALLELE_PRIMARY_EXTRAS = [
     ('is_aberration', _is_aberration_cell, ''),
 ]
@@ -85,8 +98,10 @@ Environment variables:
   ADD_ALLELE_ALLELE_ASSOC   Set to 'YES' to emit the FTA-218 'allele_allele_association_ingest_set' (aberration
                             'carries'/'breakpoint_allele' relations). Off by default: the Alliance schema has no
                             such ingest set and lacks the two CV terms, so the data cannot yet be loaded.
-  ADD_IS_ABERRATION         Set to 'YES' to emit the 'is_aberration' boolean for FBab entities.
-                            Requires a LinkML release containing the slot (absent from v2.17.0).
+  ADD_IS_ABERRATION         Set to 'YES' to emit the 'is_aberration' boolean for FBab entities, and the
+                            'is_balancer' boolean for those FBab entities flagged as balancers (FTA-235).
+                            Both slots come from the same schema PR (#327), so one gate covers them.
+                            Requires a LinkML release containing the slots (absent from v2.17.0).
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
@@ -156,9 +171,12 @@ def main():
         generate_export_file(export_dict, log, output_filename)
         tsv_filename = set_up_dict['output_filename']
         entities = export_dict['allele_ingest_set']
+        primary_extras = _ALLELE_PRIMARY_EXTRAS + [
+            ('is_balancer', _make_is_balancer_cell(aberration_handler.balancer_ids), ''),
+        ]
         curation_tsv.write_primary_tsv(
             log=log, filename=tsv_filename, entities=entities, datatype='allele',
-            extra_fields=_ALLELE_PRIMARY_EXTRAS,
+            extra_fields=primary_extras,
         )
         curation_tsv.write_notes_tsv(
             filename=tsv_filename.replace('.tsv', '_notes.tsv'), entities=entities,

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -107,6 +107,7 @@ class AlleleDTO(GenomicEntityDTO):
         self.in_collection_name = None                         # Will be the name of a FlyBase library/collection.
         self.is_extinct = None                                 # Make True if extinction reported; make False is stock exists; leave as None otherwise.
         self.is_aberration = None                              # Make True only for FBab aberrations; leave as None otherwise (FTA-217).
+        self.is_balancer = None                                # Make True only for FBab aberrations flagged as balancers; leave as None otherwise (FTA-235).
         self.allele_mutation_type_dtos = []                    # AlleleMutationTypeSlotAnnotationDTOs.
         self.allele_inheritance_mode_dtos = []                 # AlleleInheritanceModeSlotAnnotationDTOs.
         self.allele_database_status_dto = None                 # AlleleDatabaseStatusSlotAnnotationDTOs.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -9,6 +9,7 @@ Author(s):
 
 """
 
+import re
 from logging import Logger
 from os import getenv
 from sqlalchemy.orm import aliased
@@ -1221,6 +1222,16 @@ class AberrationHandler(MetaAlleleHandler):
         'complementation': ('complementation', 'note_dtos'),     # FBab
     }
 
+    # FTA-235: the balancer flag arrives as an "A15. Internal notes" featureprop on 37 FBab aberrations,
+    # added by curation record sm21867.edit (loaded 2026-08-13). The proforma line is:
+    #   ! A15.  Internal notes *K :FTA: Balancer - mark this aberration as 'balancer'.
+    # Whether the stored featureprop value keeps the proforma ":" separator is not knowable until the
+    # record is loaded, so tolerate a leading colon and match the "FTA:" marker plus its "Balancer"
+    # keyword case-insensitively. Anchored at the start of the value, so ordinary prose that merely
+    # mentions balancers (many FBab "misc" and "internal_notes" props do) cannot match.
+    balancer_flag_regex = re.compile(r'^\s*:?\s*FTA:\s*balancer\b', re.IGNORECASE)
+    balancer_flag_expected_count = 37    # Per FTA-235; a mismatch means the flag text or the curation record changed.
+
     # Additional export sets.
     aberration_gene_rels = {}            # Will be (FBab feature_id, FBgn feature_id, AGR_rel_type, ECO) tuples keying lists of FBRelationships.
     aberration_gene_associations = []    # Will be the final list of gene-aberration FBRelationships to export (AlleleGeneAssociationDTO under linkmldto attr).
@@ -1228,6 +1239,7 @@ class AberrationHandler(MetaAlleleHandler):
     aberration_allele_rels = {}          # Will be (FBab feature_id, FBal/FBti feature_id, AGR_rel_type) tuples keying lists of FBRelationships.
     aberration_allele_associations = []  # Will be the final list of aberration-allele FBRelationships (AlleleAlleleAssociationDTO under linkmldto attr).
     cassette_ignore_list = set()         # FTA-218: FBal feature_ids that are construct cassettes, and so are never exported as alleles.
+    balancer_ids = set()                 # FTA-235: FB curies of FBab aberrations flagged as balancers; filled regardless of the export gate.
 
     # Additional reference info.
     chr_str_var_terms = []    # A list of cvterm_ids for child terms of "chromosome_structure_variation" (SO:0000240).
@@ -1620,6 +1632,40 @@ class AberrationHandler(MetaAlleleHandler):
         self.log.info(f'Flagged {counter} aberrations with is_aberration=True.')
         return
 
+    def map_balancer_flag(self):
+        """Flag FBab entities carrying the curated balancer internal note with "is_balancer" (FTA-235).
+
+        The "is_balancer" slot came from the same agr_curation_schema PR (#327) as "is_aberration", so it
+        shares the ADD_IS_ABERRATION gate: both slots reach the Alliance in the same LinkML release, and
+        emitting either before then would fail schema validation for the whole allele file.
+        The FBab IDs are always collected into self.balancer_ids, gate or no gate, so the curator TSV can
+        report the flag while the JSON export stays clean (mirrors _is_aberration_cell() in the script).
+        Per FTA-235 these aberrations get both is_balancer=True and is_aberration=True.
+        """
+        self.log.info('Flag aberrations carrying the curated balancer internal note with the "is_balancer" boolean.')
+        add_flag = getenv('ADD_IS_ABERRATION', None) == 'YES'
+        if not add_flag:
+            self.log.info('ADD_IS_ABERRATION not set to "YES"; detecting balancers for the TSV, but not exporting '
+                          'the "is_balancer" flag.')
+        for aberration in self.fb_data_entities.values():
+            if aberration.linkmldto is None:
+                continue
+            for fb_prop in aberration.props_by_type.get('internal_notes', []):
+                prop_value = fb_prop.chado_obj.value
+                if not prop_value or not self.balancer_flag_regex.match(prop_value):
+                    continue
+                self.balancer_ids.add(f'FB:{aberration.uniquename}')
+                self.log.debug(f'Balancer flag found for {aberration}: "{prop_value}"')
+                if add_flag:
+                    aberration.linkmldto.is_balancer = True
+                break
+        self.log.info(f'Found {len(self.balancer_ids)} aberrations carrying the curated balancer internal note.')
+        # In testing mode only a handful of FBab entities are fetched, so the expected count cannot be met.
+        if self.testing is False and len(self.balancer_ids) != self.balancer_flag_expected_count:
+            self.log.warning(f'Expected {self.balancer_flag_expected_count} balancer-flagged aberrations per FTA-235, '
+                             f'but found {len(self.balancer_ids)}. Check the "internal_notes" flag text in chado.')
+        return
+
     def map_aberration_allele_associations(self):
         """Map aberration-allele associations to Alliance object (FTA-218)."""
         self.log.info('Map aberration-allele associations to Alliance object.')
@@ -1660,6 +1706,7 @@ class AberrationHandler(MetaAlleleHandler):
         super().map_fb_data_to_alliance()
         self.map_metaallele_basic()
         self.map_aberration_flag()
+        self.map_balancer_flag()
         self.map_metaallele_database_status()
         self.map_internal_metaallele_status()
         self.map_aberration_mutation_types()

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1205,6 +1205,8 @@ class AberrationHandler(MetaAlleleHandler):
         'FBab0001546': 'Df(2L)Sco[rv10]',  # FTA-207 note props: complementation, internal_notes, misc, origin_comment.
         'FBab0004410': 'In(2L)Cy',              # FTA-218: all 3 mappings - 2 A24a FBti, 6 A24b FBal, 1 GA10g FBal.
         'FBab0045412': 'Df(3L)sina[SH]',        # FTA-218: all 3 mappings - 1 A24a FBti, 1 A24b FBal, 2 GA10g FBal.
+        'FBab0004786': 'In(2LR)CyO',            # FTA-235: carries the balancer "internal_notes" flag.
+        'FBab0003929': 'In(1)FM7a',             # FTA-235: carries the balancer "internal_notes" flag.
     }
 
     # Simple mapping of props to Alliance note types, for cases where it is one-to-one correspondence.
@@ -1223,13 +1225,15 @@ class AberrationHandler(MetaAlleleHandler):
     }
 
     # FTA-235: the balancer flag arrives as an "A15. Internal notes" featureprop on 37 FBab aberrations,
-    # added by curation record sm21867.edit (loaded 2026-08-13). The proforma line is:
-    #   ! A15.  Internal notes *K :FTA: Balancer - mark this aberration as 'balancer'.
-    # Whether the stored featureprop value keeps the proforma ":" separator is not knowable until the
-    # record is loaded, so tolerate a leading colon and match the "FTA:" marker plus its "Balancer"
-    # keyword case-insensitively. Anchored at the start of the value, so ordinary prose that merely
-    # mentions balancers (many FBab "misc" and "internal_notes" props do) cannot match.
-    balancer_flag_regex = re.compile(r'^\s*:?\s*FTA:\s*balancer\b', re.IGNORECASE)
+    # added by curation record sm21867.edit. Verified in production_chado: 37 "internal_notes" props, all on
+    # non-obsolete "chromosome_structure_variation" features, each holding exactly
+    #   FTA: Balancer - mark this aberration as 'balancer'.
+    # (the proforma ":" separator is not kept in the stored value; a leading colon is tolerated anyway).
+    # The instruction clause is part of the match on purpose: FBba balancers carry sibling flags that also
+    # begin "FTA: Balancer -" ("merge with parent ...", "use balancer symbol and fullname for parent ..."),
+    # 62 of them, and those mean something else. Anchoring also keeps ordinary prose that merely mentions
+    # balancers - which plenty of FBab "misc" and "internal_notes" props do - from matching.
+    balancer_flag_regex = re.compile(r'^\s*:?\s*FTA:\s*balancer\s*-\s*mark this aberration as\b', re.IGNORECASE)
     balancer_flag_expected_count = 37    # Per FTA-235; a mismatch means the flag text or the curation record changed.
 
     # Additional export sets.


### PR DESCRIPTION
## Summary

[FTA-235](https://flybase.atlassian.net/browse/FTA-235): curation record `sm21867.edit` adds an "A15. Internal notes" flag to 37 FBab aberrations, marking each as a balancer. `AberrationHandler.map_balancer_flag()` detects that flag in the `internal_notes` featureprops and sets the LinkML `is_balancer` boolean, so those aberrations export with both `is_balancer=true` and `is_aberration=true` (FTA-217).

- `src/agr_datatypes.py` — re-adds `AlleleDTO.is_balancer`, dropped in 6bc88c5 when no chado signal for balancers was known.
- `src/allele_handlers.py` — `map_balancer_flag()`, called right after `map_aberration_flag()`. No new query: `props_by_type` already holds every FBab prop type. Two of the 37 aberrations added to `test_set` so testing-mode runs exercise the flag.
- `src/AGR_data_retrieval_curation_allele.py` — `is_balancer` column in the allele primary TSV, plus updated env-var docs.

## Gating

`is_balancer` came from the same `agr_curation_schema` PR ([#327](https://github.com/alliance-genome/agr_curation_schema/pull/327)) as `is_aberration`, so both slots reach the Alliance in the same LinkML release and share the existing **`ADD_IS_ABERRATION`** gate. With the gate off, the JSON omits the slot but the FBab IDs are still collected, so the new TSV column is populated for curator review — mirroring the `is_aberration` TSV cell.

## Flag matching (verified against production_chado)

The record is loaded. The flag is exactly 37 `internal_notes` props, byte-identical:

```
FTA: Balancer - mark this aberration as 'balancer'.
```

All 37 sit on non-obsolete `chromosome_structure_variation` features, one flag prop and one `featureprop_pub` each. The proforma `:` separator is **not** kept in the stored value (a leading colon is tolerated anyway).

The match requires the instruction clause — `^\s*:?\s*FTA:\s*balancer\s*-\s*mark this aberration as\b`, case-insensitive — because FBba balancers carry 62 sibling flags that open identically but mean something else:

| prop | ID | n | value |
|---|---|---|---|
| `internal_notes` | FBab | 37 | `FTA: Balancer - mark this aberration as 'balancer'.` |
| `internal_notes` | FBba | 62 | `FTA: Balancer - merge with parent …` / `FTA: Balancer - use balancer symbol and fullname for parent …` |

Anchoring also keeps ordinary prose that merely mentions balancers (plenty of FBab `misc` and `internal_notes` props do) from matching. A count other than 37 logs a warning (suppressed in testing mode).

The flag note itself still exports as an `internal_note` NoteDTO with `internal: true`, as it does today — deliberate, per discussion.

## Testing

- `py_compile` clean; no lines over the 160-char `.flake8` limit; no trailing whitespace.
- An offline harness drove the real `map_balancer_flag()` source with duck-typed props/DTOs (8/8 checks): the exact production_chado value across 37 entities, the tolerated variants, the real FBba sibling flags, real FBab prose, NULL prop values, gate on/off, testing mode, and the exact-37 no-warning case.
- The real `write_primary_tsv()` was run to confirm the new column lands correctly.
- **Full run against `production_chado`** (13 Aug, `-l main`, `ADD_IS_ABERRATION=YES`, artifacts in `flysql26:/data/alliance/PERSISTENT_main_FTA-235_balancer/`):
  - log: `Found 37 aberrations carrying the curated balancer internal note.` — no count warning; 0 ERRORs, and all 357 WARNINGs are pre-existing `entity_handler` types unrelated to this change; 0 uncleanable note props.
  - JSON: `"is_balancer": true` × 37 and `"is_aberration": true` × 36859, with no `false` values — the slot stays absent for every other allele.
  - the 37 exported IDs diff identical to the 37 FBab carrying the flag in chado, and the symbols are the classic balancers (FM7a, Basc, CyO, SM1/SM5/SM6, TM1/TM2/TM3/TM6/TM6B/TM6C/TM8/TM9/TMS, ...). No FBba sibling-flag contamination.
  - TSV: 37 `is_balancer=true` rows, all also `is_aberration=true`. The flag note appears 37× in the notes TSV as `internal_note` / `internal: true`.

## Still blocked on a schema release

The run used `-l main`. No LinkML **release** carries these slots yet — v2.17.0 (latest, 15 Jun) has zero `is_balancer` occurrences — so the output cannot be schema-validated or uploaded until a release picks up #327. That is exactly what the `ADD_IS_ABERRATION` gate exists for: with the gate off this branch is a no-op on the JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FTA-235]: https://flybase.atlassian.net/browse/FTA-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
