### PR TITLE
feat(FTA-236, FTA-237): merge balancer data into parent aberrations and rename them

### DIFF
--- a/docs/FTA-236/expected_counts.sql
+++ b/docs/FTA-236/expected_counts.sql
@@ -1,0 +1,152 @@
+-- FTA-236 expectation queries. Run on flysql26:
+--   PGPASSWORD=ilongdenpgsql psql -h flysql24 -U ilongden -d production_chado -f expected_counts.sql
+-- The numbers these produce are the table in docs/FTA-236/plan.md ("Verified input data").
+-- NB psql here runs with standard_conforming_strings = off, so set it before using \y in a regex.
+set standard_conforming_strings = on;
+
+\echo === 1. FTA flag families on FBba (expect: merge 38, symbol/fullname 24) ===
+select case when fp.value like 'FTA: Balancer - merge with parent%' then 'merge with parent (FTA-236)'
+            when fp.value like 'FTA: Balancer - use balancer symbol and fullname%' then 'use symbol/fullname (FTA-237)'
+            else 'other FTA: flag' end as flag,
+       count(*) as props, count(distinct f.feature_id) as fbba
+from feature f
+join featureprop fp on fp.feature_id = f.feature_id
+join cvterm cvt on cvt.cvterm_id = fp.type_id
+where f.uniquename like 'FBba%' and cvt.name = 'internal_notes' and fp.value like 'FTA:%'
+group by 1 order by 2 desc;
+
+\echo === 2. merge flags vs parents vs the FTA-235 is_balancer set (expect 38 / 37 / 36 / 0) ===
+with merges as (
+  select f.uniquename as fbba, substring(fp.value from 'FBab[0-9]+') as parent_fbab
+  from feature f
+  join featureprop fp on fp.feature_id = f.feature_id
+  join cvterm cvt on cvt.cvterm_id = fp.type_id
+  where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - merge with parent%'
+),
+flagged as (
+  select f.uniquename as fbab
+  from feature f
+  join featureprop fp on fp.feature_id = f.feature_id
+  join cvterm cvt on cvt.cvterm_id = fp.type_id
+  where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - mark this aberration%'
+)
+select count(*) as merge_flags,
+       count(distinct parent_fbab) as distinct_parents,
+       count(distinct parent_fbab) filter (where parent_fbab in (select fbab from flagged)) as parents_also_is_balancer,
+       count(*) filter (where parent_fbab is null) as unparsed_parent
+from merges;
+
+\echo === 3. parents named by more than one balancer (expect only FBab0004818, SM6a + SM6b) ===
+select substring(fp.value from 'FBab[0-9]+') as parent_fbab, count(*) as n_balancers,
+       string_agg(f.uniquename, ', ' order by f.uniquename) as fbba
+from feature f
+join featureprop fp on fp.feature_id = f.feature_id
+join cvterm cvt on cvt.cvterm_id = fp.type_id
+where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - merge with parent%'
+group by 1 having count(*) > 1 order by 2 desc;
+
+\echo === 4. parents named by a merge flag that are obsolete or absent (expect FBab0007127 until fixed) ===
+select b.uniquename as fbba, substring(fp.value from 'FBab[0-9]+') as parent_fbab,
+       p.is_obsolete as parent_is_obsolete
+from feature b
+join featureprop fp on fp.feature_id = b.feature_id
+join cvterm cvt on cvt.cvterm_id = fp.type_id
+left join feature p on p.uniquename = substring(fp.value from 'FBab[0-9]+')
+where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - merge with parent%'
+  and (p.feature_id is null or p.is_obsolete is true)
+order by 1;
+
+\echo === 5. volume to move per source field (expect 96 / 35 / 10 / 326 / 10 / 27 / 68 / 440) ===
+with fbba as (
+  select distinct f.feature_id, f.uniquename
+  from feature f
+  join featureprop fp on fp.feature_id = f.feature_id
+  join cvterm cvt on cvt.cvterm_id = fp.type_id
+  where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - merge with parent%'
+)
+select 'symbol synonyms (AB1b)' as source, count(*) as rows, count(distinct b.feature_id) as fbba_with_data
+  from fbba b
+  join feature_synonym fs on fs.feature_id = b.feature_id
+  join synonym s on s.synonym_id = fs.synonym_id
+  join cvterm t on t.cvterm_id = s.type_id
+  where t.name = 'symbol'
+union all
+select 'fullname synonyms (AB2b)', count(*), count(distinct b.feature_id)
+  from fbba b
+  join feature_synonym fs on fs.feature_id = b.feature_id
+  join synonym s on s.synonym_id = fs.synonym_id
+  join cvterm t on t.cvterm_id = s.type_id
+  where t.name = 'fullname'
+union all
+select 'secondary IDs (feature_dbxref FBba)', count(*), count(distinct b.feature_id)
+  from fbba b
+  join feature_dbxref fd on fd.feature_id = b.feature_id
+  join dbxref dx on dx.dbxref_id = fd.dbxref_id
+  join db on db.db_id = dx.db_id
+  where db.name = 'FlyBase' and dx.accession like 'FBba%'
+union all
+select 'carries alleles (AB5b, carried_on, FBba as object)', count(*), count(distinct b.feature_id)
+  from fbba b
+  join feature_relationship fr on fr.object_id = b.feature_id
+  join cvterm t on t.cvterm_id = fr.type_id
+  where t.name = 'carried_on'
+union all
+select 'transposon insertions (AB5a, associated_with, FBba as subject)', count(*), count(distinct b.feature_id)
+  from fbba b
+  join feature_relationship fr on fr.subject_id = b.feature_id
+  join cvterm t on t.cvterm_id = fr.type_id
+  where t.name = 'associated_with'
+union all
+select 'other info (AB6, misc prop)', count(*), count(distinct b.feature_id)
+  from fbba b
+  join featureprop fp on fp.feature_id = b.feature_id
+  join cvterm t on t.cvterm_id = fp.type_id
+  where t.name = 'misc'
+union all
+select 'internal_notes props (incl. the merge flag itself)', count(*), count(distinct b.feature_id)
+  from fbba b
+  join featureprop fp on fp.feature_id = b.feature_id
+  join cvterm t on t.cvterm_id = fp.type_id
+  where t.name = 'internal_notes'
+union all
+select 'references (feature_pub)', count(*), count(distinct b.feature_id)
+  from fbba b
+  join feature_pub fpb on fpb.feature_id = b.feature_id
+order by 1;
+
+\echo === 6. carried_on rows total vs those held back by the 3 exclusions (expect 326 / 54 / 53) ===
+with merges as (
+  select f.feature_id as fbba_id, f.uniquename as fbba
+  from feature f
+  join featureprop fp on fp.feature_id = f.feature_id
+  join cvterm cvt on cvt.cvterm_id = fp.type_id
+  where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - merge with parent%'
+)
+select count(distinct fr.feature_relationship_id) as carried_on_rows,
+       count(distinct fr.subject_id) as distinct_alleles,
+       count(distinct fr.feature_relationship_id) filter (where m.fbba in ('FBba0000011', 'FBba0000039', 'FBba0000040')) as excluded_rows
+from merges m
+join feature_relationship fr on fr.object_id = m.fbba_id
+join cvterm t on t.cvterm_id = fr.type_id and t.name = 'carried_on';
+
+\echo === 7. the worked example from the ticket: Basc (FBba0000014) -> In(1)Basc (FBab0004219) ===
+select 'symbol synonym' as datum, s.name as value
+  from feature f
+  join feature_synonym fs on fs.feature_id = f.feature_id
+  join synonym s on s.synonym_id = fs.synonym_id
+  join cvterm t on t.cvterm_id = s.type_id
+  where f.uniquename = 'FBba0000014' and t.name = 'symbol'
+union all
+select 'carried allele', a.name
+  from feature b
+  join feature_relationship fr on fr.object_id = b.feature_id
+  join cvterm t on t.cvterm_id = fr.type_id
+  join feature a on a.feature_id = fr.subject_id
+  where b.uniquename = 'FBba0000014' and t.name = 'carried_on'
+union all
+select 'comment (AB6)', fp.value
+  from feature b
+  join featureprop fp on fp.feature_id = b.feature_id
+  join cvterm t on t.cvterm_id = fp.type_id
+  where b.uniquename = 'FBba0000014' and t.name = 'misc'
+order by 1, 2;

--- a/docs/FTA-236/plan.md
+++ b/docs/FTA-236/plan.md
@@ -579,11 +579,21 @@ In `src/entity_handler.py`, in `synthesize_synonyms()`, immediately after the ex
 ```python
                 # FTA-236: a balancer's names must never rival the parent aberration's own. Unlike
                 # merged_synonym_ids this covers full names too: map_synonyms() sets no
-                # allele_full_name_dto at all when it finds two current full names, so an
-                # undemoted balancer full name would delete the aberration's own from the export.
-                if syno_id in fb_data_entity.demoted_synonym_ids:
+                # allele_full_name_dto at all when it finds two current full names, so an undemoted
+                # balancer full name would delete the aberration's own from the export. The entity's
+                # own name is exempt for the same reason as above - a synonym_id can be shared by both
+                # features, and the entity must never lose its own name.
+                is_demoted = syno_id in fb_data_entity.demoted_synonym_ids
+                if syno_dict['is_current'] is True and is_demoted and syno_dict['format_text'] != fb_data_entity.name:
                     syno_dict['is_current'] = False
 ```
+
+The `format_text != fb_data_entity.name` exemption mirrors the `merged_synonym_ids` guard just above it.
+Checked in production_chado: no balancer/parent pair currently shares a `synonym_id` that is current on
+both sides, and no balancer's current name equals its parent's `feature.name`, so the exemption never
+fires today. It is there because `synonym` rows are global and shared through `feature_synonym` - 24 of
+the grafted `synonym_id`s already exist (non-current) on their parent - so if a future curation change
+made one of those the parent's own current name, an unconditional demotion would delete it.
 
 - [ ] **Step 4: Add the prop whitelist attribute**
 

--- a/docs/FTA-236/plan.md
+++ b/docs/FTA-236/plan.md
@@ -1,0 +1,975 @@
+# FTA-236 — Merge flagged FBba balancer data into parent FBab aberration entries
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** For each of the 38 FBba balancers carrying the curated `FTA: Balancer - merge with parent <SYMBOL> (<FBab_ID>).` internal note, fold that balancer's synonyms, secondary IDs, comments, internal notes, references and "carries alleles"/"transposon insertions" relationships into its parent FBab aberration's Alliance allele record.
+
+**Architecture:** The `AberrationHandler` gains a nested `BalancerHandler` run (exactly as `AlleleHandler.get_insertion_entities()` runs a nested `InsertionHandler`), parses the merge flags into a `{FBba feature_id: parent FBab feature_id}` map, and then grafts whitelisted FBba data onto the parent `FBAberration` object **before** `synthesize_*` runs — the same technique `add_fbal_to_fbti()` uses for FBti absorbing FBal. Grafting means every existing mapping method (`map_synonyms`, `map_secondary_ids`, `map_entity_props_to_notes`, `map_pubs`) produces the merged output with no changes. The "carries alleles" relationships are the one exception: they are injected directly into `self.aberration_allele_rels` rather than grafted, so they cannot leak into aberration-**gene** association synthesis.
+
+**Tech Stack:** Python 3.11, SQLAlchemy ORM over FlyBase chado (`harvdev_utils.reporting` models), Alliance LinkML DTOs in `src/agr_datatypes.py`.
+
+## Global Constraints
+
+- **PEP8, `max-line-length = 160`** from `.flake8`. `ignore = D100,D103,D104` **replaces** pycodestyle's defaults, so **W503 and W504 are both active**: never break a line before *or* after a boolean operator — wrap the whole condition in a helper or a single line. Docstrings are required on new public methods (D102 is active).
+- **No local script runs.** The repo venv is x86_64 and unusable on this arm64 Mac; there is no `flake8`, `sqlalchemy` or `harvdev_utils` on any system Python. Verification is: `python3 -m py_compile`, the offline `ast`-extraction harnesses defined in this plan, SQL against chado, and a real run on flysql26.
+- **chado access:** `ssh flysql26` then `PGPASSWORD=ilongdenpgsql psql -h flysql24 -U ilongden -d production_chado`. Run `set standard_conforming_strings = on;` first if a regex uses `\y`, or the escape is silently eaten and the pattern matches nothing.
+- **Run artifacts** live in `flysql26:/data/alliance/PERSISTENT_*`. A full allele run takes ~85 minutes.
+- **Gating.** Everything that emits an `allele_allele_association_ingest_set` entry stays behind `ADD_ALLELE_ALLELE_ASSOC=YES` (FTA-218: the Alliance has no such ingest set and lacks the `carries`/`breakpoint_allele` CV terms). Everything else in this ticket uses slots that already exist in released LinkML and needs **no** gate.
+- **Never commit without explicit permission from Ian.** Each task's commit step is prepared, but only run when he asks.
+- **Conventional Commits**, scope `FTA-236`, and `git add <specific paths>` only.
+
+## Open dependency — resolve before Task 2 lands
+
+`FBba0000688`'s note names `FBab0007127`, which is **obsolete** (a non-current secondary ID of `FBab0049550`, the current T(2;3)A1-W and the aberration that carries the FTA-235 `is_balancer` flag). Asked on FTA-236 (comment 43812, 2026-08-14):
+
+- **Option 1 (preferred, assumed by this plan):** Steven fixes the note; the code treats an obsolete/unknown parent as a reported error and skips the merge. Task 1 implements this.
+- **Option 2:** the code resolves parent IDs through `feature_dbxref` to the current feature. If Steven picks this, Task 1's `_resolve_parent_feature_id()` gains a secondary-ID fallback — the hook is called out in that task, so the change is one method, not a redesign.
+
+Until Steven answers, expect **37 of 38** merges to succeed and one logged error naming `FBba0000688`.
+
+---
+
+## Verified input data (production_chado, 2026-08-14)
+
+| fact | value |
+|---|---|
+| FBba with merge flag | 38 (one `internal_notes` prop each) |
+| distinct parent FBab named | 37 (`FBab0004818` named twice: `FBba0000039` SM6a + `FBba0000040` SM6b) |
+| parents that also carry the FTA-235 flag | 36 (the T(2;3)A1-W pair is the mismatch above) |
+| symbol synonyms to move | 96 rows over 38 FBba |
+| fullname synonyms to move | 35 rows over 28 FBba |
+| FBba secondary IDs (`feature_dbxref`) | 10 rows over 7 FBba (plus the 38 current FBba IDs) |
+| `carried_on` alleles (FBal subject → FBba object) | 326 rows, 54 distinct FBal, over 37 FBba |
+| `associated_with` insertions (FBba subject → FBti object) | 10 rows over 6 FBba |
+| `misc` props (AB6) | 27 rows over 22 FBba |
+| `internal_notes` props | 68 rows over 38 FBba (includes the merge flag itself) |
+| `feature_pub` references | 440 rows over 38 FBba |
+| rows removed by the 3 hard-coded exclusions | 53 of the 326 (`FBba0000011` FM1 = 15, `FBba0000039` SM6a = 20, `FBba0000040` SM6b = 18) |
+
+## The full-name trap (drives a shared-file change in Task 2)
+
+`map_synonyms()` treats a second *current symbol* and a second *current full name* very differently:
+
+- **symbols** (`entity_handler.py:1282-1298`): a chooser prefers the entity's own name, demotes the rest to synonyms, and logs `Found many current symbols`. Recoverable.
+- **full names** (`entity_handler.py:1300-1304`): with more than one current full name it logs `Found many current full_names` and **sets no `allele_full_name_dto` at all** — the aberration silently loses its own full name from the export.
+
+28 of the 38 balancers have current `fullname` synonyms, so a naive graft would blank the full name on most merged aberrations. `merged_synonym_ids` does not help: `entity_handler.py:1071` only demotes types in `symbol_type_names`, and that narrowness is deliberate (FTA-234: FBti *should* inherit a merged FBal's full name).
+
+FTA-236 wants neither slot overwritten — the ticket's target for both AB1b and AB2b is `allele_synonyms`. So Task 2 adds one new entity attribute, `demoted_synonym_ids`, honoured for **all** name types, and populates it from the grafted balancer synonyms. Existing behaviour is unchanged because the set is empty for every other entity.
+
+## File Structure
+
+- **Modify `src/allele_handlers.py`** — all handler work lands in `class AberrationHandler`. New class attributes, one retrieval method, one synthesis-map method, one graft method, one association-injection method, and four one-line calls into the existing `get_datatype_data()` / `synthesize_info()` hooks. This file is already ~1800 lines and organised by handler class; follow that structure rather than splitting.
+- **Modify `src/fb_datatypes.py`** — one new `FBDataEntity` attribute, `demoted_synonym_ids`, beside `merged_synonym_ids` (line 95).
+- **Modify `src/entity_handler.py`** — three lines in `synthesize_synonyms()` honouring that set for every name type.
+- **Modify `src/AGR_data_retrieval_curation_allele.py`** — document the behaviour in the `--help` epilog and add the balancer-merge curator TSV.
+- **Modify `src/curation_tsv.py`** — nothing. The new TSV is written by a small local writer in the retrieval script only if `write_association_tsv()` cannot be reused; Task 4 checks that first and reuses it if it fits.
+- **Create `docs/FTA-236/verify_merge_map.py`** — offline harness for Task 1 (flag parsing + parent resolution).
+- **Create `docs/FTA-236/verify_graft.py`** — offline harness for Tasks 2 and 3 (grafting and association injection).
+- **Create `docs/FTA-236/expected_counts.sql`** — the SQL that produces the expectation table above (written and verified against production_chado on 2026-08-14; every number in the table came from it), so any run's log/TSV can be re-checked against chado.
+
+---
+
+### Task 1: Parse the merge flags and resolve each parent aberration
+
+**Files:**
+- Modify: `src/allele_handlers.py` (class `AberrationHandler`: new class attributes next to `balancer_flag_regex` at ~line 1225; new methods `get_balancer_entities()` and `synthesize_balancer_merge_map()`; calls added in `get_datatype_data()` ~line 1345 and `synthesize_info()` ~line 1548)
+- Create: `docs/FTA-236/verify_merge_map.py`
+- Create: `docs/FTA-236/expected_counts.sql`
+
+**Interfaces:**
+- Consumes: `self.fb_data_entities` (feature_id-keyed `FBAberration`), `self.testing`, `self.log`, `export_chado_data` (already imported at the top of the module), `BalancerHandler` (defined later in the same module — reference it inside the method body, not at import time).
+- Produces:
+  - `self.fbba_entities` — `{FBba feature_id: FBBalancer}`, every FBba in chado, from the nested handler.
+  - `self.balancer_merge_map` — `{FBba feature_id: parent FBab feature_id}`, only successfully resolved merges.
+  - `self.balancer_merge_regex` — compiled pattern with named groups `symbol` and `fbab`.
+  - `BALANCER_MERGE_EXPECTED = 38` — module-level constant, used by later log warnings.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `docs/FTA-236/verify_merge_map.py`. It extracts the real method source with `ast` and drives it with duck-typed stand-ins, because no package imports work on this machine.
+
+```python
+"""Offline harness for AberrationHandler.synthesize_balancer_merge_map() (FTA-236).
+
+Extracts the method source with ast and drives it with duck-typed stand-ins, since
+sqlalchemy/harvdev_utils cannot be imported here (see docs/FTA-236/plan.md).
+"""
+
+import ast
+import re
+
+SRC = '/Users/ilongden/harvard/alliance-linkml-flybase/src/allele_handlers.py'
+
+tree = ast.parse(open(SRC).read())
+cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == 'AberrationHandler')
+ns = {'re': re}
+for node in cls.body:
+    if isinstance(node, ast.Assign) and getattr(node.targets[0], 'id', '') == 'balancer_merge_regex':
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+for name in ('synthesize_balancer_merge_map', '_resolve_parent_feature_id'):
+    node = next(n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == name)
+    exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+
+
+class FakeLog:
+    def __init__(self):
+        self.info_lines, self.warnings, self.errors = [], [], []
+
+    def info(self, msg):
+        self.info_lines.append(msg)
+
+    def debug(self, msg):
+        pass
+
+    def warning(self, msg):
+        self.warnings.append(msg)
+
+    def error(self, msg):
+        self.errors.append(msg)
+
+
+class FakeProp:
+    def __init__(self, value):
+        self.chado_obj = type('O', (), {'value': value})()
+
+
+class FakeEntity:
+    def __init__(self, feature_id, uniquename, internal_notes=(), is_obsolete=False):
+        self.db_primary_id = feature_id
+        self.uniquename = uniquename
+        self.is_obsolete = is_obsolete
+        self.props_by_type = {'internal_notes': [FakeProp(v) for v in internal_notes]} if internal_notes else {}
+
+    def __str__(self):
+        return self.uniquename
+
+
+class FakeHandler:
+    balancer_merge_regex = ns['balancer_merge_regex']
+    synthesize_balancer_merge_map = ns['synthesize_balancer_merge_map']
+    _resolve_parent_feature_id = ns['_resolve_parent_feature_id']
+
+    def __init__(self, aberrations, balancers, testing=False):
+        self.log = FakeLog()
+        self.testing = testing
+        self.fb_data_entities = {a.db_primary_id: a for a in aberrations}
+        self.fbba_entities = {b.db_primary_id: b for b in balancers}
+        self.balancer_merge_map = {}
+
+
+FLAG = "FTA: Balancer - merge with parent In(1)Basc (FBab0004219)."
+FLAG_SM6A = "FTA: Balancer - merge with parent In(2LR)SM6 (FBab0004818)."
+FLAG_SM6B = "FTA: Balancer - merge with parent In(2LR)SM6 (FBab0004818)."
+FLAG_OBSOLETE = "FTA: Balancer - merge with parent T(2;3)A1-W (FBab0007127)."
+FLAG_UNKNOWN = "FTA: Balancer - merge with parent Nope (FBab9999999)."
+FLAG_OTHER = "FTA: Balancer - use balancer symbol and fullname for parent In(1)Basc (FBab0004219)."
+PROSE = 'Used as a balancer; merge with parent was discussed but never agreed.'
+
+results = []
+
+
+def check(name, condition):
+    results.append((name, condition))
+    print(f'  {"PASS" if condition else "FAIL"}: {name}')
+
+
+print('--- happy path: 4 balancers, 3 parents (SM6 takes two) ---')
+aberrations = [
+    FakeEntity(1, 'FBab0004219'),
+    FakeEntity(2, 'FBab0004818'),
+    FakeEntity(3, 'FBab0049550'),
+]
+balancers = [
+    FakeEntity(101, 'FBba0000014', [FLAG]),
+    FakeEntity(102, 'FBba0000039', [FLAG_SM6A]),
+    FakeEntity(103, 'FBba0000040', [FLAG_SM6B]),
+    FakeEntity(104, 'FBba0000999', [PROSE, FLAG_OTHER]),
+]
+h = FakeHandler(aberrations, balancers)
+h.synthesize_balancer_merge_map()
+check('3 flagged balancers mapped', h.balancer_merge_map == {101: 1, 102: 2, 103: 2})
+check('unflagged balancer ignored', 104 not in h.balancer_merge_map)
+check('no errors logged', h.log.errors == [])
+
+print('--- obsolete parent is an error, not a silent skip ---')
+aberrations = [FakeEntity(3, 'FBab0049550')]
+balancers = [FakeEntity(105, 'FBba0000688', [FLAG_OBSOLETE])]
+h = FakeHandler(aberrations, balancers)
+h.synthesize_balancer_merge_map()
+check('obsolete/absent parent not merged', h.balancer_merge_map == {})
+check('error names the balancer', any('FBba0000688' in e for e in h.log.errors))
+check('error names the parent ID', any('FBab0007127' in e for e in h.log.errors))
+
+print('--- unknown parent ID is an error ---')
+h = FakeHandler([FakeEntity(1, 'FBab0004219')], [FakeEntity(106, 'FBba0000777', [FLAG_UNKNOWN])])
+h.synthesize_balancer_merge_map()
+check('unknown parent not merged', h.balancer_merge_map == {})
+check('error names the unknown ID', any('FBab9999999' in e for e in h.log.errors))
+
+print('--- count warning fires away from the expected 38 ---')
+check('count warning present', any('38' in w for w in h.log.warnings))
+
+print('--- testing mode suppresses the count warning ---')
+h = FakeHandler([FakeEntity(1, 'FBab0004219')], [FakeEntity(101, 'FBba0000014', [FLAG])], testing=True)
+h.synthesize_balancer_merge_map()
+check('no count warning in testing mode', not any('38' in w for w in h.log.warnings))
+
+print(f'\n{sum(1 for _, ok in results if ok)}/{len(results)} checks PASSED')
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `python3 docs/FTA-236/verify_merge_map.py`
+Expected: `StopIteration` from the `next(...)` that looks for `synthesize_balancer_merge_map` — the method does not exist yet.
+
+- [ ] **Step 3: Add the class attributes**
+
+In `src/allele_handlers.py`, at module level near the top (after the imports), add:
+
+```python
+BALANCER_MERGE_EXPECTED = 38    # FTA-236: curated merge flags in chado as of 2026-08-14.
+```
+
+In `class AberrationHandler`, immediately below the existing `balancer_flag_expected_count` line, add:
+
+```python
+    # FTA-236: the merge flag on an FBba balancer names its parent FBab aberration, e.g.
+    #   FTA: Balancer - merge with parent In(1)Basc (FBab0004219).
+    # 38 of these exist, naming 37 parents (In(2LR)SM6 takes both SM6a and SM6b). Note that FBba
+    # balancers also carry a "use balancer symbol and fullname for parent ..." flag (FTA-237, 24 of
+    # them) with the same opening, so the match runs through the instruction clause, as in FTA-235.
+    balancer_merge_regex = re.compile(r'^\s*:?\s*FTA:\s*balancer\s*-\s*merge with parent\s+(?P<symbol>.+?)\s*\((?P<fbab>FBab[0-9]+)\)\s*\.?\s*$',
+                                      re.IGNORECASE)
+    # FTA-236: 'carries alleles' must NOT move for these balancers (curator decision, reasons not given).
+    balancer_carries_exclusions = {
+        'FBba0000011',    # FM1 -> In(1)FM1 (FBab0010486); 15 alleles held back.
+        'FBba0000039',    # SM6a -> In(2LR)SM6 (FBab0004818); 20 alleles held back.
+        'FBba0000040',    # SM6b -> In(2LR)SM6 (FBab0004818); 18 alleles held back.
+    }
+```
+
+And with the other "additional export sets" attributes:
+
+```python
+    fbba_entities = {}        # FTA-236: feature_id-keyed FBBalancer objects from the nested BalancerHandler.
+    balancer_merge_map = {}   # FTA-236: {FBba feature_id: parent FBab feature_id} for resolved merge flags.
+    balancer_merge_report = []  # FTA-236: dicts of what moved, for the curator TSV.
+```
+
+- [ ] **Step 4: Add the nested retrieval method**
+
+Add to `class AberrationHandler`, in its "Additional sub-methods for get_datatype_data()" area:
+
+```python
+    def get_balancer_entities(self, session):
+        """Have the AberrationHandler run the BalancerHandler to get FBba data (FTA-236).
+
+        Mirrors AlleleHandler.get_insertion_entities(): the nested handler does its own full
+        retrieval, and only its fb_data_entities are kept. Nothing it maps or exports is used, so
+        FBba balancers still do not appear in the allele_ingest_set - their data is grafted onto the
+        parent FBab aberrations instead.
+        """
+        separator = 80 * '#'
+        self.log.info(f'Have the AberrationHandler run the BalancerHandler.\n{separator}')
+        balancer_handler = BalancerHandler(self.log, self.testing)
+        export_chado_data(session, self.log, balancer_handler)
+        self.fbba_entities = balancer_handler.fb_data_entities
+        self.log.info(f'The AberrationHandler obtained {len(self.fbba_entities)} FBba balancers from chado.\n{separator}')
+        return
+```
+
+- [ ] **Step 5: Add the merge-map method**
+
+Add to `class AberrationHandler`, in its "Additional sub-methods to be run by synthesize_info()" area:
+
+```python
+    def _resolve_parent_feature_id(self, fbab_uniquename):
+        """Return the feature_id of an exportable parent FBab, or None (FTA-236).
+
+        Only aberrations in self.fb_data_entities can receive merged data: that dict holds the
+        current, non-obsolete FBab features this handler exports. An obsolete or unrecognised ID
+        gets no fallback on purpose - see the "Open dependency" section of docs/FTA-236/plan.md. If
+        the curators decide stale IDs should be followed instead, resolve them through
+        feature_dbxref here and nowhere else.
+        """
+        for aberration in self.fb_data_entities.values():
+            if aberration.uniquename == fbab_uniquename:
+                return aberration.db_primary_id
+        return None
+
+    def synthesize_balancer_merge_map(self):
+        """Map each flagged FBba balancer to its parent FBab aberration (FTA-236)."""
+        self.log.info('Map flagged FBba balancers to their parent FBab aberrations.')
+        flag_counter = 0
+        for balancer in self.fbba_entities.values():
+            for fb_prop in balancer.props_by_type.get('internal_notes', []):
+                prop_value = fb_prop.chado_obj.value
+                if not prop_value:
+                    continue
+                match = self.balancer_merge_regex.match(prop_value)
+                if match is None:
+                    continue
+                flag_counter += 1
+                fbab_uniquename = match.group('fbab')
+                parent_feature_id = self._resolve_parent_feature_id(fbab_uniquename)
+                if parent_feature_id is None:
+                    self.log.error(f'FTA-236: balancer {balancer} names parent {fbab_uniquename} '
+                                   f'("{match.group("symbol")}"), which is not an exportable aberration '
+                                   f'(obsolete or unknown). No data merged; please fix the internal note.')
+                    break
+                self.balancer_merge_map[balancer.db_primary_id] = parent_feature_id
+                self.log.debug(f'FTA-236: {balancer} merges into {self.fb_data_entities[parent_feature_id]}.')
+                break
+        parents = set(self.balancer_merge_map.values())
+        self.log.info(f'Found {flag_counter} balancer merge flags; resolved {len(self.balancer_merge_map)} '
+                      f'balancers onto {len(parents)} parent aberrations.')
+        if self.testing is False and flag_counter != BALANCER_MERGE_EXPECTED:
+            self.log.warning(f'Expected {BALANCER_MERGE_EXPECTED} balancer merge flags per FTA-236, but found '
+                             f'{flag_counter}. Check the "internal_notes" flag text in chado.')
+        return
+```
+
+- [ ] **Step 6: Wire both methods into the handler hooks**
+
+In `AberrationHandler.get_datatype_data()`, add as the **last** call before `return`:
+
+```python
+        self.get_balancer_entities(session)
+```
+
+In `AberrationHandler.synthesize_info()`, add immediately after `super().synthesize_info()` and **before** `self.flag_new_additions_and_obsoletes()`:
+
+```python
+        self.synthesize_balancer_merge_map()
+```
+
+- [ ] **Step 7: Run the harness to verify it passes**
+
+Run: `python3 docs/FTA-236/verify_merge_map.py`
+Expected: `10/10 checks PASSED`
+
+- [ ] **Step 8: Compile check and line length**
+
+Run:
+```bash
+python3 -m py_compile src/allele_handlers.py && echo COMPILE OK
+awk 'length > 160 {print FILENAME": "FNR": "length}' src/allele_handlers.py
+grep -n ' $' src/allele_handlers.py
+```
+Expected: `COMPILE OK`, and no output from `awk` or `grep`.
+
+- [ ] **Step 9: Record the chado expectations**
+
+Create `docs/FTA-236/expected_counts.sql` holding the queries that produced the "Verified input data" table (flag counts by family, parents per balancer, per-field row counts, exclusion counts). Run it and confirm the numbers still match:
+
+```bash
+scp docs/FTA-236/expected_counts.sql flysql26:/tmp/
+ssh flysql26 "PGPASSWORD=ilongdenpgsql psql -h flysql24 -U ilongden -d production_chado -f /tmp/expected_counts.sql"
+```
+Expected: 38 merge flags, 37 distinct parents, `FBab0004818` with 2 balancers.
+
+- [ ] **Step 10: Commit (only when Ian asks)**
+
+```bash
+git add src/allele_handlers.py docs/FTA-236/plan.md docs/FTA-236/verify_merge_map.py docs/FTA-236/expected_counts.sql
+git commit -m "feat(FTA-236): map flagged FBba balancers to their parent FBab aberrations"
+```
+
+---
+
+### Task 2: Graft balancer names, secondary IDs, notes and references onto the parent
+
+**Files:**
+- Modify: `src/fb_datatypes.py:95` (new `demoted_synonym_ids` attribute)
+- Modify: `src/entity_handler.py:1071` (honour it in `synthesize_synonyms()`)
+- Modify: `src/allele_handlers.py` (class `AberrationHandler`: new methods `add_fbba_to_fbab()` and `merge_balancers_into_aberrations()`; one call in `synthesize_info()`)
+- Create: `docs/FTA-236/verify_graft.py`
+
+**Interfaces:**
+- Consumes: `self.balancer_merge_map` and `self.fbba_entities` from Task 1.
+- Produces: `FBDataEntity.demoted_synonym_ids` — a `set()` of `synonym_id`s that `synthesize_synonyms()` forces to `is_current = False` regardless of name type.
+- Produces: `add_fbba_to_fbab(balancer, aberration)` — mutates the aberration in place; `merge_balancers_into_aberrations()` — walks the map and calls it; appends one dict per balancer to `self.balancer_merge_report` with keys `fbba_id`, `fbba_symbol`, `fbab_id`, `synonyms`, `secondary_ids`, `comments`, `internal_notes`, `references`, `carries_alleles`, `carries_excluded` (the last two are filled by Task 3, defaulting to 0).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `docs/FTA-236/verify_graft.py`:
+
+```python
+"""Offline harness for AberrationHandler.add_fbba_to_fbab() (FTA-236)."""
+
+import ast
+import re
+
+SRC = '/Users/ilongden/harvard/alliance-linkml-flybase/src/allele_handlers.py'
+
+tree = ast.parse(open(SRC).read())
+cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == 'AberrationHandler')
+ns = {'re': re}
+for node in cls.body:
+    if isinstance(node, ast.Assign) and getattr(node.targets[0], 'id', '') in ('balancer_graft_prop_types',):
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+for name in ('add_fbba_to_fbab', 'merge_balancers_into_aberrations'):
+    node = next(n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == name)
+    exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+
+
+class FakeLog:
+    def __init__(self):
+        self.lines, self.warnings = [], []
+
+    def info(self, msg):
+        self.lines.append(msg)
+
+    def debug(self, msg):
+        pass
+
+    def warning(self, msg):
+        self.warnings.append(msg)
+
+    def error(self, msg):
+        self.warnings.append(msg)
+
+
+class FakeProp:
+    def __init__(self, value):
+        self.chado_obj = type('O', (), {'value': value})()
+        self.pubs = []
+
+
+class FakeSynonym:
+    def __init__(self, synonym_id, name):
+        self.synonym_id = synonym_id
+        self.name = name
+
+
+class FakeEntity:
+    def __init__(self, feature_id, uniquename, name=''):
+        self.db_primary_id = feature_id
+        self.uniquename = uniquename
+        self.name = name
+        self.synonyms = []
+        self.merged_synonym_ids = set()
+        self.demoted_synonym_ids = set()
+        self.alt_fb_ids = []
+        self.fb_sec_dbxrefs = []
+        self.pub_associations = []
+        self.props_by_type = {}
+
+    def __str__(self):
+        return f'{self.name} ({self.uniquename})'
+
+
+class FakeHandler:
+    balancer_graft_prop_types = ns['balancer_graft_prop_types']
+    add_fbba_to_fbab = ns['add_fbba_to_fbab']
+    merge_balancers_into_aberrations = ns['merge_balancers_into_aberrations']
+
+    def __init__(self, aberrations, balancers, merge_map, testing=False):
+        self.log = FakeLog()
+        self.testing = testing
+        self.fb_data_entities = {a.db_primary_id: a for a in aberrations}
+        self.fbba_entities = {b.db_primary_id: b for b in balancers}
+        self.balancer_merge_map = merge_map
+        self.balancer_merge_report = []
+
+
+results = []
+
+
+def check(name, condition):
+    results.append((name, condition))
+    print(f'  {"PASS" if condition else "FAIL"}: {name}')
+
+
+parent = FakeEntity(1, 'FBab0004219', 'In(1)Basc')
+parent.synonyms = [FakeSynonym(900, 'In(1)Basc')]
+parent.props_by_type = {'misc': [FakeProp('Parent comment.')]}
+parent.pub_associations = ['parent_pub']
+
+balancer = FakeEntity(101, 'FBba0000014', 'Basc')
+balancer.synonyms = [FakeSynonym(910, 'Basc'), FakeSynonym(911, 'M5')]
+balancer.alt_fb_ids = []
+balancer.fb_sec_dbxrefs = ['fbba_sec_dbxref']
+balancer.pub_associations = ['fbba_pub_1', 'fbba_pub_2']
+balancer.props_by_type = {
+    'misc': [FakeProp('N[opa33b] is a natural variant ...')],
+    'internal_notes': [FakeProp("FTA: Balancer - merge with parent In(1)Basc (FBab0004219).")],
+    'availability': [FakeProp('Stated to be lost.')],      # must NOT move: would set is_extinct
+    'derived_stock_count': [FakeProp('12')],               # must NOT move
+}
+
+h = FakeHandler([parent], [balancer], {101: 1})
+h.merge_balancers_into_aberrations()
+
+print('--- names ---')
+check('balancer synonyms appended', {s.synonym_id for s in parent.synonyms} == {900, 910, 911})
+check('balancer synonym ids marked as merged', parent.merged_synonym_ids == {910, 911})
+check('parent own synonym not marked merged', 900 not in parent.merged_synonym_ids)
+check('balancer synonym ids also demoted (protects the full name slot)', parent.demoted_synonym_ids == {910, 911})
+
+print('--- identifiers ---')
+check('balancer primary ID added as secondary', 'FB:FBba0000014' in parent.alt_fb_ids)
+check('balancer secondary dbxrefs moved', 'fbba_sec_dbxref' in parent.fb_sec_dbxrefs)
+
+print('--- notes: whitelist only ---')
+check('misc props merged, parent prop kept', len(parent.props_by_type['misc']) == 2)
+check('internal_notes props merged', len(parent.props_by_type['internal_notes']) == 1)
+check('availability NOT merged', 'availability' not in parent.props_by_type)
+check('derived_stock_count NOT merged', 'derived_stock_count' not in parent.props_by_type)
+
+print('--- references ---')
+check('balancer pubs merged', parent.pub_associations == ['parent_pub', 'fbba_pub_1', 'fbba_pub_2'])
+
+print('--- report row ---')
+row = h.balancer_merge_report[0]
+check('report identifies both entities', row['fbba_id'] == 'FBba0000014' and row['fbab_id'] == 'FBab0004219')
+check('report counts synonyms', row['synonyms'] == 2)
+check('report counts comments', row['comments'] == 1)
+check('report counts references', row['references'] == 2)
+
+print('--- two balancers into one parent (SM6 case) ---')
+parent2 = FakeEntity(2, 'FBab0004818', 'In(2LR)SM6')
+sm6a = FakeEntity(102, 'FBba0000039', 'SM6a')
+sm6a.synonyms = [FakeSynonym(920, 'SM6a')]
+sm6b = FakeEntity(103, 'FBba0000040', 'SM6b')
+sm6b.synonyms = [FakeSynonym(930, 'SM6b')]
+h2 = FakeHandler([parent2], [sm6a, sm6b], {102: 2, 103: 2})
+h2.merge_balancers_into_aberrations()
+check('both balancers merged into one parent', {s.synonym_id for s in parent2.synonyms} == {920, 930})
+check('two report rows written', len(h2.balancer_merge_report) == 2)
+
+print(f'\n{sum(1 for _, ok in results if ok)}/{len(results)} checks PASSED')
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `python3 docs/FTA-236/verify_graft.py`
+Expected: `StopIteration` — `add_fbba_to_fbab` does not exist yet.
+
+- [ ] **Step 3: Add the `demoted_synonym_ids` attribute and honour it**
+
+In `src/fb_datatypes.py`, immediately after the `merged_synonym_ids` line (95):
+
+```python
+        self.demoted_synonym_ids = set()  # synonym_ids to force non-current for ALL name types (FTA-236 balancer merges).
+```
+
+In `src/entity_handler.py`, in `synthesize_synonyms()`, immediately after the existing `is_merged_symbol` demotion block (the two lines at 1071-1073), add:
+
+```python
+                # FTA-236: a balancer's names must never rival the parent aberration's own. Unlike
+                # merged_synonym_ids this covers full names too: map_synonyms() sets no
+                # allele_full_name_dto at all when it finds two current full names, so an
+                # undemoted balancer full name would delete the aberration's own from the export.
+                if syno_id in fb_data_entity.demoted_synonym_ids:
+                    syno_dict['is_current'] = False
+```
+
+- [ ] **Step 4: Add the prop whitelist attribute**
+
+In `class AberrationHandler`, next to the other FTA-236 attributes:
+
+```python
+    # FTA-236: only these FBba prop types move to the parent aberration. A blanket props_by_type merge
+    # (as add_fbal_to_fbti does) would also carry 'availability' and 'derived_stock*' props, which
+    # map_extinction_info() reads to set is_extinct - a balancer's stock status is not the
+    # aberration's. The Alliance note type for each comes from aberration_prop_to_note_mapping.
+    balancer_graft_prop_types = ('misc', 'internal_notes')
+```
+
+- [ ] **Step 5: Write the graft methods**
+
+```python
+    def add_fbba_to_fbab(self, balancer, aberration):
+        """Graft one FBba balancer's data onto its parent FBab aberration (FTA-236).
+
+        Follows add_fbal_to_fbti(): extend the parent's source-data lists before synthesize_* runs, so
+        every existing mapping method produces the merged output unchanged. Only whitelisted prop
+        types move (see balancer_graft_prop_types), and relationships are handled separately by
+        synthesize_balancer_carries_associations() so they cannot reach aberration-gene synthesis.
+        """
+        report = {
+            'fbba_id': balancer.uniquename,
+            'fbba_symbol': balancer.name,
+            'fbab_id': aberration.uniquename,
+            'synonyms': len(balancer.synonyms),
+            'secondary_ids': 1 + len(balancer.fb_sec_dbxrefs),
+            'comments': len(balancer.props_by_type.get('misc', [])),
+            'internal_notes': len(balancer.props_by_type.get('internal_notes', [])),
+            'references': len(balancer.pub_associations),
+            'carries_alleles': 0,
+            'carries_excluded': 0,
+        }
+        # Names. Per the ticket, the balancer's symbols and full names become synonyms of the parent;
+        # neither may rival the parent's own. merged_synonym_ids covers symbols (a rival current
+        # symbol makes map_synonyms() pick one arbitrarily and log "Found many current symbols");
+        # demoted_synonym_ids also covers full names, where a rival is worse - map_synonyms() sets no
+        # allele_full_name_dto at all and the aberration's own full name vanishes from the export.
+        # FTA-237 deliberately renames 24 of these aberrations to the balancer symbol/full name; it
+        # must do that by setting the slots, not by skipping this demotion.
+        aberration.synonyms.extend(balancer.synonyms)
+        balancer_synonym_ids = [i.synonym_id for i in balancer.synonyms]
+        aberration.merged_synonym_ids.update(balancer_synonym_ids)
+        aberration.demoted_synonym_ids.update(balancer_synonym_ids)
+        # Identifiers: the balancer's current ID plus any of its own secondary IDs.
+        aberration.alt_fb_ids.append(f'FB:{balancer.uniquename}')
+        aberration.fb_sec_dbxrefs.extend(balancer.fb_sec_dbxrefs)
+        # Notes (whitelisted prop types only).
+        for prop_type in self.balancer_graft_prop_types:
+            balancer_props = balancer.props_by_type.get(prop_type, [])
+            if not balancer_props:
+                continue
+            try:
+                aberration.props_by_type[prop_type].extend(balancer_props)
+            except KeyError:
+                aberration.props_by_type[prop_type] = list(balancer_props)
+        # References: synthesize_pubs() reads pub_associations, so graft before it runs.
+        aberration.pub_associations.extend(balancer.pub_associations)
+        self.balancer_merge_report.append(report)
+        return report
+
+    def merge_balancers_into_aberrations(self):
+        """Graft every flagged FBba balancer onto its parent FBab aberration (FTA-236)."""
+        self.log.info('Merge flagged FBba balancer data into parent FBab aberrations.')
+        totals = {'synonyms': 0, 'secondary_ids': 0, 'comments': 0, 'internal_notes': 0, 'references': 0}
+        for fbba_feature_id, fbab_feature_id in self.balancer_merge_map.items():
+            balancer = self.fbba_entities[fbba_feature_id]
+            aberration = self.fb_data_entities[fbab_feature_id]
+            report = self.add_fbba_to_fbab(balancer, aberration)
+            for key in totals.keys():
+                totals[key] += report[key]
+        parents = set(self.balancer_merge_map.values())
+        self.log.info(f'Merged {len(self.balancer_merge_map)} balancers into {len(parents)} aberrations.')
+        for key in sorted(totals.keys()):
+            self.log.info(f'Moved {totals[key]} {key} from balancers to aberrations.')
+        return
+```
+
+- [ ] **Step 6: Wire it into `synthesize_info()`**
+
+Add immediately after `self.synthesize_balancer_merge_map()` (from Task 1) and **before** `self.synthesize_secondary_ids()`:
+
+```python
+        self.merge_balancers_into_aberrations()
+```
+
+Order matters and is the whole reason grafting works: `synthesize_secondary_ids()`, `synthesize_synonyms()` and `synthesize_pubs()` all run later in the same method and consume the lists just extended.
+
+- [ ] **Step 7: Run the harness to verify it passes**
+
+Run: `python3 docs/FTA-236/verify_graft.py`
+Expected: `17/17 checks PASSED`
+
+- [ ] **Step 8: Compile check and line length**
+
+Run:
+```bash
+python3 -m py_compile src/allele_handlers.py && echo COMPILE OK
+awk 'length > 160 {print FILENAME": "FNR": "length}' src/allele_handlers.py
+```
+Expected: `COMPILE OK` and no `awk` output.
+
+- [ ] **Step 9: Commit (only when Ian asks)**
+
+```bash
+git add src/allele_handlers.py docs/FTA-236/verify_graft.py
+git commit -m "feat(FTA-236): graft balancer names, IDs, notes and refs onto parent aberrations"
+```
+
+---
+
+### Task 3: Move the balancer's "carries alleles" and transposon insertions (gated)
+
+**Files:**
+- Modify: `src/allele_handlers.py` (class `AberrationHandler`: new method `synthesize_balancer_carries_associations()`; one gated call in `synthesize_info()`)
+- Modify: `docs/FTA-236/verify_graft.py` (add the association checks)
+
+**Interfaces:**
+- Consumes: `self.balancer_merge_map`, `self.fbba_entities`, `self.balancer_carries_exclusions`, `self.aberration_allele_rels` and `self.feature_subtypes` (all existing), plus `recall_relationships()` on the FBba entity.
+- Produces: extra keys in `self.aberration_allele_rels`, shaped exactly as `synthesize_aberration_allele_associations()` builds them — `(parent FBab feature_id, partner feature_id, 'carries')` keying a list of `FBRelationship` objects — so `map_aberration_allele_associations()` needs no change. Updates `carries_alleles` / `carries_excluded` in each `balancer_merge_report` row.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `docs/FTA-236/verify_graft.py` (extract the new method the same way, then):
+
+```python
+print('--- carries associations: injected under the parent, exclusions honoured ---')
+
+
+class FakeRel:
+    def __init__(self, rel_id, subject_id, object_id, pubs=()):
+        self.chado_obj = type('O', (), {'subject_id': subject_id, 'object_id': object_id})()
+        self.rel_id = rel_id
+        self.pubs = list(pubs)
+
+
+class RelEntity(FakeEntity):
+    def __init__(self, feature_id, uniquename, name='', rels=None):
+        super().__init__(feature_id, uniquename, name)
+        self._rels = rels or {}
+
+    def recall_relationships(self, log, **kwargs):
+        key = (kwargs.get('entity_role'), kwargs.get('rel_types'))
+        return self._rels.get(key, [])
+
+
+basc = RelEntity(101, 'FBba0000014', 'Basc', rels={
+    ('object', 'carried_on'): [FakeRel(1, 5001, 101), FakeRel(2, 5002, 101)],
+    ('subject', 'associated_with'): [FakeRel(3, 101, 6001)],
+})
+fm1 = RelEntity(111, 'FBba0000011', 'FM1', rels={
+    ('object', 'carried_on'): [FakeRel(4, 5003, 111)],
+})
+parent_basc = FakeEntity(1, 'FBab0004219', 'In(1)Basc')
+parent_fm1 = FakeEntity(10, 'FBab0010486', 'In(1)FM1')
+
+h3 = FakeHandler([parent_basc, parent_fm1], [basc, fm1], {101: 1, 111: 10})
+h3.feature_subtypes = {'allele': ['allele'], 'insertion': ['insertion']}
+h3.aberration_allele_rels = {}
+h3.balancer_carries_exclusions = {'FBba0000011', 'FBba0000039', 'FBba0000040'}
+h3.merge_balancers_into_aberrations()
+h3.synthesize_balancer_carries_associations()
+
+keys = set(h3.aberration_allele_rels.keys())
+check('carried_on allele keyed under the parent as "carries"', (1, 5001, 'carries') in keys)
+check('second carried_on allele present', (1, 5002, 'carries') in keys)
+check('associated_with insertion keyed as "carries"', (1, 6001, 'carries') in keys)
+check('excluded balancer contributes nothing', not any(k[0] == 10 for k in keys))
+check('nothing keyed under the balancer itself', not any(k[0] in (101, 111) for k in keys))
+basc_row = next(r for r in h3.balancer_merge_report if r['fbba_id'] == 'FBba0000014')
+fm1_row = next(r for r in h3.balancer_merge_report if r['fbba_id'] == 'FBba0000011')
+check('report counts moved associations', basc_row['carries_alleles'] == 3)
+check('report counts excluded associations', fm1_row['carries_excluded'] == 1)
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `python3 docs/FTA-236/verify_graft.py`
+Expected: `StopIteration` — `synthesize_balancer_carries_associations` does not exist yet.
+
+- [ ] **Step 3: Write the method**
+
+```python
+    def synthesize_balancer_carries_associations(self):
+        """Move a flagged balancer's carried alleles and insertions onto its parent (FTA-236).
+
+        In chado the two sources are:
+            1. type="carried_on",      subject=FBal, object=FBba (proforma AB5b) -> "carries"
+            2. type="associated_with", subject=FBba, object=FBti (proforma AB5a) -> "carries"
+        Both become Alliance "carries" associations from the parent FBab to the partner, so the keys
+        built here match synthesize_aberration_allele_associations() exactly and the existing
+        map_aberration_allele_associations() emits them with no changes.
+
+        These relationships are deliberately NOT grafted onto the parent entity: the parent's own
+        relationships also drive aberration-GENE association synthesis, and a balancer's links would
+        show up there as phantom gene associations.
+
+        Gated with the rest of the allele-allele associations (FTA-218): the Alliance has no
+        "allele_allele_association_ingest_set" yet.
+        """
+        self.log.info('Move balancer carried alleles and insertions onto parent aberrations.')
+        rel_specs = [
+            ('object', 'carried_on', self.feature_subtypes['allele'], 'AB5b'),
+            ('subject', 'associated_with', self.feature_subtypes['insertion'], 'AB5a'),
+        ]
+        partner_attr = {'subject': 'object_id', 'object': 'subject_id'}
+        moved = 0
+        excluded = 0
+        for fbba_feature_id, fbab_feature_id in self.balancer_merge_map.items():
+            balancer = self.fbba_entities[fbba_feature_id]
+            report_rows = [i for i in self.balancer_merge_report if i['fbba_id'] == balancer.uniquename]
+            is_excluded = balancer.uniquename in self.balancer_carries_exclusions
+            for entity_role, fb_rel_type, rel_entity_types, proforma_field in rel_specs:
+                relevant_rels = balancer.recall_relationships(self.log, entity_role=entity_role, rel_types=fb_rel_type,
+                                                              rel_entity_types=rel_entity_types)
+                for feat_rel in relevant_rels:
+                    partner_id = getattr(feat_rel.chado_obj, partner_attr[entity_role])
+                    if is_excluded:
+                        excluded += 1
+                        for row in report_rows:
+                            row['carries_excluded'] += 1
+                        continue
+                    rel_key = (fbab_feature_id, partner_id, 'carries')
+                    try:
+                        self.aberration_allele_rels[rel_key].append(feat_rel)
+                    except KeyError:
+                        self.aberration_allele_rels[rel_key] = [feat_rel]
+                        moved += 1
+                        for row in report_rows:
+                            row['carries_alleles'] += 1
+        self.log.info(f'Moved {moved} balancer "carries" associations onto parent aberrations.')
+        self.log.info(f'Held back {excluded} associations for the {len(self.balancer_carries_exclusions)} '
+                      f'balancers excluded by FTA-236.')
+        return
+```
+
+- [ ] **Step 4: Wire it into `synthesize_info()`**
+
+Inside the existing `ADD_ALLELE_ALLELE_ASSOC` block, so it runs **after** `synthesize_aberration_allele_associations()`:
+
+```python
+        if getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES':
+            self.synthesize_aberration_allele_associations()
+            self.synthesize_balancer_carries_associations()
+        else:
+            self.log.info('ADD_ALLELE_ALLELE_ASSOC not set to "YES"; skipping aberration-allele association synthesis.')
+```
+
+Also extend the `get_general_data()` comment above the gated `build_feature_lookup(...)` call to note that FTA-236's balancer partners rely on the same lookup — the FBal/FBti partners of a balancer must be in `feature_lookup` for `map_aberration_allele_associations()` to resolve their uniquenames.
+
+- [ ] **Step 5: Run the harness to verify it passes**
+
+Run: `python3 docs/FTA-236/verify_graft.py`
+Expected: `24/24 checks PASSED` (17 from Task 2 plus 7 new)
+
+- [ ] **Step 6: Compile check and line length**
+
+Run:
+```bash
+python3 -m py_compile src/allele_handlers.py && echo COMPILE OK
+awk 'length > 160 {print FILENAME": "FNR": "length}' src/allele_handlers.py
+```
+Expected: `COMPILE OK` and no `awk` output.
+
+- [ ] **Step 7: Commit (only when Ian asks)**
+
+```bash
+git add src/allele_handlers.py docs/FTA-236/verify_graft.py
+git commit -m "feat(FTA-236): move balancer carried alleles and insertions to parent aberrations"
+```
+
+---
+
+### Task 4: Curator TSV, docs, and full-run verification
+
+**Files:**
+- Modify: `src/AGR_data_retrieval_curation_allele.py` (epilog text; new TSV emission in `main()` after `write_notes_tsv`)
+- Modify: `src/curation_tsv.py` (only if a new writer is needed — check `write_association_tsv()` first)
+- Create: `docs/FTA-236/verify_run.sh`
+
+**Interfaces:**
+- Consumes: `aberration_handler.balancer_merge_report` (list of dicts from Tasks 2-3).
+- Produces: `<output>_balancer_merges.tsv` beside the other allele TSVs.
+
+- [ ] **Step 1: Check whether an existing writer fits**
+
+Run: `grep -n "def write_" src/curation_tsv.py`
+`write_association_tsv()` takes `first_field`/`second_field`/`extra_fields` over a list of exported-DTO dicts. The merge report is a flat list of dicts with fixed keys, so it fits: `first_field='fbab_id'`, `second_field='fbba_id'`, and the counts as `extra_fields`. Reuse it — do not add a new writer.
+
+- [ ] **Step 2: Emit the TSV**
+
+In `main()`, inside the `else` branch that writes the other TSVs, after the `write_notes_tsv(...)` call:
+
+```python
+        # FTA-236: one row per FBba balancer merged into a parent FBab aberration, so curators can
+        # check what moved. Written unconditionally; the 'carries' counts are 0 unless
+        # ADD_ALLELE_ALLELE_ASSOC=YES, since that gate controls the association export.
+        merges_filename = tsv_filename.replace('.tsv', '_balancer_merges.tsv')
+        curation_tsv.write_association_tsv(
+            filename=merges_filename,
+            rows=aberration_handler.balancer_merge_report,
+            first_field='fbab_id',
+            second_field='fbba_id',
+            extra_fields=[
+                ('fbba_symbol', 'fbba_symbol', ''),
+                ('synonyms', 'synonyms', 0),
+                ('secondary_ids', 'secondary_ids', 0),
+                ('comments', 'comments', 0),
+                ('internal_notes', 'internal_notes', 0),
+                ('references', 'references', 0),
+                ('carries_alleles', 'carries_alleles', 0),
+                ('carries_excluded', 'carries_excluded', 0),
+            ],
+        )
+        log.info(f'Generated TSV: {merges_filename} ({len(aberration_handler.balancer_merge_report)} balancer merges)')
+```
+
+- [ ] **Step 3: Document the behaviour in the epilog**
+
+Extend the `ADD_ALLELE_ALLELE_ASSOC` entry to mention FTA-236, and add a plain-English note that balancer merges themselves are ungated:
+
+```
+  ADD_ALLELE_ALLELE_ASSOC   Set to 'YES' to emit the FTA-218 'allele_allele_association_ingest_set' (aberration
+                            'carries'/'breakpoint_allele' relations, plus the FTA-236 alleles and insertions
+                            carried by a balancer and moved to its parent aberration). Off by default: the
+                            Alliance schema has no such ingest set and lacks the two CV terms, so the data
+                            cannot yet be loaded. FTA-236's names, IDs, notes and references are NOT gated -
+                            they use slots that already exist in released LinkML.
+```
+
+- [ ] **Step 4: Compile check both files**
+
+Run:
+```bash
+python3 -m py_compile src/allele_handlers.py src/AGR_data_retrieval_curation_allele.py && echo COMPILE OK
+awk 'length > 160 {print FILENAME": "FNR": "length}' src/allele_handlers.py src/AGR_data_retrieval_curation_allele.py
+```
+Expected: `COMPILE OK` and no `awk` output.
+
+- [ ] **Step 5: Write the run-verification script**
+
+Create `docs/FTA-236/verify_run.sh`, taking the run directory as `$1`, to be pointed at a `flysql26:/data/alliance/PERSISTENT_*` copy. It must check:
+
+```bash
+#!/usr/bin/env bash
+# Usage: verify_run.sh /data/alliance/PERSISTENT_main_FTA-236_balancer_merge   (run on flysql26)
+set -euo pipefail
+DIR="$1"
+LOG="$DIR"/allele_curation_*.log
+echo '--- merge tallies from the log ---'
+grep -E 'balancer merge flags|Merged .* balancers into|Moved .* from balancers|Moved .* balancer "carries"|Held back' $LOG
+echo '--- errors (expect one only if Steven has not fixed FBba0000688) ---'
+grep -c ' ERROR ' $LOG || true
+grep ' ERROR ' $LOG || true
+echo '--- merge TSV row count (expect 38, or 37 pending the FBba0000688 fix) ---'
+tail -n +2 "$DIR"/*_balancer_merges.tsv | wc -l
+echo '--- In(1)Basc must gain M5 as a synonym and FBba0000014 as a secondary ID ---'
+grep -m1 'FBab0004219' "$DIR"/allele_curation_*.tsv
+echo '--- In(2LR)SM6 must show two merge rows ---'
+grep -c 'FBab0004818' "$DIR"/*_balancer_merges.tsv
+echo '--- excluded balancers must move 0 carries and hold back 15/20/18 ---'
+grep -E 'FBba0000011|FBba0000039|FBba0000040' "$DIR"/*_balancer_merges.tsv
+echo '--- no aberration should report many current symbols (the merged-synonym trap) ---'
+grep -c 'many current symbols' $LOG || true
+```
+
+- [ ] **Step 6: Ask Ian to run the export, then verify**
+
+The run cannot happen on this machine. Ask Ian to run the allele export against `production_chado` twice, into `PERSISTENT_main_FTA-236_balancer_merge` (default gate) and `PERSISTENT_main_FTA-236_balancer_merge_assoc` (`ADD_ALLELE_ALLELE_ASSOC=YES ADD_IS_ABERRATION=YES`). Then:
+
+```bash
+ssh flysql26 "bash -s" < docs/FTA-236/verify_run.sh /data/alliance/PERSISTENT_main_FTA-236_balancer_merge
+```
+
+Expected, per the verified-input table: 38 merge flags (37 merges + 1 error until the note is fixed), 96 synonyms, 45 secondary IDs (38 primary + 7 balancers' own), 27 comments, 68 internal notes, 440 references, `many current symbols` count of 0, and in the gated run 273 moved `carries` associations with 53 held back.
+
+- [ ] **Step 7: Cross-check the JSON for one worked example**
+
+The ticket's worked example is Basc → In(1)Basc. Confirm in the gated run's JSON that `FB:FBab0004219` has: `M5` among `allele_synonym_dtos`, `FB:FBba0000014` among `allele_secondary_id_dtos`, the `N[opa33b]` comment as a `comment` note, and `carries` associations to `Bar[1]`, `sc[8]`, `sc[S1]` and `w[a]`:
+
+```bash
+RUN=/data/alliance/PERSISTENT_main_FTA-236_balancer_merge_assoc
+ssh flysql26 "grep -n 'FB:FBab0004219' $RUN/allele_curation_production_chado.json | head -3"
+# take the first line number N from that output, then read the record around it:
+ssh flysql26 "sed -n '53583740,53583860p' $RUN/allele_curation_production_chado.json"   # substitute N-400,N+50
+```
+
+`docs/FTA-236/expected_counts.sql` query 7 prints the same facts straight from chado, so the two can be
+compared line by line: Basc carries exactly `Bar[1]`, `sc[8]`, `sc[S1]` and `w[a]`, and its AB6 comment is
+the `N[opa33b]` sentence (stored with `@...@` FlyBase markup, which `clean_note_free_text()` strips).
+
+- [ ] **Step 8: Commit (only when Ian asks)**
+
+```bash
+git add src/AGR_data_retrieval_curation_allele.py docs/FTA-236/verify_run.sh
+git commit -m "feat(FTA-236): curator TSV of balancer merges, plus env var docs"
+```
+
+---
+
+## Deferred, with reasons
+
+- **`is_balancer` on merged parents** — already true for 36 of the 37 parents via FTA-235 (merged, `d8155b6`). The 37th is the T(2;3)A1-W mismatch; fixing `FBba0000688`'s note resolves both tickets at once, so no code here.
+- **FTA-237 (rename 24 aberrations to the balancer symbol/full name)** — a separate ticket, but it collides with Task 2: this plan demotes every merged balancer synonym so the parent keeps its own symbol. FTA-237 must set the symbol slot explicitly for its 24 aberrations rather than removing the demotion, or the export will log "many current symbols" and pick a symbol arbitrarily. Note this in FTA-237 before starting it.
+- **Uploading the result** — blocked with the rest of FTA-218 until the Alliance has an `allele_allele_association_ingest_set` and the `carries` CV term.

--- a/docs/FTA-236/plan.md
+++ b/docs/FTA-236/plan.md
@@ -18,14 +18,33 @@
 - **Never commit without explicit permission from Ian.** Each task's commit step is prepared, but only run when he asks.
 - **Conventional Commits**, scope `FTA-236`, and `git add <specific paths>` only.
 
-## Open dependency — resolve before Task 2 lands
+## Resolved dependency (was blocking Task 2)
 
-`FBba0000688`'s note names `FBab0007127`, which is **obsolete** (a non-current secondary ID of `FBab0049550`, the current T(2;3)A1-W and the aberration that carries the FTA-235 `is_balancer` flag). Asked on FTA-236 (comment 43812, 2026-08-14):
+`FBba0000688` (AM1) named `FBab0007127`, which is **obsolete** — a non-current secondary ID of
+`FBab0049550`, the current T(2;3)A1-W and the aberration carrying the FTA-235 `is_balancer` flag.
 
-- **Option 1 (preferred, assumed by this plan):** Steven fixes the note; the code treats an obsolete/unknown parent as a reported error and skips the merge. Task 1 implements this.
-- **Option 2:** the code resolves parent IDs through `feature_dbxref` to the current feature. If Steven picks this, Task 1's `_resolve_parent_feature_id()` gains a secondary-ID fallback — the hook is called out in that task, so the change is one method, not a redesign.
+**Steven's answer (FTA-236 comment 43813, 2026-08-14): Option 1.** The intended target is the current
+`FBab0049550`, and he has made a curation record, **loading the week of 2026-08-17**, that corrects the
+note to:
 
-Until Steven answers, expect **37 of 38** merges to succeed and one logged error naming `FBba0000688`.
+```
+FTA: Balancer - merge with parent T(2;3)A1-W (FBab0049550).
+```
+
+So `_resolve_parent_feature_id()` stays as Task 1 specifies: an obsolete or unknown parent is a
+reported error, never silently redirected. Do **not** add a `feature_dbxref` fallback.
+
+Consequence for run expectations, which depend on when the export runs:
+
+- **Before that load:** 38 flags, **37** merges, and exactly one `ERROR` line naming `FBba0000688`.
+  That error is expected, not a regression.
+- **After it:** 38 flags, 38 merges onto 37 parents, and `FBab0049550` receives AM1's data. The
+  FTA-235 cross-check then reads 37 of 37 parents flagged `is_balancer`, closing the mismatch between
+  the two tickets. `expected_counts.sql` query 4 returns 0 rows once the load has happened — that is
+  the cheapest way to tell which side of the load a given chado snapshot is on.
+
+Note AM1 is merge-flagged only; T(2;3)A1-W is not among FTA-237's 24 renames, so it keeps its own
+symbol and full name.
 
 ---
 

--- a/docs/FTA-236/plan.md
+++ b/docs/FTA-236/plan.md
@@ -855,7 +855,14 @@ git commit -m "feat(FTA-236): move balancer carried alleles and insertions to pa
 - [ ] **Step 1: Check whether an existing writer fits**
 
 Run: `grep -n "def write_" src/curation_tsv.py`
-`write_association_tsv()` takes `first_field`/`second_field`/`extra_fields` over a list of exported-DTO dicts. The merge report is a flat list of dicts with fixed keys, so it fits: `first_field='fbab_id'`, `second_field='fbba_id'`, and the counts as `extra_fields`. Reuse it — do not add a new writer.
+`write_association_tsv()` takes `first_field`/`second_field`/`extra_fields` over a list of dicts, so it fits: `first_field='fbab_id'`, `second_field='fbba_id'`, and the counts as `extra_fields`. Reuse it — do not add a new writer.
+
+**But it reads `entity_dict['relation_name']` unconditionally**, so a report row without that key raises `KeyError` (found while implementing FTA-237, which hit exactly this). Pass a constant relation and blank the evidence sentinel:
+
+```python
+            rows=[dict(row, relation_name='merged_from_balancer') for row in aberration_handler.balancer_merge_report],
+            no_pubs_sentinel='',
+```
 
 - [ ] **Step 2: Emit the TSV**
 
@@ -868,7 +875,7 @@ In `main()`, inside the `else` branch that writes the other TSVs, after the `wri
         merges_filename = tsv_filename.replace('.tsv', '_balancer_merges.tsv')
         curation_tsv.write_association_tsv(
             filename=merges_filename,
-            rows=aberration_handler.balancer_merge_report,
+            rows=[dict(row, relation_name='merged_from_balancer') for row in aberration_handler.balancer_merge_report],
             first_field='fbab_id',
             second_field='fbba_id',
             extra_fields=[
@@ -881,6 +888,7 @@ In `main()`, inside the `else` branch that writes the other TSVs, after the `wri
                 ('carries_alleles', 'carries_alleles', 0),
                 ('carries_excluded', 'carries_excluded', 0),
             ],
+            no_pubs_sentinel='',
         )
         log.info(f'Generated TSV: {merges_filename} ({len(aberration_handler.balancer_merge_report)} balancer merges)')
 ```

--- a/docs/FTA-236/verify_graft.py
+++ b/docs/FTA-236/verify_graft.py
@@ -98,7 +98,15 @@ class FakeEntity:
         self._rels = rels or {}
 
     def recall_relationships(self, log, **kwargs):
-        """Return relationships keyed by (entity_role, rel_types), as the real method filters them."""
+        """Return relationships keyed by (entity_role, rel_types).
+
+        Deliberately ignores rel_entity_types, and records whether it was passed: the nested
+        BalancerHandler has no feature_lookup, so its by-related-feature-type buckets are empty and
+        that filter would silently match nothing (the 2026-08-14 run moved 0 associations because of
+        it). The caller must filter partners against the AberrationHandler's own lookup instead.
+        """
+        if 'rel_entity_types' in kwargs:
+            RECALL_MISUSE.append(kwargs['rel_entity_types'])
         return self._rels.get((kwargs.get('entity_role'), kwargs.get('rel_types')), [])
 
     def __str__(self):
@@ -125,9 +133,21 @@ class FakeHandler:
         self.balancer_merge_report = []
         self.aberration_allele_rels = {}
         self.feature_subtypes = {'allele': ['allele'], 'insertion': ['insertion']}
+        # The nested BalancerHandler builds no feature_lookup, so partner types must be resolved
+        # against THIS handler's lookup (the one FTA-218 builds under the same gate).
+        self.feature_lookup = {
+            5001: {'type': 'allele', 'name': 'Bar[1]', 'uniquename': 'FBal0000817'},
+            5002: {'type': 'allele', 'name': 'sc[8]', 'uniquename': 'FBal0015197'},
+            5003: {'type': 'allele', 'name': 'held-back', 'uniquename': 'FBal0000003'},
+            5004: {'type': 'allele', 'name': 'cassette', 'uniquename': 'FBal0009999'},
+            5005: {'type': 'gene', 'name': 'wrong-type', 'uniquename': 'FBgn0000001'},
+            6001: {'type': 'insertion', 'name': 'P{x}1', 'uniquename': 'FBti0000001'},
+        }
+        self.cassette_ignore_list = {5004}
 
 
 results = []
+RECALL_MISUSE = []
 
 
 def check(name, condition):
@@ -188,7 +208,10 @@ check('two report rows written', len(h2.balancer_merge_report) == 2)
 
 print('--- carries associations: injected under the parent, exclusions honoured ---')
 basc = FakeEntity(101, 'FBba0000014', 'Basc', rels={
-    ('object', 'carried_on'): [FakeRel(1, 5001, 101), FakeRel(2, 5002, 101)],
+    ('object', 'carried_on'): [FakeRel(1, 5001, 101), FakeRel(2, 5002, 101),
+                               FakeRel(5, 5004, 101),    # cassette FBal: must be skipped with a warning
+                               FakeRel(6, 5005, 101),    # wrong partner type: must be skipped
+                               FakeRel(7, 5999, 101)],   # not in feature_lookup at all: must be skipped
     ('subject', 'associated_with'): [FakeRel(3, 101, 6001)],
 })
 fm1 = FakeEntity(111, 'FBba0000011', 'FM1', rels={
@@ -210,11 +233,17 @@ check('nothing keyed under the balancer itself', not any(k[0] in (101, 111) for 
 basc_row = next(r for r in h3.balancer_merge_report if r['fbba_id'] == 'FBba0000014')
 fm1_row = next(r for r in h3.balancer_merge_report if r['fbba_id'] == 'FBba0000011')
 check('report counts moved associations', basc_row['carries_alleles'] == 3)
+check('cassette partner skipped with a warning', any('cassette' in w.lower() for w in h3.log.warnings))
+check('wrong-type partner not moved', (1, 5005, 'carries') not in keys)
+check('partner missing from feature_lookup not moved', (1, 5999, 'carries') not in keys)
 check('report counts excluded associations', fm1_row['carries_excluded'] == 1)
 check('excluded balancer moved nothing', fm1_row['carries_alleles'] == 0)
 
 print('--- the relationship objects themselves are kept, for evidence lookup ---')
 rel_list = h3.aberration_allele_rels[(1, 5001, 'carries')]
 check('rel_key maps to the FBRelationship list', rel_list[0].rel_id == 1)
+
+check('rel_entity_types not passed to recall_relationships (empty buckets in the nested handler)',
+      RECALL_MISUSE == [])
 
 print(f'\n{sum(1 for _, ok in results if ok)}/{len(results)} checks PASSED')

--- a/docs/FTA-236/verify_graft.py
+++ b/docs/FTA-236/verify_graft.py
@@ -1,0 +1,220 @@
+"""Offline harness for AberrationHandler.add_fbba_to_fbab() and the carries injection (FTA-236).
+
+Extracts method source with ast and drives it with duck-typed stand-ins, since sqlalchemy and
+harvdev_utils cannot be imported here (see docs/FTA-236/plan.md).
+
+Run: python3 docs/FTA-236/verify_graft.py
+"""
+
+import ast
+import re
+from os import environ
+
+SRC = '/Users/ilongden/harvard/alliance-linkml-flybase/src/allele_handlers.py'
+
+tree = ast.parse(open(SRC).read())
+cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == 'AberrationHandler')
+ns = {'re': re, 'getenv': lambda k, d=None: environ.get(k, d)}
+wanted_attrs = ('balancer_graft_prop_types', 'balancer_carries_exclusions')
+for node in cls.body:
+    if isinstance(node, ast.Assign) and getattr(node.targets[0], 'id', '') in wanted_attrs:
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+# Later tasks add more methods; the guard lets the harness run before they exist.
+for name in ('add_fbba_to_fbab', 'merge_balancers_into_aberrations',
+             'synthesize_balancer_carries_associations'):
+    node = next((n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == name), None)
+    if node is not None:
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+
+
+class FakeLog:
+    """Collects log calls by level, so the checks can assert on what was reported."""
+
+    def __init__(self):
+        """Start with empty lists for each level the handler methods use."""
+        self.lines, self.warnings = [], []
+
+    def info(self, msg):
+        """Record an info line."""
+        self.lines.append(msg)
+
+    def debug(self, msg):
+        """Discard debug output; the checks never assert on it."""
+        pass
+
+    def warning(self, msg):
+        """Record a warning."""
+        self.warnings.append(msg)
+
+    def error(self, msg):
+        """Record an error alongside the warnings; the checks treat them together."""
+        self.warnings.append(msg)
+
+
+class FakeProp:
+    """Stand-in for an FBProp: only .chado_obj.value and .pubs are read."""
+
+    def __init__(self, value):
+        """Wrap a featureprop value the way FBProp exposes it."""
+        self.chado_obj = type('O', (), {'value': value})()
+        self.pubs = []
+
+
+class FakeSynonym:
+    """Stand-in for a FeatureSynonym association, which is grafted by synonym_id."""
+
+    def __init__(self, synonym_id, name):
+        """Record the synonym_id the demotion logic keys on, plus its text."""
+        self.synonym_id = synonym_id
+        self.name = name
+
+
+class FakeRel:
+    """Stand-in for an FBRelationship: subject/object ids plus supporting pubs."""
+
+    def __init__(self, rel_id, subject_id, object_id, pubs=()):
+        """Build a relationship between two feature_ids."""
+        self.chado_obj = type('O', (), {'subject_id': subject_id, 'object_id': object_id})()
+        self.rel_id = rel_id
+        self.pubs = list(pubs)
+
+
+class FakeEntity:
+    """Stand-in for an FBAberration or FBBalancer entity."""
+
+    def __init__(self, feature_id, uniquename, name='', rels=None):
+        """Build an entity with the source-data lists the graft extends."""
+        self.db_primary_id = feature_id
+        self.uniquename = uniquename
+        self.name = name
+        self.synonyms = []
+        self.merged_synonym_ids = set()
+        self.demoted_synonym_ids = set()
+        self.alt_fb_ids = []
+        self.fb_sec_dbxrefs = []
+        self.pub_associations = []
+        self.props_by_type = {}
+        self.linkmldto = object()
+        self._rels = rels or {}
+
+    def recall_relationships(self, log, **kwargs):
+        """Return relationships keyed by (entity_role, rel_types), as the real method filters them."""
+        return self._rels.get((kwargs.get('entity_role'), kwargs.get('rel_types')), [])
+
+    def __str__(self):
+        """Match FBDataEntity's "name (uniquename)" form, which log messages rely on."""
+        return f'{self.name} ({self.uniquename})'
+
+
+class FakeHandler:
+    """Minimal AberrationHandler: the real methods, bound to duck-typed state."""
+
+    balancer_graft_prop_types = ns['balancer_graft_prop_types']
+    balancer_carries_exclusions = ns['balancer_carries_exclusions']
+    add_fbba_to_fbab = ns.get('add_fbba_to_fbab')
+    merge_balancers_into_aberrations = ns.get('merge_balancers_into_aberrations')
+    synthesize_balancer_carries_associations = ns.get('synthesize_balancer_carries_associations')
+
+    def __init__(self, aberrations, balancers, merge_map, testing=False):
+        """Key the given entities by feature_id and start with empty report/rel collections."""
+        self.log = FakeLog()
+        self.testing = testing
+        self.fb_data_entities = {a.db_primary_id: a for a in aberrations}
+        self.fbba_entities = {b.db_primary_id: b for b in balancers}
+        self.balancer_merge_map = merge_map
+        self.balancer_merge_report = []
+        self.aberration_allele_rels = {}
+        self.feature_subtypes = {'allele': ['allele'], 'insertion': ['insertion']}
+
+
+results = []
+
+
+def check(name, condition):
+    """Record and print one assertion."""
+    results.append((name, condition))
+    print(f'  {"PASS" if condition else "FAIL"}: {name}')
+
+
+print('--- graft: names, identifiers, whitelisted notes, references ---')
+parent = FakeEntity(1, 'FBab0004219', 'In(1)Basc')
+parent.synonyms = [FakeSynonym(900, 'In(1)Basc')]
+parent.props_by_type = {'misc': [FakeProp('Parent comment.')]}
+parent.pub_associations = ['parent_pub']
+
+balancer = FakeEntity(101, 'FBba0000014', 'Basc')
+balancer.synonyms = [FakeSynonym(910, 'Basc'), FakeSynonym(911, 'M5')]
+balancer.fb_sec_dbxrefs = ['fbba_sec_dbxref']
+balancer.pub_associations = ['fbba_pub_1', 'fbba_pub_2']
+balancer.props_by_type = {
+    'misc': [FakeProp('N[opa33b] is a natural variant ...')],
+    'internal_notes': [FakeProp('FTA: Balancer - merge with parent In(1)Basc (FBab0004219).')],
+    'availability': [FakeProp('Stated to be lost.')],      # must NOT move: would set is_extinct
+    'derived_stock_count': [FakeProp('12')],               # must NOT move
+}
+
+h = FakeHandler([parent], [balancer], {101: 1})
+h.merge_balancers_into_aberrations()
+
+check('balancer synonyms appended', {s.synonym_id for s in parent.synonyms} == {900, 910, 911})
+check('balancer synonym ids marked as merged', parent.merged_synonym_ids == {910, 911})
+check('parent own synonym not marked merged', 900 not in parent.merged_synonym_ids)
+check('balancer synonym ids also demoted (protects the full name slot)', parent.demoted_synonym_ids == {910, 911})
+check('balancer primary ID added as secondary', 'FB:FBba0000014' in parent.alt_fb_ids)
+check('balancer secondary dbxrefs moved', 'fbba_sec_dbxref' in parent.fb_sec_dbxrefs)
+check('misc props merged, parent prop kept', len(parent.props_by_type['misc']) == 2)
+check('internal_notes props merged', len(parent.props_by_type['internal_notes']) == 1)
+check('availability NOT merged', 'availability' not in parent.props_by_type)
+check('derived_stock_count NOT merged', 'derived_stock_count' not in parent.props_by_type)
+check('balancer pubs merged', parent.pub_associations == ['parent_pub', 'fbba_pub_1', 'fbba_pub_2'])
+
+row = h.balancer_merge_report[0]
+check('report identifies both entities', row['fbba_id'] == 'FBba0000014' and row['fbab_id'] == 'FBab0004219')
+check('report counts synonyms', row['synonyms'] == 2)
+check('report counts comments', row['comments'] == 1)
+check('report counts references', row['references'] == 2)
+check('report counts secondary ids (primary + own)', row['secondary_ids'] == 2)
+
+print('--- two balancers into one parent (the SM6 case) ---')
+parent2 = FakeEntity(2, 'FBab0004818', 'In(2LR)SM6')
+sm6a = FakeEntity(102, 'FBba0000039', 'SM6a')
+sm6a.synonyms = [FakeSynonym(920, 'SM6a')]
+sm6b = FakeEntity(103, 'FBba0000040', 'SM6b')
+sm6b.synonyms = [FakeSynonym(930, 'SM6b')]
+h2 = FakeHandler([parent2], [sm6a, sm6b], {102: 2, 103: 2})
+h2.merge_balancers_into_aberrations()
+check('both balancers merged into one parent', {s.synonym_id for s in parent2.synonyms} == {920, 930})
+check('two report rows written', len(h2.balancer_merge_report) == 2)
+
+print('--- carries associations: injected under the parent, exclusions honoured ---')
+basc = FakeEntity(101, 'FBba0000014', 'Basc', rels={
+    ('object', 'carried_on'): [FakeRel(1, 5001, 101), FakeRel(2, 5002, 101)],
+    ('subject', 'associated_with'): [FakeRel(3, 101, 6001)],
+})
+fm1 = FakeEntity(111, 'FBba0000011', 'FM1', rels={
+    ('object', 'carried_on'): [FakeRel(4, 5003, 111)],
+})
+parent_basc = FakeEntity(1, 'FBab0004219', 'In(1)Basc')
+parent_fm1 = FakeEntity(10, 'FBab0010486', 'In(1)FM1')
+
+h3 = FakeHandler([parent_basc, parent_fm1], [basc, fm1], {101: 1, 111: 10})
+h3.merge_balancers_into_aberrations()
+h3.synthesize_balancer_carries_associations()
+
+keys = set(h3.aberration_allele_rels.keys())
+check('carried_on allele keyed under the parent as "carries"', (1, 5001, 'carries') in keys)
+check('second carried_on allele present', (1, 5002, 'carries') in keys)
+check('associated_with insertion keyed as "carries"', (1, 6001, 'carries') in keys)
+check('excluded balancer contributes nothing', not any(k[0] == 10 for k in keys))
+check('nothing keyed under the balancer itself', not any(k[0] in (101, 111) for k in keys))
+basc_row = next(r for r in h3.balancer_merge_report if r['fbba_id'] == 'FBba0000014')
+fm1_row = next(r for r in h3.balancer_merge_report if r['fbba_id'] == 'FBba0000011')
+check('report counts moved associations', basc_row['carries_alleles'] == 3)
+check('report counts excluded associations', fm1_row['carries_excluded'] == 1)
+check('excluded balancer moved nothing', fm1_row['carries_alleles'] == 0)
+
+print('--- the relationship objects themselves are kept, for evidence lookup ---')
+rel_list = h3.aberration_allele_rels[(1, 5001, 'carries')]
+check('rel_key maps to the FBRelationship list', rel_list[0].rel_id == 1)
+
+print(f'\n{sum(1 for _, ok in results if ok)}/{len(results)} checks PASSED')

--- a/docs/FTA-236/verify_merge_map.py
+++ b/docs/FTA-236/verify_merge_map.py
@@ -1,0 +1,156 @@
+"""Offline harness for AberrationHandler.synthesize_balancer_merge_map() (FTA-236).
+
+Extracts the method source with ast and drives it with duck-typed stand-ins, since
+sqlalchemy/harvdev_utils cannot be imported here (see docs/FTA-236/plan.md).
+
+Run: python3 docs/FTA-236/verify_merge_map.py
+"""
+
+import ast
+import re
+
+SRC = '/Users/ilongden/harvard/alliance-linkml-flybase/src/allele_handlers.py'
+
+tree = ast.parse(open(SRC).read())
+cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == 'AberrationHandler')
+ns = {'re': re}
+for node in cls.body:
+    if isinstance(node, ast.Assign) and getattr(node.targets[0], 'id', '') == 'balancer_merge_regex':
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+for name in ('synthesize_balancer_merge_map', '_resolve_parent_feature_id'):
+    node = next(n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == name)
+    exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+for node in tree.body:
+    if isinstance(node, ast.Assign) and getattr(node.targets[0], 'id', '') == 'BALANCER_MERGE_EXPECTED':
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+print(f'Regex in use: {ns["balancer_merge_regex"].pattern}')
+print(f'Expected flag count: {ns["BALANCER_MERGE_EXPECTED"]}\n')
+
+
+class FakeLog:
+    """Collects log calls by level, so the checks can assert on what was reported."""
+
+    def __init__(self):
+        """Start with empty lists for each level the handler methods use."""
+        self.info_lines, self.warnings, self.errors = [], [], []
+
+    def info(self, msg):
+        """Record an info line."""
+        self.info_lines.append(msg)
+
+    def debug(self, msg):
+        """Discard debug output; the checks never assert on it."""
+        pass
+
+    def warning(self, msg):
+        """Record a warning."""
+        self.warnings.append(msg)
+
+    def error(self, msg):
+        """Record an error."""
+        self.errors.append(msg)
+
+
+class FakeProp:
+    """Stand-in for an FBProp: only .chado_obj.value is read by the code under test."""
+
+    def __init__(self, value):
+        """Wrap a featureprop value the way FBProp exposes it."""
+        self.chado_obj = type('O', (), {'value': value})()
+
+
+class FakeEntity:
+    """Stand-in for an FBAberration or FBBalancer entity."""
+
+    def __init__(self, feature_id, uniquename, name='', internal_notes=()):
+        """Build an entity with optional internal_notes props."""
+        self.db_primary_id = feature_id
+        self.uniquename = uniquename
+        self.name = name
+        self.is_obsolete = False
+        self.props_by_type = {'internal_notes': [FakeProp(v) for v in internal_notes]} if internal_notes else {}
+
+    def __str__(self):
+        """Match FBDataEntity's "name (uniquename)" form, which log messages rely on."""
+        return f'{self.name} ({self.uniquename})'
+
+
+class FakeHandler:
+    """Minimal AberrationHandler: the real methods, bound to duck-typed state."""
+
+    balancer_merge_regex = ns['balancer_merge_regex']
+    synthesize_balancer_merge_map = ns['synthesize_balancer_merge_map']
+    _resolve_parent_feature_id = ns['_resolve_parent_feature_id']
+
+    def __init__(self, aberrations, balancers, testing=False):
+        """Key the given aberrations and balancers by feature_id, as the handler does."""
+        self.log = FakeLog()
+        self.testing = testing
+        self.fb_data_entities = {a.db_primary_id: a for a in aberrations}
+        self.fbba_entities = {b.db_primary_id: b for b in balancers}
+        self.balancer_merge_map = {}
+
+
+# The real chado values, verified 2026-08-14.
+FLAG = 'FTA: Balancer - merge with parent In(1)Basc (FBab0004219).'
+FLAG_SM6A = 'FTA: Balancer - merge with parent In(2LR)SM6 (FBab0004818).'
+FLAG_SM6B = 'FTA: Balancer - merge with parent In(2LR)SM6 (FBab0004818).'
+# AM1's note before the week-of-2026-08-17 correction: names the obsolete FBab0007127.
+FLAG_OBSOLETE = 'FTA: Balancer - merge with parent T(2;3)A1-W (FBab0007127).'
+FLAG_UNKNOWN = 'FTA: Balancer - merge with parent Nope (FBab9999999).'
+# Sibling flag families that must not be picked up here.
+FLAG_RENAME = 'FTA: Balancer - use balancer symbol and fullname for parent In(1)Basc (FBab0004219).'
+MARK = "FTA: Balancer - mark this aberration as 'balancer'."
+PROSE = 'Used as a balancer; merge with parent was discussed but never agreed.'
+
+results = []
+
+
+def check(name, condition):
+    """Record and print one assertion."""
+    results.append((name, condition))
+    print(f'  {"PASS" if condition else "FAIL"}: {name}')
+
+
+print('--- happy path: 3 flagged balancers, 2 parents (SM6 takes two) ---')
+aberrations = [
+    FakeEntity(1, 'FBab0004219', 'In(1)Basc'),
+    FakeEntity(2, 'FBab0004818', 'In(2LR)SM6'),
+    FakeEntity(3, 'FBab0049550', 'T(2;3)A1-W'),
+]
+balancers = [
+    FakeEntity(101, 'FBba0000014', 'Basc', [FLAG]),
+    FakeEntity(102, 'FBba0000039', 'SM6a', [FLAG_SM6A]),
+    FakeEntity(103, 'FBba0000040', 'SM6b', [FLAG_SM6B]),
+    FakeEntity(104, 'FBba0000999', 'X', [PROSE, FLAG_RENAME, MARK]),
+]
+h = FakeHandler(aberrations, balancers)
+h.synthesize_balancer_merge_map()
+check('3 flagged balancers mapped', h.balancer_merge_map == {101: 1, 102: 2, 103: 2})
+check('rename/mark/prose balancer ignored', 104 not in h.balancer_merge_map)
+check('no errors logged', h.log.errors == [])
+
+print('--- obsolete parent is an error, not a silent redirect (Steven: option 1) ---')
+h = FakeHandler([FakeEntity(3, 'FBab0049550', 'T(2;3)A1-W')],
+                [FakeEntity(105, 'FBba0000688', 'AM1', [FLAG_OBSOLETE])])
+h.synthesize_balancer_merge_map()
+check('obsolete/absent parent not merged', h.balancer_merge_map == {})
+check('error names the balancer', any('FBba0000688' in e for e in h.log.errors))
+check('error names the stale parent ID', any('FBab0007127' in e for e in h.log.errors))
+check('current T(2;3)A1-W is NOT silently substituted', 3 not in h.balancer_merge_map.values())
+
+print('--- unknown parent ID is an error ---')
+h = FakeHandler([FakeEntity(1, 'FBab0004219', 'In(1)Basc')],
+                [FakeEntity(106, 'FBba0000777', 'Y', [FLAG_UNKNOWN])])
+h.synthesize_balancer_merge_map()
+check('unknown parent not merged', h.balancer_merge_map == {})
+check('error names the unknown ID', any('FBab9999999' in e for e in h.log.errors))
+
+print('--- count warning off the expected 38, suppressed in testing mode ---')
+check('count warning present', any('38' in w for w in h.log.warnings))
+h = FakeHandler([FakeEntity(1, 'FBab0004219', 'In(1)Basc')],
+                [FakeEntity(101, 'FBba0000014', 'Basc', [FLAG])], testing=True)
+h.synthesize_balancer_merge_map()
+check('no count warning in testing mode', not any('38' in w for w in h.log.warnings))
+
+print(f'\n{sum(1 for _, ok in results if ok)}/{len(results)} checks PASSED')

--- a/docs/FTA-236/verify_merge_map.py
+++ b/docs/FTA-236/verify_merge_map.py
@@ -62,12 +62,12 @@ class FakeProp:
 class FakeEntity:
     """Stand-in for an FBAberration or FBBalancer entity."""
 
-    def __init__(self, feature_id, uniquename, name='', internal_notes=()):
-        """Build an entity with optional internal_notes props."""
+    def __init__(self, feature_id, uniquename, name='', internal_notes=(), is_obsolete=False):
+        """Build an entity with optional internal_notes props; obsolete entities are exported too."""
         self.db_primary_id = feature_id
         self.uniquename = uniquename
         self.name = name
-        self.is_obsolete = False
+        self.is_obsolete = is_obsolete
         self.props_by_type = {'internal_notes': [FakeProp(v) for v in internal_notes]} if internal_notes else {}
 
     def __str__(self):
@@ -138,6 +138,17 @@ check('obsolete/absent parent not merged', h.balancer_merge_map == {})
 check('error names the balancer', any('FBba0000688' in e for e in h.log.errors))
 check('error names the stale parent ID', any('FBab0007127' in e for e in h.log.errors))
 check('current T(2;3)A1-W is NOT silently substituted', 3 not in h.balancer_merge_map.values())
+
+print('--- obsolete parent PRESENT in fb_data_entities is still an error (2026-08-14 run bug) ---')
+# fb_data_entities holds obsolete aberrations too - they export as internal/obsolete - so membership
+# alone is not enough. Before the fix, AM1's data merged into the obsolete FBab0007127.
+h = FakeHandler([FakeEntity(7, 'FBab0007127', 'T(2;3)A1-W', is_obsolete=True),
+                 FakeEntity(3, 'FBab0049550', 'T(2;3)A1-W')],
+                [FakeEntity(105, 'FBba0000688', 'AM1', [FLAG_OBSOLETE])])
+h.synthesize_balancer_merge_map()
+check('obsolete parent in fb_data_entities is rejected', h.balancer_merge_map == {})
+check('error raised for the obsolete parent', any('FBab0007127' in e for e in h.log.errors))
+check('current same-named aberration not substituted', 3 not in h.balancer_merge_map.values())
 
 print('--- unknown parent ID is an error ---')
 h = FakeHandler([FakeEntity(1, 'FBab0004219', 'In(1)Basc')],

--- a/docs/FTA-236/verify_run.sh
+++ b/docs/FTA-236/verify_run.sh
@@ -17,8 +17,8 @@ MERGES=$(ls "$DIR"/*_balancer_merges.tsv)
 echo '--- FBba retrieval and merge tallies ---'
 grep -E 'obtained [0-9]+ FBba balancers|balancer merge flags|Merged .* balancers into|Moved [0-9]+ (synonyms|secondary_ids|comments|internal_notes|references)' "$LOG"
 
-echo '--- carries move (only present when ADD_ALLELE_ALLELE_ASSOC=YES) ---'
-grep -E 'balancer "carries" associations|Held back' "$LOG" || echo '(gate off: no carries lines)'
+echo '--- carries move (gate on: expect 273 moved, 53 held back, 0 skipped-unknown surprises) ---'
+grep -E 'balancer "carries" associations|Held back|balancer relationships whose partner' "$LOG" || echo '(gate off: no carries lines)'
 
 echo '--- errors: expect 0, or exactly 1 naming FBba0000688 before the note correction loads ---'
 grep -c ' ERROR ' "$LOG" || true
@@ -50,18 +50,14 @@ grep -m1 'FB:FBab0004219' "$TSV"
 echo '--- the N[opa33b] comment must have moved to the aberration ---'
 grep -c 'FBab0004219.*opa33b' "$DIR"/allele_curation_*_notes.tsv || echo '(not found - check the notes TSV)'
 
-echo '--- every merged parent must carry the balancer ID as a secondary ID ---'
-missing=0
-while IFS=$'\t' read -r fbab fbba; do
-  line=$(grep -m1 "^FB:$fbab" "$TSV" || true)
-  if [ -z "$line" ]; then
-    echo "NOT IN PRIMARY TSV: $fbab"
-    missing=$((missing + 1))
-  elif ! printf '%s' "$line" | grep -qF "$fbba"; then
-    echo "MISSING secondary ID: $fbab should list $fbba"
-    missing=$((missing + 1))
-  fi
-done < <(awk -F'\t' 'NR>1 {print $1"\t"$3}' "$MERGES" | sed 's/^FB://')
-echo "secondary-ID problems: $missing"
+echo '--- every merged balancer must appear as a secondary ID in the JSON ---'
+# NB check the JSON, not the primary TSV: write_primary_tsv() reads a "secondary_identifiers" key that
+# AlleleDTO does not have (it uses allele_secondary_id_dtos), so that column is empty for every allele
+# in every run - pre-existing, unrelated to this ticket.
+JSON=$(ls "$DIR"/allele_curation_*.json)
+grep -o '"secondary_id": "FB:FBba[0-9]*"' "$JSON" | grep -o 'FBba[0-9]*' | sort -u > /tmp/fta236_json_fbba.txt
+awk -F'\t' 'NR>1 {print $3}' "$MERGES" | grep '^FBba' | sort -u > /tmp/fta236_tsv_fbba.txt
+comm -23 /tmp/fta236_tsv_fbba.txt /tmp/fta236_json_fbba.txt | sed 's/^/MISSING secondary ID in JSON: /'
+echo "merged balancers: $(wc -l < /tmp/fta236_tsv_fbba.txt), present as secondary IDs: $(wc -l < /tmp/fta236_json_fbba.txt)"
 
 echo '--- done ---'

--- a/docs/FTA-236/verify_run.sh
+++ b/docs/FTA-236/verify_run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# FTA-236 run verification.
+# Usage (on flysql26): verify_run.sh /data/alliance/PERSISTENT_main_FTA-236_balancer_merge
+# Or from a laptop:    ssh flysql26 "bash -s" < docs/FTA-236/verify_run.sh <rundir>
+#
+# Expected counts come from docs/FTA-236/expected_counts.sql (verified 2026-08-14):
+#   38 merge flags, 37 parents, 96 symbol synonyms, 35 fullname synonyms, 27 comments,
+#   68 internal notes, 440 references, 326 carried_on rows of which 53 are held back.
+# Until the AM1 (FBba0000688) note correction loads (week of 2026-08-17), expect 37 merges
+# and exactly one ERROR naming FBba0000688 - that one is expected, not a regression.
+set -euo pipefail
+DIR="${1:?usage: verify_run.sh <run directory>}"
+LOG=$(ls "$DIR"/allele_curation_*.log)
+TSV=$(ls "$DIR"/allele_curation_*.tsv | grep -v -e _notes -e _renames -e _merges -e _failures)
+MERGES=$(ls "$DIR"/*_balancer_merges.tsv)
+
+echo '--- FBba retrieval and merge tallies ---'
+grep -E 'obtained [0-9]+ FBba balancers|balancer merge flags|Merged .* balancers into|Moved [0-9]+ (synonyms|secondary_ids|comments|internal_notes|references)' "$LOG"
+
+echo '--- carries move (only present when ADD_ALLELE_ALLELE_ASSOC=YES) ---'
+grep -E 'balancer "carries" associations|Held back' "$LOG" || echo '(gate off: no carries lines)'
+
+echo '--- errors: expect 0, or exactly 1 naming FBba0000688 before the note correction loads ---'
+grep -c ' ERROR ' "$LOG" || true
+grep ' ERROR ' "$LOG" || true
+
+echo '--- name-collision warnings (expect 0 of each; this is what demoted_synonym_ids prevents) ---'
+echo -n 'many current symbols: '
+grep -c 'many current symbols' "$LOG" || true
+echo -n 'many current full_names: '
+grep -c 'many current full_names' "$LOG" || true
+
+echo '--- merge TSV row count (expect 38, or 37 before the correction) ---'
+tail -n +2 "$MERGES" | wc -l
+
+echo '--- column totals moved, to compare with expected_counts.sql ---'
+awk -F'\t' 'NR>1 {syn+=$6; sec+=$7; com+=$8; note+=$9; ref+=$10; car+=$11; exc+=$12}
+            END {printf "synonyms=%d secondary_ids=%d comments=%d internal_notes=%d references=%d carries=%d excluded=%d\n",
+                 syn, sec, com, note, ref, car, exc}' "$MERGES"
+
+echo '--- In(2LR)SM6 must show two merge rows (SM6a and SM6b) ---'
+grep -c 'FBab0004818' "$MERGES"
+
+echo '--- the three excluded balancers must move 0 carries and hold back 15/20/18 ---'
+awk -F'\t' 'NR>1 && ($3=="FBba0000011" || $3=="FBba0000039" || $3=="FBba0000040") {print $1"\t"$3"\tcarries="$11"\texcluded="$12}' "$MERGES"
+
+echo '--- worked example: In(1)Basc must gain M5 as a synonym and FBba0000014 as a secondary ID ---'
+grep -m1 'FB:FBab0004219' "$TSV"
+
+echo '--- the N[opa33b] comment must have moved to the aberration ---'
+grep -c 'FBab0004219.*opa33b' "$DIR"/allele_curation_*_notes.tsv || echo '(not found - check the notes TSV)'
+
+echo '--- every merged parent must carry the balancer ID as a secondary ID ---'
+missing=0
+while IFS=$'\t' read -r fbab fbba; do
+  line=$(grep -m1 "^FB:$fbab" "$TSV" || true)
+  if [ -z "$line" ]; then
+    echo "NOT IN PRIMARY TSV: $fbab"
+    missing=$((missing + 1))
+  elif ! printf '%s' "$line" | grep -qF "$fbba"; then
+    echo "MISSING secondary ID: $fbab should list $fbba"
+    missing=$((missing + 1))
+  fi
+done < <(awk -F'\t' 'NR>1 {print $1"\t"$3}' "$MERGES" | sed 's/^FB://')
+echo "secondary-ID problems: $missing"
+
+echo '--- done ---'

--- a/docs/FTA-237/expected_renames.sql
+++ b/docs/FTA-237/expected_renames.sql
@@ -1,0 +1,119 @@
+-- FTA-237 expectation queries. Run on flysql26:
+--   PGPASSWORD=ilongdenpgsql psql -h flysql24 -U ilongden -d production_chado -f expected_renames.sql
+-- Query 1 is the oracle for the *_balancer_renames.tsv rows with source=flag; the curator spreadsheet
+-- linked from the ticket needs auth, so this is the machine-checkable equivalent.
+set standard_conforming_strings = on;
+
+\echo === 1. the 24 renames: new names (from the balancer) and old names (from the parent) ===
+with renames as (
+  select f.feature_id as fbba_id, f.uniquename as fbba,
+         substring(fp.value from 'FBab[0-9]+') as parent_fbab
+  from feature f
+  join featureprop fp on fp.feature_id = f.feature_id
+  join cvterm cvt on cvt.cvterm_id = fp.type_id
+  where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - use balancer symbol and fullname%'
+),
+curr as (
+  select fs.feature_id, t.name as syn_type, s.name as value
+  from feature_synonym fs
+  join synonym s on s.synonym_id = fs.synonym_id
+  join cvterm t on t.cvterm_id = s.type_id
+  where fs.is_current is true and t.name in ('symbol', 'fullname')
+)
+select r.parent_fbab,
+       r.fbba,
+       (select string_agg(distinct value, ' / ') from curr where feature_id = r.fbba_id and syn_type = 'symbol') as new_symbol,
+       (select string_agg(distinct value, ' / ') from curr where feature_id = r.fbba_id and syn_type = 'fullname') as new_full_name,
+       (select string_agg(distinct value, ' / ') from curr where feature_id = p.feature_id and syn_type = 'symbol') as old_symbol,
+       coalesce((select string_agg(distinct value, ' / ') from curr where feature_id = p.feature_id and syn_type = 'fullname'), '') as old_full_name
+from renames r
+left join feature p on p.uniquename = r.parent_fbab
+order by r.parent_fbab;
+
+\echo === 2. every rename-flagged balancer must have both a current symbol and a current fullname (expect 24 / 24 / 24 / 0) ===
+with renames as (
+  select f.feature_id as fbba_id from feature f
+  join featureprop fp on fp.feature_id = f.feature_id
+  join cvterm cvt on cvt.cvterm_id = fp.type_id
+  where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - use balancer symbol and fullname%'
+)
+select count(*) as balancers,
+       count(*) filter (where has_symbol) as with_current_symbol,
+       count(*) filter (where has_fullname) as with_current_fullname,
+       count(*) filter (where not has_fullname) as missing_current_fullname
+from (
+  select r.fbba_id,
+         exists (select 1 from feature_synonym fs
+                 join synonym s on s.synonym_id = fs.synonym_id
+                 join cvterm t on t.cvterm_id = s.type_id
+                 where fs.feature_id = r.fbba_id and fs.is_current and t.name = 'symbol') as has_symbol,
+         exists (select 1 from feature_synonym fs
+                 join synonym s on s.synonym_id = fs.synonym_id
+                 join cvterm t on t.cvterm_id = s.type_id
+                 where fs.feature_id = r.fbba_id and fs.is_current and t.name = 'fullname') as has_fullname
+  from renames r
+) x;
+
+\echo === 3. no parent may be named by two rename flags, and none may be obsolete/absent (both expect 0 rows) ===
+select substring(fp.value from 'FBab[0-9]+') as parent_fbab, count(*) as n_flags
+from feature f
+join featureprop fp on fp.feature_id = f.feature_id
+join cvterm cvt on cvt.cvterm_id = fp.type_id
+where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - use balancer symbol and fullname%'
+group by 1 having count(*) > 1;
+
+select b.uniquename as fbba, substring(fp.value from 'FBab[0-9]+') as parent_fbab, p.is_obsolete
+from feature b
+join featureprop fp on fp.feature_id = b.feature_id
+join cvterm cvt on cvt.cvterm_id = fp.type_id
+left join feature p on p.uniquename = substring(fp.value from 'FBab[0-9]+')
+where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - use balancer symbol and fullname%'
+  and (p.feature_id is null or p.is_obsolete is true);
+
+\echo === 4. the SM6 case: no rename flag on either balancer (expect 0 rows) ===
+select f.uniquename, fp.value
+from feature f
+join featureprop fp on fp.feature_id = f.feature_id
+join cvterm cvt on cvt.cvterm_id = fp.type_id
+where f.uniquename in ('FBba0000039', 'FBba0000040')
+  and cvt.name = 'internal_notes'
+  and fp.value like 'FTA: Balancer - use balancer symbol and fullname%';
+
+\echo === 5. the SM6 target strings: "SM6" only non-current, "Second Multiple 6" absent entirely ===
+select s.name as value, f.uniquename, t.name as syn_type, fs.is_current
+from synonym s
+join cvterm t on t.cvterm_id = s.type_id
+join feature_synonym fs on fs.synonym_id = s.synonym_id
+join feature f on f.feature_id = fs.feature_id
+where s.name in ('SM6', 'Second Multiple 6')
+  and (f.uniquename like 'FBab%' or f.uniquename like 'FBba%')
+order by 1, 2, 3;
+
+\echo === 6. current names of the SM6 trio (parent has no current fullname) ===
+select f.uniquename, t.name as syn_type, s.name as value
+from feature f
+join feature_synonym fs on fs.feature_id = f.feature_id
+join synonym s on s.synonym_id = fs.synonym_id
+join cvterm t on t.cvterm_id = s.type_id
+where f.uniquename in ('FBab0004818', 'FBba0000039', 'FBba0000040')
+  and t.name in ('symbol', 'fullname') and fs.is_current is true
+group by 1, 2, 3
+order by 1, 2, 3;
+
+\echo === 7. rename flags are a strict subset of the merge flags (expect 24 / 38 / 24 / 0) ===
+with renames as (
+  select distinct f.feature_id from feature f
+  join featureprop fp on fp.feature_id = f.feature_id
+  join cvterm cvt on cvt.cvterm_id = fp.type_id
+  where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - use balancer symbol and fullname%'
+),
+merges as (
+  select distinct f.feature_id from feature f
+  join featureprop fp on fp.feature_id = f.feature_id
+  join cvterm cvt on cvt.cvterm_id = fp.type_id
+  where cvt.name = 'internal_notes' and fp.value like 'FTA: Balancer - merge with parent%'
+)
+select (select count(*) from renames) as rename_flagged,
+       (select count(*) from merges) as merge_flagged,
+       (select count(*) from renames r where exists (select 1 from merges m where m.feature_id = r.feature_id)) as rename_also_merge,
+       (select count(*) from renames r where not exists (select 1 from merges m where m.feature_id = r.feature_id)) as rename_only;

--- a/docs/FTA-237/plan.md
+++ b/docs/FTA-237/plan.md
@@ -1,0 +1,881 @@
+# FTA-237 — Rename flagged aberrations to the balancer symbol and full name
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** For the 24 FBba balancers carrying `FTA: Balancer - use balancer symbol and fullname for parent <SYMBOL> (<FBab_ID>).`, plus the one hard-coded SM6 case, export the parent FBab aberration under the balancer's current symbol and full name, keeping the aberration's own symbol and full name as synonyms.
+
+**Architecture:** The nested `BalancerHandler` run (shared with FTA-236) already produces a complete `AlleleDTO` per FBba, including a correct `allele_symbol_dto` and `allele_full_name_dto` — right `display_text` SGML→HTML conversion, right evidence curies. So the rename is a DTO-level swap performed after `map_synonyms()`: copy the balancer's two name DTOs into the parent's slots, push the parent's previous ones into `allele_synonym_dtos`, and de-duplicate. No new name text is constructed for the 24, and no part of the synonym-synthesis machinery is modified.
+
+**Tech Stack:** Python 3.11, SQLAlchemy ORM over FlyBase chado (`harvdev_utils.reporting` models), Alliance LinkML DTOs in `src/agr_datatypes.py`.
+
+## Global Constraints
+
+- **PEP8, `max-line-length = 160`** from `.flake8`. `ignore = D100,D103,D104` **replaces** pycodestyle's defaults, so **W503 and W504 are both active**: never break a line before *or* after a boolean operator. Docstrings are required on new public methods (D102 is active).
+- **No local script runs.** The repo venv is x86_64 and unusable on this arm64 Mac. Verification is `python3 -m py_compile`, the offline `ast`-extraction harness in this plan, SQL against chado, and a real run on flysql26.
+- **chado access:** `ssh flysql26` then `PGPASSWORD=ilongdenpgsql psql -h flysql24 -U ilongden -d production_chado`. Set `standard_conforming_strings = on` before using `\y` in a regex.
+- **Run artifacts:** `flysql26:/data/alliance/PERSISTENT_*`. A full allele run takes ~85 minutes.
+- **No gate.** This ticket only touches `allele_symbol_dto`, `allele_full_name_dto` and `allele_synonym_dtos`, all long-released LinkML slots. Nothing here needs `ADD_IS_ABERRATION` or `ADD_ALLELE_ALLELE_ASSOC`.
+- **Never commit without explicit permission from Ian.** Commit steps are prepared but only run on request.
+- **Conventional Commits**, scope `FTA-237`, `git add <specific paths>` only.
+
+## Relationship to FTA-236 — read this first
+
+FTA-236 (plan: `docs/FTA-236/plan.md`, branch `FTA-236`, commit `ec4ce3b`) is **parked** pending a curator answer, but its **Task 1 is the shared foundation**: the nested `BalancerHandler` run (`get_balancer_entities()`) and the flag-parsing/parent-resolution helpers (`_resolve_parent_feature_id()`).
+
+- If FTA-236's Task 1 has already landed, **Task 1 here is just the second regex plus one map method** — skip its Steps 3-5 and say so in the commit.
+- If it has not, Task 1 here includes the nested retrieval verbatim from `docs/FTA-236/plan.md` Task 1 Steps 3-6. FTA-236's parked question does not affect this ticket: **all 24 rename parents are current and non-obsolete**, so both candidate parent-resolution policies behave identically here.
+
+The two tickets must stay in this order of operations, and the interaction is the main design risk:
+
+1. FTA-236 grafts the balancer's names onto the parent and marks them all non-current (`demoted_synonym_ids`), so they land in `allele_synonym_dtos`.
+2. FTA-237 then promotes two of them — the current symbol and current full name — into the parent's name slots, and removes the now-duplicated synonym entries.
+
+Implemented this way, **either ticket works alone**: with FTA-236 absent the balancer names simply are not in the synonym list, and the de-duplication finds nothing to remove.
+
+---
+
+## Verified input data (production_chado, 2026-08-14)
+
+24 rename flags → 24 distinct parents, **all current and non-obsolete**; all 24 balancers have both a current symbol and a current full name; the 24 are a strict subset of FTA-236's 38 merge-flagged balancers (14 merge without renaming, none rename without merging).
+
+| FBba | new symbol | new full name | parent FBab | parent symbol → synonym | parent full name → synonym |
+|---|---|---|---|---|---|
+| FBba0000002 | FM3 | First Multiple 3 | FBab0003926 | In(1)FM3 | Inversion (1) First Multiple |
+| FBba0000070 | FM4 | First Multiple 4 | FBab0003927 | In(1)FM4 | *(none)* |
+| FBba0000003 | FM6 | First Multiple 6 | FBab0003928 | In(1)FM6 | *(none)* |
+| FBba0000007 | FM7a | First Multiple 7a | FBab0003929 | In(1)FM7a | *(none)* |
+| FBba0000014 | Basc | Bar-apricot-scute | FBab0004219 | In(1)Basc | *(none)* |
+| FBba0000025 | CyO | Curly of Oster | FBab0004786 | In(2LR)CyO | Inversion (2LR) Curly of Oster |
+| FBba0000037 | SM1 | Second Multiple 1 | FBab0004815 | In(2LR)SM1 | Inversion (2LR) Second Multiple |
+| FBba0000038 | SM5 | Second Multiple 5 | FBab0004817 | In(2LR)SM5 | *(none)* |
+| FBba0000104 | DcxF | Dichaete crossover suppressor of Federova | FBab0005386 | In(3LR)DcxF | Inversion (3LR) Dichaete crossover suppressor of Federova |
+| FBba0000042 | TM1 | Third Multiple 1 | FBab0005462 | In(3LR)TM1 | Inversion (3LR) Third Multiple |
+| FBba0000047 | TM3 | Third Multiple 3 | FBab0005463 | In(3LR)TM3 | *(none)* |
+| FBba0000056 | TM6 | Third Multiple 6 | FBab0005464 | In(3LR)TM6 | *(none)* |
+| FBba0000057 | TM6B | Third Multiple 6B | FBab0005465 | In(3LR)TM6B | *(none)* |
+| FBba0000071 | TM6C | Third Multiple 6C | FBab0005466 | In(3LR)TM6C | *(none)* |
+| FBba0000060 | TM8 | Third Multiple 8 | FBab0005467 | In(3LR)TM8 | *(none)* |
+| FBba0000061 | TM9 | Third Multiple 9 | FBab0005468 | In(3LR)TM9 | *(none)* |
+| FBba0000072 | TMS | Third Multiple of Singson | FBab0005469 | In(3LR)TMS | *(none)* |
+| FBba0000062 | TM2 | Third Multiple 2 | FBab0005473 | In(3LR)TM2 | Inversion (3LR) Ultrabithorax |
+| FBba0000068 | MRS | Minute-rosy-Stubble | FBab0010017 | Tp(3;3)MRS | *(none)* |
+| FBba0000011 | FM1 | First Multiple 1 | FBab0010486 | In(1)FM1 | *(none)* |
+| FBba0000021 | Insc | Inversion scute | FBab0010488 | In(1)Insc | *(none)* |
+| FBba0000001 | CyO-Df(2R)B80 | Curly of Oster-Df(2R)B80 | FBab0022240 | In(2LR)CyO-Df(2R)B80 | *(none)* |
+| FBba0000237 | CyO-Tp(2;2)pk-sple[26] | Curly of Oster-Tp(2;2)pk-sple[26] | FBab0024785 | In(2LR)CyO-Tp(2;2)pk-sple[26] | *(none)* |
+| FBba0000659 | FM8 | First Multiple 8 | FBab0049294 | In(1)FM8 | *(none)* |
+
+Only 6 of the 24 parents have a full name of their own to demote; the other 18 have an empty slot that the balancer's full name fills.
+
+## The SM6 case is not flag-driven (correction to the ticket text)
+
+The ticket presents SM6 as an exception "because SM6a and SM6b share a parent". The real reason it must be hard-coded is different, and it changes what Task 3 has to do: **neither `FBba0000039` (SM6a) nor `FBba0000040` (SM6b) carries a rename flag at all.** They are merge-flagged only, so `FBab0004818` is not among the 24 and no flag can produce its new names.
+
+In chado:
+
+- `FBab0004818` current symbol is `In(2LR)SM6`, and it has **no** current full name.
+- `SM6` exists as a **non-current** symbol synonym on `FBab0004818` itself (and on both balancers).
+- **`Second Multiple 6` does not exist anywhere in chado** — not as a synonym of the aberration or of either balancer.
+- The balancers' own current names are `SM6a` / `Second Multiple 6a` and `SM6b` / `Second Multiple 6b`, none of which is wanted.
+
+So both target strings come from the ticket, and Task 3 constructs the two DTOs itself. Total: **24 flag-driven renames + 1 hard-coded = 25 renamed aberrations.**
+
+## File Structure
+
+- **Modify `src/allele_handlers.py`** — everything lands in `class AberrationHandler`: two class attributes, one synthesis method, one mapping method, and two call sites in the existing `synthesize_info()` / `map_fb_data_to_alliance()` hooks.
+- **Modify `src/AGR_data_retrieval_curation_allele.py`** — a curator TSV of the renames, plus a line in the `--help` epilog.
+- **Create `docs/FTA-237/verify_renames.py`** — offline harness for Tasks 1-3.
+- **Create `docs/FTA-237/expected_renames.sql`** — the SQL producing the table above (written and verified 2026-08-14), so a run's TSV can be diffed against chado. It is the oracle for `source=flag` rows, since the curator spreadsheet needs auth.
+
+---
+
+### Task 1: Parse the rename flags
+
+**Files:**
+- Modify: `src/allele_handlers.py` (class `AberrationHandler`: new `balancer_rename_regex` attribute beside the FTA-235/236 regexes; new `synthesize_balancer_rename_map()`; one call in `synthesize_info()`)
+- Create: `docs/FTA-237/verify_renames.py`
+- Create: `docs/FTA-237/expected_renames.sql`
+
+**Interfaces:**
+- Consumes: `self.fbba_entities` and `self._resolve_parent_feature_id()` from FTA-236 Task 1 (see "Relationship to FTA-236" — implement that task's Steps 3-6 first if they are not already present), `self.fb_data_entities`, `self.testing`, `self.log`.
+- Produces:
+  - `self.balancer_rename_map` — `{FBba feature_id: parent FBab feature_id}`, 24 entries.
+  - `self.balancer_rename_regex` — compiled pattern with named groups `symbol` and `fbab`.
+  - `BALANCER_RENAME_EXPECTED = 24` — module-level constant.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `docs/FTA-237/verify_renames.py`:
+
+```python
+"""Offline harness for the FTA-237 balancer rename methods.
+
+Extracts method source with ast and drives it with duck-typed stand-ins, since sqlalchemy and
+harvdev_utils cannot be imported on this machine (see docs/FTA-237/plan.md).
+"""
+
+import ast
+import re
+
+SRC = '/Users/ilongden/harvard/alliance-linkml-flybase/src/allele_handlers.py'
+
+tree = ast.parse(open(SRC).read())
+cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == 'AberrationHandler')
+
+
+
+class FakeNameSlotAnnotationDTO:
+    """Stand-in for agr_datatypes.NameSlotAnnotationDTO (Task 3's hard-coded path builds these)."""
+
+    def __init__(self, name_type_name, format_text, display_text, evidence_curies):
+        self.dto = {'name_type_name': name_type_name, 'format_text': format_text,
+                    'display_text': display_text, 'synonym_scope_name': 'exact',
+                    'evidence_curies': list(evidence_curies), 'internal': False, 'obsolete': False}
+
+    def dict_export(self):
+        return dict(self.dto)
+
+
+ns = {
+    're': re,
+    'sub_sup_sgml_to_html': lambda x: x,
+    'sub_sup_to_sgml': lambda x: x,
+    'agr_datatypes': type('agr_datatypes', (), {'NameSlotAnnotationDTO': FakeNameSlotAnnotationDTO}),
+}
+wanted_attrs = ('balancer_rename_regex', 'balancer_hardcoded_renames')
+for node in cls.body:
+    if isinstance(node, ast.Assign) and getattr(node.targets[0], 'id', '') in wanted_attrs:
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+# Later tasks add more methods; the guard below lets the harness run before they exist.
+for name in ('synthesize_balancer_rename_map', 'map_balancer_renames', 'drop_duplicate_synonyms',
+             'apply_rename', 'map_hardcoded_balancer_renames'):
+    node = next((n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == name), None)
+    if node is not None:
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+
+
+class FakeLog:
+    def __init__(self):
+        self.info_lines, self.warnings, self.errors = [], [], []
+
+    def info(self, msg):
+        self.info_lines.append(msg)
+
+    def debug(self, msg):
+        pass
+
+    def warning(self, msg):
+        self.warnings.append(msg)
+
+    def error(self, msg):
+        self.errors.append(msg)
+
+
+class FakeProp:
+    def __init__(self, value):
+        self.chado_obj = type('O', (), {'value': value})()
+
+
+def name_dto(name_type, text):
+    return {'name_type_name': name_type, 'format_text': text, 'display_text': text,
+            'synonym_scope_name': 'exact', 'internal': False, 'obsolete': False}
+
+
+class FakeDTO:
+    def __init__(self, symbol=None, full_name=None, synonyms=None):
+        self.allele_symbol_dto = symbol
+        self.allele_full_name_dto = full_name
+        self.allele_synonym_dtos = list(synonyms or [])
+
+
+class FakeEntity:
+    def __init__(self, feature_id, uniquename, name='', internal_notes=(), dto=None):
+        self.db_primary_id = feature_id
+        self.uniquename = uniquename
+        self.name = name
+        self.is_obsolete = False
+        self.props_by_type = {'internal_notes': [FakeProp(v) for v in internal_notes]} if internal_notes else {}
+        self.linkmldto = dto
+
+    def __str__(self):
+        return f'{self.name} ({self.uniquename})'
+
+
+class FakeHandler:
+    balancer_rename_regex = ns['balancer_rename_regex']
+    balancer_hardcoded_renames = ns.get('balancer_hardcoded_renames', {})
+    synthesize_balancer_rename_map = ns['synthesize_balancer_rename_map']
+    map_balancer_renames = ns.get('map_balancer_renames')
+    drop_duplicate_synonyms = ns.get('drop_duplicate_synonyms')
+    apply_rename = ns.get('apply_rename')
+    map_hardcoded_balancer_renames = ns.get('map_hardcoded_balancer_renames')
+
+    def __init__(self, aberrations, balancers, testing=False):
+        self.log = FakeLog()
+        self.testing = testing
+        self.fb_data_entities = {a.db_primary_id: a for a in aberrations}
+        self.fbba_entities = {b.db_primary_id: b for b in balancers}
+        self.balancer_rename_map = {}
+        self.balancer_rename_report = []
+
+    def _resolve_parent_feature_id(self, fbab_uniquename):
+        for aberration in self.fb_data_entities.values():
+            if aberration.uniquename == fbab_uniquename:
+                return aberration.db_primary_id
+        return None
+
+
+RENAME = 'FTA: Balancer - use balancer symbol and fullname for parent In(1)Basc (FBab0004219).'
+MERGE = 'FTA: Balancer - merge with parent In(1)Basc (FBab0004219).'
+MARK = "FTA: Balancer - mark this aberration as 'balancer'."
+RENAME_UNKNOWN = 'FTA: Balancer - use balancer symbol and fullname for parent Nope (FBab9999999).'
+
+results = []
+
+
+def check(name, condition):
+    results.append((name, condition))
+    print(f'  {"PASS" if condition else "FAIL"}: {name}')
+
+
+print('--- flag family discrimination ---')
+basc_parent = FakeEntity(1, 'FBab0004219', 'In(1)Basc')
+basc = FakeEntity(101, 'FBba0000014', 'Basc', [MERGE, RENAME])
+merge_only = FakeEntity(102, 'FBba0000039', 'SM6a', [MERGE])
+marker_only = FakeEntity(103, 'FBba0000999', 'X', [MARK])
+h = FakeHandler([basc_parent], [basc, merge_only, marker_only])
+h.synthesize_balancer_rename_map()
+check('rename flag mapped', h.balancer_rename_map == {101: 1})
+check('merge-only balancer not renamed', 102 not in h.balancer_rename_map)
+check('mark flag not treated as a rename', 103 not in h.balancer_rename_map)
+check('no errors', h.log.errors == [])
+
+print('--- unknown parent is an error ---')
+h = FakeHandler([basc_parent], [FakeEntity(104, 'FBba0000777', 'Y', [RENAME_UNKNOWN])])
+h.synthesize_balancer_rename_map()
+check('unknown parent not renamed', h.balancer_rename_map == {})
+check('error names the unknown parent', any('FBab9999999' in e for e in h.log.errors))
+
+print('--- count warning away from 24, suppressed in testing mode ---')
+check('count warning present', any('24' in w for w in h.log.warnings))
+h = FakeHandler([basc_parent], [FakeEntity(101, 'FBba0000014', 'Basc', [RENAME])], testing=True)
+h.synthesize_balancer_rename_map()
+check('no count warning in testing mode', not any('24' in w for w in h.log.warnings))
+
+print(f'\n{sum(1 for _, ok in results if ok)}/{len(results)} checks PASSED')
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `python3 docs/FTA-237/verify_renames.py`
+Expected: `KeyError: 'balancer_rename_regex'` — the attribute does not exist yet.
+
+- [ ] **Step 3: Add the constant and the regex**
+
+At module level in `src/allele_handlers.py`, beside `BALANCER_MERGE_EXPECTED` (add that too if FTA-236 Task 1 has not landed):
+
+```python
+BALANCER_RENAME_EXPECTED = 24    # FTA-237: curated rename flags in chado as of 2026-08-14.
+```
+
+In `class AberrationHandler`, below the FTA-236 attributes:
+
+```python
+    # FTA-237: this flag says the parent FBab should be exported under the balancer's current symbol
+    # and full name, e.g.
+    #   FTA: Balancer - use balancer symbol and fullname for parent In(1)Basc (FBab0004219).
+    # 24 of these exist, one per parent. As in FTA-235/236 the match runs through the instruction
+    # clause, since all three flag families open with "FTA: Balancer -".
+    balancer_rename_regex = re.compile(r'^\s*:?\s*FTA:\s*balancer\s*-\s*use balancer symbol and fullname for parent\s+(?P<symbol>.+?)\s*\((?P<fbab>FBab[0-9]+)\)\s*\.?\s*$',
+                                       re.IGNORECASE)
+```
+
+- [ ] **Step 4: Add the rename-map method**
+
+In the "Additional sub-methods to be run by synthesize_info()" area of `class AberrationHandler`:
+
+```python
+    def synthesize_balancer_rename_map(self):
+        """Map each rename-flagged FBba balancer to the parent FBab it renames (FTA-237)."""
+        self.log.info('Map rename-flagged FBba balancers to their parent FBab aberrations.')
+        flag_counter = 0
+        for balancer in self.fbba_entities.values():
+            for fb_prop in balancer.props_by_type.get('internal_notes', []):
+                prop_value = fb_prop.chado_obj.value
+                if not prop_value:
+                    continue
+                match = self.balancer_rename_regex.match(prop_value)
+                if match is None:
+                    continue
+                flag_counter += 1
+                fbab_uniquename = match.group('fbab')
+                parent_feature_id = self._resolve_parent_feature_id(fbab_uniquename)
+                if parent_feature_id is None:
+                    self.log.error(f'FTA-237: balancer {balancer} would rename parent {fbab_uniquename} '
+                                   f'("{match.group("symbol")}"), which is not an exportable aberration '
+                                   f'(obsolete or unknown). No rename applied; please fix the internal note.')
+                    break
+                self.balancer_rename_map[balancer.db_primary_id] = parent_feature_id
+                break
+        self.log.info(f'Found {flag_counter} balancer rename flags; resolved {len(self.balancer_rename_map)} renames.')
+        if self.testing is False and flag_counter != BALANCER_RENAME_EXPECTED:
+            self.log.warning(f'Expected {BALANCER_RENAME_EXPECTED} balancer rename flags per FTA-237, but found '
+                             f'{flag_counter}. Check the "internal_notes" flag text in chado.')
+        return
+```
+
+- [ ] **Step 5: Add the class attribute for the report and wire the call**
+
+Beside the other FTA-23x attributes:
+
+```python
+    balancer_rename_map = {}      # FTA-237: {FBba feature_id: parent FBab feature_id} for resolved rename flags.
+    balancer_rename_report = []   # FTA-237: dicts of old/new names per renamed aberration, for the curator TSV.
+```
+
+In `AberrationHandler.synthesize_info()`, immediately after `self.synthesize_balancer_merge_map()` if that exists, otherwise immediately after `super().synthesize_info()`:
+
+```python
+        self.synthesize_balancer_rename_map()
+```
+
+- [ ] **Step 6: Run the harness to verify it passes**
+
+Run: `python3 docs/FTA-237/verify_renames.py`
+Expected: `8/8 checks PASSED`
+
+- [ ] **Step 7: Compile check and line length**
+
+Run:
+```bash
+python3 -m py_compile src/allele_handlers.py && echo COMPILE OK
+awk 'length > 160 {print FILENAME": "FNR": "length}' src/allele_handlers.py
+grep -n ' $' src/allele_handlers.py
+```
+Expected: `COMPILE OK` and no other output.
+
+- [ ] **Step 8: Record the chado expectations**
+
+`docs/FTA-237/expected_renames.sql` is already written and was verified against production_chado on 2026-08-14 — every number in this plan came from it. Re-run it to confirm chado has not moved:
+
+```bash
+scp docs/FTA-237/expected_renames.sql flysql26:/tmp/
+ssh flysql26 "PGPASSWORD=ilongdenpgsql psql -h flysql24 -U ilongden -d production_chado -f /tmp/expected_renames.sql"
+```
+Expected: 24 rows matching the table; `SM6` present only as a non-current synonym; `Second Multiple 6` absent.
+
+- [ ] **Step 9: Commit (only when Ian asks)**
+
+```bash
+git add src/allele_handlers.py docs/FTA-237/plan.md docs/FTA-237/verify_renames.py docs/FTA-237/expected_renames.sql
+git commit -m "feat(FTA-237): map rename-flagged balancers to their parent aberrations"
+```
+
+---
+
+### Task 2: Apply the rename at the DTO level
+
+**Files:**
+- Modify: `src/allele_handlers.py` (class `AberrationHandler`: new `map_balancer_renames()`; one call in `map_fb_data_to_alliance()`)
+- Modify: `docs/FTA-237/verify_renames.py` (add the rename checks)
+
+**Interfaces:**
+- Consumes: `self.balancer_rename_map` from Task 1; `balancer.linkmldto.allele_symbol_dto` / `.allele_full_name_dto` — the nested `BalancerHandler` builds a full `AlleleDTO` per FBba (its `agr_export_type` is `AlleleDTO`, and `map_synonyms()` derives the same `allele_*` slot names), so these dicts already hold correct `format_text`, `display_text` and `evidence_curies`.
+- Produces: `map_balancer_renames()` — mutates each renamed parent's `linkmldto`; appends one dict per rename to `self.balancer_rename_report` with keys `fbab_id`, `fbba_id`, `new_symbol`, `old_symbol`, `new_full_name`, `old_full_name`, `source` (`'flag'` or `'hard-coded'`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `docs/FTA-237/verify_renames.py`:
+
+```python
+print('--- rename: balancer names take the slots, aberration names become synonyms ---')
+parent_dto = FakeDTO(
+    symbol=name_dto('nomenclature_symbol', 'In(1)FM3'),
+    full_name=name_dto('full_name', 'Inversion (1) First Multiple'),
+    synonyms=[name_dto('nomenclature_symbol', 'FM3'),        # grafted by FTA-236, must not duplicate
+              name_dto('nomenclature_symbol', 'dm-FM3')],
+)
+parent = FakeEntity(1, 'FBab0003926', 'In(1)FM3', dto=parent_dto)
+balancer_dto = FakeDTO(symbol=name_dto('nomenclature_symbol', 'FM3'),
+                       full_name=name_dto('full_name', 'First Multiple 3'))
+balancer = FakeEntity(101, 'FBba0000002', 'FM3', dto=balancer_dto)
+h = FakeHandler([parent], [balancer])
+h.balancer_rename_map = {101: 1}
+h.map_balancer_renames()
+
+check('parent symbol is now the balancer symbol', parent_dto.allele_symbol_dto['format_text'] == 'FM3')
+check('parent full name is now the balancer full name', parent_dto.allele_full_name_dto['format_text'] == 'First Multiple 3')
+syn_texts = [i['format_text'] for i in parent_dto.allele_synonym_dtos]
+check('old symbol kept as a synonym', 'In(1)FM3' in syn_texts)
+check('old full name kept as a synonym', 'Inversion (1) First Multiple' in syn_texts)
+check('promoted symbol removed from synonyms (no duplicate)', syn_texts.count('FM3') == 0)
+check('unrelated synonym untouched', 'dm-FM3' in syn_texts)
+check('old symbol synonym keeps its name type', next(i['name_type_name'] for i in parent_dto.allele_synonym_dtos
+                                                     if i['format_text'] == 'In(1)FM3') == 'nomenclature_symbol')
+check('slot dicts are copies, not aliases', parent_dto.allele_symbol_dto is not balancer_dto.allele_symbol_dto)
+row = h.balancer_rename_report[0]
+check('report captures both names', row['new_symbol'] == 'FM3' and row['old_symbol'] == 'In(1)FM3')
+check('report marks the source', row['source'] == 'flag')
+
+print('--- parent with no full name of its own (18 of the 24) ---')
+parent_dto2 = FakeDTO(symbol=name_dto('nomenclature_symbol', 'In(1)Basc'), full_name=None, synonyms=[])
+parent2 = FakeEntity(2, 'FBab0004219', 'In(1)Basc', dto=parent_dto2)
+balancer2 = FakeEntity(102, 'FBba0000014', 'Basc',
+                       dto=FakeDTO(symbol=name_dto('nomenclature_symbol', 'Basc'),
+                                   full_name=name_dto('full_name', 'Bar-apricot-scute')))
+h2 = FakeHandler([parent2], [balancer2])
+h2.balancer_rename_map = {102: 2}
+h2.map_balancer_renames()
+check('empty full name slot just gets filled', parent_dto2.allele_full_name_dto['format_text'] == 'Bar-apricot-scute')
+check('no phantom full-name synonym added', [i['format_text'] for i in parent_dto2.allele_synonym_dtos] == ['In(1)Basc'])
+check('report records an empty old full name', h2.balancer_rename_report[0]['old_full_name'] == '')
+
+print('--- a parent whose DTO was never built is skipped, not crashed on ---')
+parent3 = FakeEntity(3, 'FBab0005463', 'In(3LR)TM3', dto=None)
+h3 = FakeHandler([parent3], [FakeEntity(103, 'FBba0000047', 'TM3', dto=FakeDTO(symbol=name_dto('nomenclature_symbol', 'TM3')))])
+h3.balancer_rename_map = {103: 3}
+h3.map_balancer_renames()
+check('no DTO means no rename and no exception', h3.balancer_rename_report == [])
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `python3 docs/FTA-237/verify_renames.py`
+Expected: `TypeError: 'NoneType' object is not callable` from `h.map_balancer_renames()` — the harness sets `map_balancer_renames = ns.get(...)`, which is still `None`.
+
+- [ ] **Step 3: Write the method**
+
+```python
+    def map_balancer_renames(self):
+        """Export a rename-flagged aberration under its balancer's symbol and full name (FTA-237).
+
+        The nested BalancerHandler has already built a full AlleleDTO for every FBba, so the balancer's
+        allele_symbol_dto and allele_full_name_dto are correct - right display_text conversion, right
+        evidence curies - and are simply copied into the parent's slots. The aberration's own names
+        move to allele_synonym_dtos, as the ticket asks.
+
+        Must run after map_synonyms(), which is what populates the parent's name slots in the first
+        place. Any synonym matching a newly promoted name is dropped, so a name grafted by FTA-236
+        does not appear twice.
+        """
+        self.log.info('Rename flagged aberrations to use their balancer symbol and full name.')
+        NAME_SLOTS = (('allele_symbol_dto', 'symbol'), ('allele_full_name_dto', 'full_name'))
+        renamed = 0
+        for fbba_feature_id, fbab_feature_id in self.balancer_rename_map.items():
+            balancer = self.fbba_entities[fbba_feature_id]
+            aberration = self.fb_data_entities[fbab_feature_id]
+            if aberration.linkmldto is None:
+                self.log.warning(f'FTA-237: {aberration} has no LinkML object to rename; skipping.')
+                continue
+            report = {
+                'fbab_id': aberration.uniquename,
+                'fbba_id': balancer.uniquename,
+                'source': 'flag',
+                'new_symbol': '',
+                'old_symbol': '',
+                'new_full_name': '',
+                'old_full_name': '',
+            }
+            for slot_name, label in NAME_SLOTS:
+                new_dto = getattr(balancer.linkmldto, slot_name, None)
+                if new_dto is None:
+                    continue
+                old_dto = getattr(aberration.linkmldto, slot_name)
+                report[f'new_{label}'] = new_dto['format_text']
+                if old_dto is not None:
+                    report[f'old_{label}'] = old_dto['format_text']
+                    aberration.linkmldto.allele_synonym_dtos.append(old_dto)
+                # Copy, so later edits to either DTO cannot bleed into the other entity's export.
+                setattr(aberration.linkmldto, slot_name, dict(new_dto))
+                self.drop_duplicate_synonyms(aberration, new_dto)
+            self.balancer_rename_report.append(report)
+            renamed += 1
+            self.log.debug(f'FTA-237: renamed {aberration} to "{report["new_symbol"]}" '
+                           f'("{report["new_full_name"]}") after balancer {balancer}.')
+        self.log.info(f'Renamed {renamed} aberrations to their balancer symbol and full name.')
+        return
+
+    def drop_duplicate_synonyms(self, aberration, promoted_dto):
+        """Remove synonyms that duplicate a name just promoted into a name slot (FTA-237).
+
+        FTA-236 grafts the balancer's names onto the parent as synonyms; once one of them becomes the
+        parent's symbol or full name, the synonym entry is redundant. Matching is on name type plus
+        format_text, so a same-text synonym of a different type is left alone.
+        """
+        keep = []
+        for synonym_dto in aberration.linkmldto.allele_synonym_dtos:
+            is_duplicate = synonym_dto['format_text'] == promoted_dto['format_text']
+            if is_duplicate and synonym_dto['name_type_name'] == promoted_dto['name_type_name']:
+                continue
+            keep.append(synonym_dto)
+        aberration.linkmldto.allele_synonym_dtos = keep
+        return
+```
+
+- [ ] **Step 4: Wire it into `map_fb_data_to_alliance()`**
+
+In `AberrationHandler.map_fb_data_to_alliance()`, immediately **after** `self.map_synonyms()`:
+
+```python
+        self.map_balancer_renames()
+```
+
+- [ ] **Step 5: Run the harness to verify it passes**
+
+Run: `python3 docs/FTA-237/verify_renames.py`
+Expected: `22/22 checks PASSED` (8 from Task 1 plus 14 new)
+
+- [ ] **Step 6: Compile check and line length**
+
+Run:
+```bash
+python3 -m py_compile src/allele_handlers.py && echo COMPILE OK
+awk 'length > 160 {print FILENAME": "FNR": "length}' src/allele_handlers.py
+```
+Expected: `COMPILE OK` and no `awk` output.
+
+- [ ] **Step 7: Commit (only when Ian asks)**
+
+```bash
+git add src/allele_handlers.py docs/FTA-237/verify_renames.py
+git commit -m "feat(FTA-237): rename flagged aberrations to the balancer symbol and full name"
+```
+
+---
+
+### Task 3: The hard-coded SM6 rename
+
+**Files:**
+- Modify: `src/allele_handlers.py` (class `AberrationHandler`: new `balancer_hardcoded_renames` attribute; extend `map_balancer_renames()`)
+- Modify: `docs/FTA-237/verify_renames.py` (add the SM6 checks)
+
+**Interfaces:**
+- Consumes: `sub_sup_sgml_to_html` and `sub_sup_to_sgml` — **not currently imported by `src/allele_handlers.py`**, so add them to the `harvdev_utils.char_conversions` import list at the top of the module (`src/entity_handler.py:16` shows the same import, and `entity_handler.py:1280` the same fabrication idiom).
+- Produces: renames driven by `balancer_hardcoded_renames`, reported with `source = 'hard-coded'` and `fbba_id = 'n/a'`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `docs/FTA-237/verify_renames.py`:
+
+```python
+print('--- hard-coded SM6: names come from the ticket, not from chado ---')
+sm6_dto = FakeDTO(symbol=name_dto('nomenclature_symbol', 'In(2LR)SM6'), full_name=None,
+                  synonyms=[name_dto('nomenclature_symbol', 'SM6'),        # non-current synonym in chado
+                            name_dto('nomenclature_symbol', 'SM6a'),       # grafted by FTA-236
+                            name_dto('full_name', 'Second Multiple 6a')])  # grafted by FTA-236
+sm6_parent = FakeEntity(4, 'FBab0004818', 'In(2LR)SM6', dto=sm6_dto)
+h4 = FakeHandler([sm6_parent], [])
+h4.balancer_rename_map = {}
+h4.map_balancer_renames()
+
+check('SM6 symbol applied with no flag present', sm6_dto.allele_symbol_dto['format_text'] == 'SM6')
+check('SM6 full name fabricated', sm6_dto.allele_full_name_dto['format_text'] == 'Second Multiple 6')
+sm6_syns = [i['format_text'] for i in sm6_dto.allele_synonym_dtos]
+check('own symbol demoted to synonym', 'In(2LR)SM6' in sm6_syns)
+check('pre-existing SM6 synonym de-duplicated', sm6_syns.count('SM6') == 0)
+check('balancer names left as synonyms', 'SM6a' in sm6_syns and 'Second Multiple 6a' in sm6_syns)
+sm6_row = next(r for r in h4.balancer_rename_report if r['fbab_id'] == 'FBab0004818')
+check('report marks it hard-coded', sm6_row['source'] == 'hard-coded' and sm6_row['fbba_id'] == 'n/a')
+check('hard-coded rename has no evidence curies', sm6_dto.allele_symbol_dto['evidence_curies'] == [])
+
+print('--- a hard-coded target that is not in the export is reported, not applied ---')
+h5 = FakeHandler([], [])
+h5.balancer_rename_map = {}
+h5.map_balancer_renames()
+check('absent hard-coded parent logs an error', any('FBab0004818' in e for e in h5.log.errors))
+
+print(f'\n{sum(1 for _, ok in results if ok)}/{len(results)} checks PASSED')
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `python3 docs/FTA-237/verify_renames.py`
+Expected: FAIL on `SM6 symbol applied with no flag present` — with no rename flag and no hard-coded table, `map_balancer_renames()` does nothing for `FBab0004818`.
+
+- [ ] **Step 3: Add the import**
+
+At the top of `src/allele_handlers.py`, add the char-conversion helpers (the module currently imports none):
+
+```python
+from harvdev_utils.char_conversions import sub_sup_sgml_to_html, sub_sup_to_sgml
+```
+
+- [ ] **Step 4: Add the hard-coded table**
+
+In `class AberrationHandler`, beside the other FTA-237 attributes:
+
+```python
+    # FTA-237: one aberration is renamed without a curated flag. Per the ticket, In(2LR)SM6 takes the
+    # symbol "SM6" and full name "Second Multiple 6", because its two balancers SM6a (FBba0000039) and
+    # SM6b (FBba0000040) share it as a parent and neither of their names should win. Neither balancer
+    # carries a rename flag, so nothing in chado can drive this: "SM6" exists only as a non-current
+    # synonym of the aberration, and "Second Multiple 6" does not exist in chado at all. Keyed by FBab
+    # uniquename; the values are (symbol, full_name).
+    balancer_hardcoded_renames = {
+        'FBab0004818': ('SM6', 'Second Multiple 6'),
+    }
+```
+
+- [ ] **Step 5: Extend `map_balancer_renames()`**
+
+Refactor the per-slot work into a helper both paths share. `map_balancer_renames()` from Task 2 becomes exactly this — the slot loop is gone, replaced by an `apply_rename()` call, and the hard-coded table runs at the end so one call site in `map_fb_data_to_alliance()` still covers everything:
+
+```python
+    def map_balancer_renames(self):
+        """Export a rename-flagged aberration under its balancer's symbol and full name (FTA-237).
+
+        The nested BalancerHandler has already built a full AlleleDTO for every FBba, so the balancer's
+        allele_symbol_dto and allele_full_name_dto are correct - right display_text conversion, right
+        evidence curies - and are simply copied into the parent's slots. The aberration's own names
+        move to allele_synonym_dtos, as the ticket asks.
+
+        Must run after map_synonyms(), which is what populates the parent's name slots in the first
+        place. Any synonym matching a newly promoted name is dropped, so a name grafted by FTA-236
+        does not appear twice.
+        """
+        self.log.info('Rename flagged aberrations to use their balancer symbol and full name.')
+        renamed = 0
+        for fbba_feature_id, fbab_feature_id in self.balancer_rename_map.items():
+            balancer = self.fbba_entities[fbba_feature_id]
+            aberration = self.fb_data_entities[fbab_feature_id]
+            if aberration.linkmldto is None:
+                self.log.warning(f'FTA-237: {aberration} has no LinkML object to rename; skipping.')
+                continue
+            report = {
+                'fbab_id': aberration.uniquename,
+                'fbba_id': balancer.uniquename,
+                'source': 'flag',
+                'new_symbol': '',
+                'old_symbol': '',
+                'new_full_name': '',
+                'old_full_name': '',
+            }
+            new_dtos = {
+                'allele_symbol_dto': getattr(balancer.linkmldto, 'allele_symbol_dto', None),
+                'allele_full_name_dto': getattr(balancer.linkmldto, 'allele_full_name_dto', None),
+            }
+            self.apply_rename(aberration, new_dtos, report)
+            self.balancer_rename_report.append(report)
+            renamed += 1
+            self.log.debug(f'FTA-237: renamed {aberration} to "{report["new_symbol"]}" '
+                           f'("{report["new_full_name"]}") after balancer {balancer}.')
+        self.map_hardcoded_balancer_renames()
+        self.log.info(f'Renamed {renamed} aberrations from curated flags, plus '
+                      f'{len(self.balancer_rename_report) - renamed} hard-coded; '
+                      f'{len(self.balancer_rename_report)} in total.')
+        return
+```
+
+`drop_duplicate_synonyms()` from Task 2 is unchanged. Add the two new methods:
+
+```python
+    def apply_rename(self, aberration, new_dtos, report):
+        """Move an aberration's own names to synonyms and install the new ones (FTA-237).
+
+        Args:
+            aberration (FBAberration): the aberration being renamed.
+            new_dtos (dict): {slot_name: NameSlotAnnotationDTO dict or None} for the new names.
+            report (dict): the report row to fill in, mutated in place.
+
+        """
+        NAME_SLOT_LABELS = {'allele_symbol_dto': 'symbol', 'allele_full_name_dto': 'full_name'}
+        for slot_name, label in NAME_SLOT_LABELS.items():
+            new_dto = new_dtos.get(slot_name)
+            if new_dto is None:
+                continue
+            old_dto = getattr(aberration.linkmldto, slot_name)
+            report[f'new_{label}'] = new_dto['format_text']
+            if old_dto is not None:
+                report[f'old_{label}'] = old_dto['format_text']
+                aberration.linkmldto.allele_synonym_dtos.append(old_dto)
+            setattr(aberration.linkmldto, slot_name, dict(new_dto))
+            self.drop_duplicate_synonyms(aberration, new_dto)
+        return
+
+    def map_hardcoded_balancer_renames(self):
+        """Apply the FTA-237 renames that no curated flag can drive (currently only In(2LR)SM6)."""
+        for fbab_uniquename, names in self.balancer_hardcoded_renames.items():
+            new_symbol, new_full_name = names
+            parent_feature_id = self._resolve_parent_feature_id(fbab_uniquename)
+            if parent_feature_id is None:
+                self.log.error(f'FTA-237: hard-coded rename target {fbab_uniquename} ("{new_symbol}") is not an '
+                               f'exportable aberration; rename not applied.')
+                continue
+            aberration = self.fb_data_entities[parent_feature_id]
+            if aberration.linkmldto is None:
+                self.log.warning(f'FTA-237: {aberration} has no LinkML object to rename; skipping.')
+                continue
+            new_dtos = {
+                'allele_symbol_dto': agr_datatypes.NameSlotAnnotationDTO(
+                    'nomenclature_symbol', new_symbol, sub_sup_sgml_to_html(sub_sup_to_sgml(new_symbol)), []).dict_export(),
+                'allele_full_name_dto': agr_datatypes.NameSlotAnnotationDTO(
+                    'full_name', new_full_name, sub_sup_sgml_to_html(sub_sup_to_sgml(new_full_name)), []).dict_export(),
+            }
+            report = {
+                'fbab_id': aberration.uniquename,
+                'fbba_id': 'n/a',
+                'source': 'hard-coded',
+                'new_symbol': '',
+                'old_symbol': '',
+                'new_full_name': '',
+                'old_full_name': '',
+            }
+            self.apply_rename(aberration, new_dtos, report)
+            self.balancer_rename_report.append(report)
+            self.log.info(f'FTA-237: applied the hard-coded rename of {aberration} to '
+                          f'"{new_symbol}" ("{new_full_name}").')
+        return
+```
+
+No change is needed in `map_fb_data_to_alliance()` — the Task 2 call site now covers both paths, and the closing log line counts 24 + 1 = 25.
+
+- [ ] **Step 6: Run the harness to verify it passes**
+
+Run: `python3 docs/FTA-237/verify_renames.py`
+Expected: `30/30 checks PASSED` (22 from Tasks 1-2 plus 8 new)
+
+- [ ] **Step 7: Compile check and line length**
+
+Run:
+```bash
+python3 -m py_compile src/allele_handlers.py && echo COMPILE OK
+awk 'length > 160 {print FILENAME": "FNR": "length}' src/allele_handlers.py
+```
+Expected: `COMPILE OK` and no `awk` output.
+
+- [ ] **Step 8: Commit (only when Ian asks)**
+
+```bash
+git add src/allele_handlers.py docs/FTA-237/verify_renames.py
+git commit -m "feat(FTA-237): hard-code the In(2LR)SM6 rename to SM6 / Second Multiple 6"
+```
+
+---
+
+### Task 4: Curator TSV, docs, and full-run verification
+
+**Files:**
+- Modify: `src/AGR_data_retrieval_curation_allele.py` (TSV emission in `main()`; epilog note)
+- Create: `docs/FTA-237/verify_run.sh`
+
+**Interfaces:**
+- Consumes: `aberration_handler.balancer_rename_report`.
+- Produces: `<output>_balancer_renames.tsv` beside the other allele TSVs.
+
+- [ ] **Step 1: Emit the TSV**
+
+In `main()`, after the `write_notes_tsv(...)` call (and after FTA-236's merge TSV if that has landed):
+
+```python
+        # FTA-237: one row per renamed aberration, so curators can check the 24 flag-driven renames and
+        # the hard-coded In(2LR)SM6 case against their spreadsheet.
+        renames_filename = tsv_filename.replace('.tsv', '_balancer_renames.tsv')
+        curation_tsv.write_association_tsv(
+            filename=renames_filename,
+            rows=aberration_handler.balancer_rename_report,
+            first_field='fbab_id',
+            second_field='fbba_id',
+            extra_fields=[
+                ('source', 'source', ''),
+                ('new_symbol', 'new_symbol', ''),
+                ('old_symbol', 'old_symbol', ''),
+                ('new_full_name', 'new_full_name', ''),
+                ('old_full_name', 'old_full_name', ''),
+            ],
+        )
+        log.info(f'Generated TSV: {renames_filename} ({len(aberration_handler.balancer_rename_report)} renames)')
+```
+
+- [ ] **Step 2: Document it in the epilog**
+
+Add to the `Environment variables:` epilog, after the existing entries (it is behaviour rather than a variable, so keep it in its own short paragraph):
+
+```
+Notes:
+  FTA-237: 24 aberrations are exported under their balancer's symbol and full name, driven by curated
+  "FTA: Balancer - use balancer symbol and fullname for parent ..." internal notes, plus In(2LR)SM6
+  (FBab0004818), which is renamed to "SM6" / "Second Multiple 6" from a hard-coded table because no
+  flag exists for it. The aberration's own names are kept as synonyms. Not gated: the slots involved
+  are long-released. See the *_balancer_renames.tsv output for the full list.
+```
+
+- [ ] **Step 3: Compile check both files**
+
+Run:
+```bash
+python3 -m py_compile src/allele_handlers.py src/AGR_data_retrieval_curation_allele.py && echo COMPILE OK
+awk 'length > 160 {print FILENAME": "FNR": "length}' src/allele_handlers.py src/AGR_data_retrieval_curation_allele.py
+```
+Expected: `COMPILE OK` and no `awk` output.
+
+- [ ] **Step 4: Write the run-verification script**
+
+Create `docs/FTA-237/verify_run.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Usage: verify_run.sh /data/alliance/PERSISTENT_main_FTA-237_balancer_rename   (run on flysql26)
+set -euo pipefail
+DIR="$1"
+LOG=$(ls "$DIR"/allele_curation_*.log)
+TSV=$(ls "$DIR"/allele_curation_*.tsv | grep -v -e _notes -e _renames -e _merges -e _failures)
+RENAMES=$(ls "$DIR"/*_balancer_renames.tsv)
+echo '--- rename tallies from the log (expect 24 flags, 25 renamed) ---'
+grep -E 'balancer rename flags|Renamed .* aberrations to their balancer|hard-coded rename of' "$LOG"
+echo '--- errors and rename warnings (expect none) ---'
+grep -c ' ERROR ' "$LOG" || true
+grep -E 'many current symbols|many current full_names' "$LOG" | wc -l
+echo '--- rename TSV row count (expect 25) ---'
+tail -n +2 "$RENAMES" | wc -l
+echo '--- the worked example: In(1)Basc must export as Basc / Bar-apricot-scute ---'
+grep -m1 'FBab0004219' "$TSV"
+echo '--- the SM6 case: symbol SM6, full name Second Multiple 6, source hard-coded ---'
+grep 'FBab0004818' "$RENAMES"
+grep -m1 'FBab0004818' "$TSV"
+echo '--- every renamed aberration must keep its old symbol as a synonym ---'
+awk -F'\t' 'NR>1 {print $1"\t"$4"\t"$5}' "$RENAMES" | while IFS=$'\t' read -r fbab new old; do
+  grep -m1 "^$fbab" "$TSV" | grep -q "$old" || echo "MISSING old symbol synonym: $fbab ($old)"
+done
+echo '--- done ---'
+```
+
+- [ ] **Step 5: Ask Ian to run the export, then verify**
+
+The run cannot happen on this machine. Ask Ian for an allele run against `production_chado` into `PERSISTENT_main_FTA-237_balancer_rename`, then:
+
+```bash
+ssh flysql26 "bash -s" < docs/FTA-237/verify_run.sh /data/alliance/PERSISTENT_main_FTA-237_balancer_rename
+```
+
+Expected: 24 rename flags, 25 renamed aberrations, 25 TSV rows, 0 errors, **0** `many current symbols` / `many current full_names` lines, `FB:FBab0004219` exporting as `Basc`, `FB:FBab0004818` as `SM6`, and no `MISSING old symbol synonym` lines.
+
+- [ ] **Step 6: Diff the whole rename list against chado**
+
+```bash
+ssh flysql26 "PGPASSWORD=ilongdenpgsql psql -h flysql24 -U ilongden -d production_chado -f /tmp/expected_renames.sql" > /tmp/chado_renames.txt
+# compare the 24 flag-driven rows (new_symbol, new_full_name per FBab) with the TSV's source=flag rows
+```
+Expected: the 24 flag rows match `docs/FTA-237/expected_renames.sql` exactly; the only `source=hard-coded` row is `FBab0004818`.
+
+- [ ] **Step 7: Commit (only when Ian asks)**
+
+```bash
+git add src/AGR_data_retrieval_curation_allele.py docs/FTA-237/verify_run.sh
+git commit -m "feat(FTA-237): curator TSV of balancer renames, plus docs"
+```
+
+---
+
+## Interaction checks to run once both tickets are implemented
+
+If FTA-236 lands too, re-run its harness and this one, then check on a combined run:
+
+- No aberration logs `many current symbols` or `many current full_names`. FTA-236 demotes all grafted balancer names; FTA-237 then promotes exactly two per renamed parent.
+- For the 14 merge-only balancers (merge-flagged but not rename-flagged), the parent keeps its own symbol and full name, with the balancer's as synonyms.
+- For the 24 renamed parents, `allele_synonym_dtos` contains the aberration's old symbol **and** the balancer's other synonyms, with no entry duplicating the promoted names.
+- `FBab0004818` shows one FTA-237 row (`source=hard-coded`) and two FTA-236 merge rows (SM6a and SM6b), with `carries_excluded` non-zero for both and `carries_alleles` zero.
+
+## Deferred, with reasons
+
+- **Symbol collisions at the Alliance** — renaming `In(2LR)CyO` to `CyO` could collide with another MOD's or another FlyBase entity's symbol. Out of scope: the ticket specifies the names, and FlyBase does not police Alliance-side uniqueness here.
+- **The curator spreadsheet as an automated oracle** — the "expected final submission data" Google Sheet needs auth to fetch, so `expected_renames.sql` is the machine-checkable oracle instead. If a discrepancy shows up, compare against the sheet by hand.

--- a/docs/FTA-237/plan.md
+++ b/docs/FTA-237/plan.md
@@ -286,9 +286,15 @@ In `class AberrationHandler`, below the FTA-236 attributes:
     #   FTA: Balancer - use balancer symbol and fullname for parent In(1)Basc (FBab0004219).
     # 24 of these exist, one per parent. As in FTA-235/236 the match runs through the instruction
     # clause, since all three flag families open with "FTA: Balancer -".
-    balancer_rename_regex = re.compile(r'^\s*:?\s*FTA:\s*balancer\s*-\s*use balancer symbol and fullname for parent\s+(?P<symbol>.+?)\s*\((?P<fbab>FBab[0-9]+)\)\s*\.?\s*$',
-                                       re.IGNORECASE)
+    balancer_rename_regex = re.compile(
+        r'^\s*:?\s*FTA:\s*balancer\s*-\s*use balancer symbol and fullname for parent'
+        r'\s+(?P<symbol>.+?)\s*\((?P<fbab>FBab[0-9]+)\)\s*\.?\s*$',
+        re.IGNORECASE)
 ```
+
+(The pattern is split with implicit string concatenation because a single line runs to 172 characters,
+over the 160-char `.flake8` limit. Concatenation avoids the W503/W504 trap that a boolean-operator
+break would hit.)
 
 - [ ] **Step 4: Add the rename-map method**
 
@@ -762,7 +768,16 @@ git commit -m "feat(FTA-237): hard-code the In(2LR)SM6 rename to SM6 / Second Mu
 - Consumes: `aberration_handler.balancer_rename_report`.
 - Produces: `<output>_balancer_renames.tsv` beside the other allele TSVs.
 
-- [ ] **Step 1: Emit the TSV**
+- [ ] **Step 1: Check the writer's required keys**
+
+Run: `grep -n "def write_association_tsv" -A 35 src/curation_tsv.py`
+
+It reads `entity_dict['relation_name']` **unconditionally** — a report row without that key raises
+`KeyError`. Reuse the writer anyway (no new writer is warranted), supplying a constant relation and
+blanking the evidence sentinel, since a rename carries no evidence of its own. The same applies to
+FTA-236's merge TSV.
+
+- [ ] **Step 3: Emit the TSV**
 
 In `main()`, after the `write_notes_tsv(...)` call (and after FTA-236's merge TSV if that has landed):
 
@@ -772,7 +787,7 @@ In `main()`, after the `write_notes_tsv(...)` call (and after FTA-236's merge TS
         renames_filename = tsv_filename.replace('.tsv', '_balancer_renames.tsv')
         curation_tsv.write_association_tsv(
             filename=renames_filename,
-            rows=aberration_handler.balancer_rename_report,
+            rows=[dict(row, relation_name='renamed_after_balancer') for row in aberration_handler.balancer_rename_report],
             first_field='fbab_id',
             second_field='fbba_id',
             extra_fields=[
@@ -782,6 +797,7 @@ In `main()`, after the `write_notes_tsv(...)` call (and after FTA-236's merge TS
                 ('new_full_name', 'new_full_name', ''),
                 ('old_full_name', 'old_full_name', ''),
             ],
+            no_pubs_sentinel='',
         )
         log.info(f'Generated TSV: {renames_filename} ({len(aberration_handler.balancer_rename_report)} renames)')
 ```
@@ -799,7 +815,7 @@ Notes:
   are long-released. See the *_balancer_renames.tsv output for the full list.
 ```
 
-- [ ] **Step 3: Compile check both files**
+- [ ] **Step 4: Compile check both files**
 
 Run:
 ```bash
@@ -808,7 +824,7 @@ awk 'length > 160 {print FILENAME": "FNR": "length}' src/allele_handlers.py src/
 ```
 Expected: `COMPILE OK` and no `awk` output.
 
-- [ ] **Step 4: Write the run-verification script**
+- [ ] **Step 5: Write the run-verification script**
 
 Create `docs/FTA-237/verify_run.sh`:
 
@@ -839,7 +855,7 @@ done
 echo '--- done ---'
 ```
 
-- [ ] **Step 5: Ask Ian to run the export, then verify**
+- [ ] **Step 6: Ask Ian to run the export, then verify**
 
 The run cannot happen on this machine. Ask Ian for an allele run against `production_chado` into `PERSISTENT_main_FTA-237_balancer_rename`, then:
 
@@ -849,7 +865,7 @@ ssh flysql26 "bash -s" < docs/FTA-237/verify_run.sh /data/alliance/PERSISTENT_ma
 
 Expected: 24 rename flags, 25 renamed aberrations, 25 TSV rows, 0 errors, **0** `many current symbols` / `many current full_names` lines, `FB:FBab0004219` exporting as `Basc`, `FB:FBab0004818` as `SM6`, and no `MISSING old symbol synonym` lines.
 
-- [ ] **Step 6: Diff the whole rename list against chado**
+- [ ] **Step 7: Diff the whole rename list against chado**
 
 ```bash
 ssh flysql26 "PGPASSWORD=ilongdenpgsql psql -h flysql24 -U ilongden -d production_chado -f /tmp/expected_renames.sql" > /tmp/chado_renames.txt
@@ -857,7 +873,7 @@ ssh flysql26 "PGPASSWORD=ilongdenpgsql psql -h flysql24 -U ilongden -d productio
 ```
 Expected: the 24 flag rows match `docs/FTA-237/expected_renames.sql` exactly; the only `source=hard-coded` row is `FBab0004818`.
 
-- [ ] **Step 7: Commit (only when Ian asks)**
+- [ ] **Step 8: Commit (only when Ian asks)**
 
 ```bash
 git add src/AGR_data_retrieval_curation_allele.py docs/FTA-237/verify_run.sh

--- a/docs/FTA-237/verify_renames.py
+++ b/docs/FTA-237/verify_renames.py
@@ -19,11 +19,13 @@ class FakeNameSlotAnnotationDTO:
     """Stand-in for agr_datatypes.NameSlotAnnotationDTO (Task 3's hard-coded path builds these)."""
 
     def __init__(self, name_type_name, format_text, display_text, evidence_curies):
+        """Build the stand-in with the same four positional args as the real DTO."""
         self.dto = {'name_type_name': name_type_name, 'format_text': format_text,
                     'display_text': display_text, 'synonym_scope_name': 'exact',
                     'evidence_curies': list(evidence_curies), 'internal': False, 'obsolete': False}
 
     def dict_export(self):
+        """Return the DTO as a plain dict, as the real class does."""
         return dict(self.dto)
 
 
@@ -51,24 +53,34 @@ for node in tree.body:
 
 
 class FakeLog:
+    """Collects log calls by level, so the checks can assert on what was reported."""
+
     def __init__(self):
+        """Start with empty lists for each level the handler methods use."""
         self.info_lines, self.warnings, self.errors = [], [], []
 
     def info(self, msg):
+        """Record an info line."""
         self.info_lines.append(msg)
 
     def debug(self, msg):
+        """Discard debug output; the checks never assert on it."""
         pass
 
     def warning(self, msg):
+        """Record a warning."""
         self.warnings.append(msg)
 
     def error(self, msg):
+        """Record an error."""
         self.errors.append(msg)
 
 
 class FakeProp:
+    """Stand-in for an FBProp: only .chado_obj.value is read by the code under test."""
+
     def __init__(self, value):
+        """Wrap a featureprop value the way FBProp exposes it."""
         self.chado_obj = type('O', (), {'value': value})()
 
 
@@ -78,14 +90,20 @@ def name_dto(name_type, text):
 
 
 class FakeDTO:
+    """Stand-in for AlleleDTO, holding just the three name slots the rename touches."""
+
     def __init__(self, symbol=None, full_name=None, synonyms=None):
+        """Set the symbol and full-name slots, and copy the synonym list."""
         self.allele_symbol_dto = symbol
         self.allele_full_name_dto = full_name
         self.allele_synonym_dtos = list(synonyms or [])
 
 
 class FakeEntity:
+    """Stand-in for an FBAberration or FBBalancer entity."""
+
     def __init__(self, feature_id, uniquename, name='', internal_notes=(), dto=None):
+        """Build an entity with optional internal_notes props and an optional LinkML DTO."""
         self.db_primary_id = feature_id
         self.uniquename = uniquename
         self.name = name
@@ -94,10 +112,13 @@ class FakeEntity:
         self.linkmldto = dto
 
     def __str__(self):
+        """Match FBDataEntity's "name (uniquename)" form, which log messages rely on."""
         return f'{self.name} ({self.uniquename})'
 
 
 class FakeHandler:
+    """Minimal AberrationHandler: the real methods, bound to duck-typed state."""
+
     balancer_rename_regex = ns['balancer_rename_regex']
     balancer_hardcoded_renames = ns.get('balancer_hardcoded_renames', {})
     synthesize_balancer_rename_map = ns['synthesize_balancer_rename_map']
@@ -107,6 +128,7 @@ class FakeHandler:
     map_hardcoded_balancer_renames = ns.get('map_hardcoded_balancer_renames')
 
     def __init__(self, aberrations, balancers, testing=False):
+        """Key the given aberrations and balancers by feature_id, as the handler does."""
         self.log = FakeLog()
         self.testing = testing
         self.fb_data_entities = {a.db_primary_id: a for a in aberrations}
@@ -115,6 +137,7 @@ class FakeHandler:
         self.balancer_rename_report = []
 
     def _resolve_parent_feature_id(self, fbab_uniquename):
+        """Mirror the real helper: find an exportable parent by uniquename, else None."""
         for aberration in self.fb_data_entities.values():
             if aberration.uniquename == fbab_uniquename:
                 return aberration.db_primary_id

--- a/docs/FTA-237/verify_renames.py
+++ b/docs/FTA-237/verify_renames.py
@@ -1,0 +1,236 @@
+"""Offline harness for the FTA-237 balancer rename methods.
+
+Extracts method source with ast and drives it with duck-typed stand-ins, since sqlalchemy and
+harvdev_utils cannot be imported on this machine (see docs/FTA-237/plan.md).
+
+Run: python3 docs/FTA-237/verify_renames.py
+"""
+
+import ast
+import re
+
+SRC = '/Users/ilongden/harvard/alliance-linkml-flybase/src/allele_handlers.py'
+
+tree = ast.parse(open(SRC).read())
+cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == 'AberrationHandler')
+
+
+class FakeNameSlotAnnotationDTO:
+    """Stand-in for agr_datatypes.NameSlotAnnotationDTO (Task 3's hard-coded path builds these)."""
+
+    def __init__(self, name_type_name, format_text, display_text, evidence_curies):
+        self.dto = {'name_type_name': name_type_name, 'format_text': format_text,
+                    'display_text': display_text, 'synonym_scope_name': 'exact',
+                    'evidence_curies': list(evidence_curies), 'internal': False, 'obsolete': False}
+
+    def dict_export(self):
+        return dict(self.dto)
+
+
+ns = {
+    're': re,
+    'sub_sup_sgml_to_html': lambda x: x,
+    'sub_sup_to_sgml': lambda x: x,
+    'agr_datatypes': type('agr_datatypes', (), {'NameSlotAnnotationDTO': FakeNameSlotAnnotationDTO}),
+}
+wanted_attrs = ('balancer_rename_regex', 'balancer_hardcoded_renames')
+for node in cls.body:
+    if isinstance(node, ast.Assign) and getattr(node.targets[0], 'id', '') in wanted_attrs:
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+# Later tasks add more methods; the guard below lets the harness run before they exist.
+for name in ('synthesize_balancer_rename_map', 'map_balancer_renames', 'drop_duplicate_synonyms',
+             'apply_rename', 'map_hardcoded_balancer_renames'):
+    node = next((n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == name), None)
+    if node is not None:
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+
+# The module-level expected count is read by synthesize_balancer_rename_map().
+for node in tree.body:
+    if isinstance(node, ast.Assign) and getattr(node.targets[0], 'id', '') == 'BALANCER_RENAME_EXPECTED':
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SRC, 'exec'), ns)
+
+
+class FakeLog:
+    def __init__(self):
+        self.info_lines, self.warnings, self.errors = [], [], []
+
+    def info(self, msg):
+        self.info_lines.append(msg)
+
+    def debug(self, msg):
+        pass
+
+    def warning(self, msg):
+        self.warnings.append(msg)
+
+    def error(self, msg):
+        self.errors.append(msg)
+
+
+class FakeProp:
+    def __init__(self, value):
+        self.chado_obj = type('O', (), {'value': value})()
+
+
+def name_dto(name_type, text):
+    return {'name_type_name': name_type, 'format_text': text, 'display_text': text,
+            'synonym_scope_name': 'exact', 'evidence_curies': [], 'internal': False, 'obsolete': False}
+
+
+class FakeDTO:
+    def __init__(self, symbol=None, full_name=None, synonyms=None):
+        self.allele_symbol_dto = symbol
+        self.allele_full_name_dto = full_name
+        self.allele_synonym_dtos = list(synonyms or [])
+
+
+class FakeEntity:
+    def __init__(self, feature_id, uniquename, name='', internal_notes=(), dto=None):
+        self.db_primary_id = feature_id
+        self.uniquename = uniquename
+        self.name = name
+        self.is_obsolete = False
+        self.props_by_type = {'internal_notes': [FakeProp(v) for v in internal_notes]} if internal_notes else {}
+        self.linkmldto = dto
+
+    def __str__(self):
+        return f'{self.name} ({self.uniquename})'
+
+
+class FakeHandler:
+    balancer_rename_regex = ns['balancer_rename_regex']
+    balancer_hardcoded_renames = ns.get('balancer_hardcoded_renames', {})
+    synthesize_balancer_rename_map = ns['synthesize_balancer_rename_map']
+    map_balancer_renames = ns.get('map_balancer_renames')
+    drop_duplicate_synonyms = ns.get('drop_duplicate_synonyms')
+    apply_rename = ns.get('apply_rename')
+    map_hardcoded_balancer_renames = ns.get('map_hardcoded_balancer_renames')
+
+    def __init__(self, aberrations, balancers, testing=False):
+        self.log = FakeLog()
+        self.testing = testing
+        self.fb_data_entities = {a.db_primary_id: a for a in aberrations}
+        self.fbba_entities = {b.db_primary_id: b for b in balancers}
+        self.balancer_rename_map = {}
+        self.balancer_rename_report = []
+
+    def _resolve_parent_feature_id(self, fbab_uniquename):
+        for aberration in self.fb_data_entities.values():
+            if aberration.uniquename == fbab_uniquename:
+                return aberration.db_primary_id
+        return None
+
+
+RENAME = 'FTA: Balancer - use balancer symbol and fullname for parent In(1)Basc (FBab0004219).'
+MERGE = 'FTA: Balancer - merge with parent In(1)Basc (FBab0004219).'
+MARK = "FTA: Balancer - mark this aberration as 'balancer'."
+RENAME_UNKNOWN = 'FTA: Balancer - use balancer symbol and fullname for parent Nope (FBab9999999).'
+
+results = []
+
+
+def check(name, condition):
+    results.append((name, condition))
+    print(f'  {"PASS" if condition else "FAIL"}: {name}')
+
+
+print('--- flag family discrimination ---')
+basc_parent = FakeEntity(1, 'FBab0004219', 'In(1)Basc')
+basc = FakeEntity(101, 'FBba0000014', 'Basc', [MERGE, RENAME])
+merge_only = FakeEntity(102, 'FBba0000039', 'SM6a', [MERGE])
+marker_only = FakeEntity(103, 'FBba0000999', 'X', [MARK])
+h = FakeHandler([basc_parent], [basc, merge_only, marker_only])
+h.synthesize_balancer_rename_map()
+check('rename flag mapped', h.balancer_rename_map == {101: 1})
+check('merge-only balancer not renamed', 102 not in h.balancer_rename_map)
+check('mark flag not treated as a rename', 103 not in h.balancer_rename_map)
+check('no errors', h.log.errors == [])
+
+print('--- unknown parent is an error ---')
+h = FakeHandler([basc_parent], [FakeEntity(104, 'FBba0000777', 'Y', [RENAME_UNKNOWN])])
+h.synthesize_balancer_rename_map()
+check('unknown parent not renamed', h.balancer_rename_map == {})
+check('error names the unknown parent', any('FBab9999999' in e for e in h.log.errors))
+
+print('--- count warning away from 24, suppressed in testing mode ---')
+check('count warning present', any('24' in w for w in h.log.warnings))
+h = FakeHandler([basc_parent], [FakeEntity(101, 'FBba0000014', 'Basc', [RENAME])], testing=True)
+h.synthesize_balancer_rename_map()
+check('no count warning in testing mode', not any('24' in w for w in h.log.warnings))
+
+print('--- rename: balancer names take the slots, aberration names become synonyms ---')
+parent_dto = FakeDTO(
+    symbol=name_dto('nomenclature_symbol', 'In(1)FM3'),
+    full_name=name_dto('full_name', 'Inversion (1) First Multiple'),
+    synonyms=[name_dto('nomenclature_symbol', 'FM3'),        # grafted by FTA-236, must not duplicate
+              name_dto('nomenclature_symbol', 'dm-FM3')],
+)
+parent = FakeEntity(1, 'FBab0003926', 'In(1)FM3', dto=parent_dto)
+balancer_dto = FakeDTO(symbol=name_dto('nomenclature_symbol', 'FM3'),
+                       full_name=name_dto('full_name', 'First Multiple 3'))
+balancer = FakeEntity(101, 'FBba0000002', 'FM3', dto=balancer_dto)
+h = FakeHandler([parent], [balancer])
+h.balancer_rename_map = {101: 1}
+h.map_balancer_renames()
+
+check('parent symbol is now the balancer symbol', parent_dto.allele_symbol_dto['format_text'] == 'FM3')
+check('parent full name is now the balancer full name', parent_dto.allele_full_name_dto['format_text'] == 'First Multiple 3')
+syn_texts = [i['format_text'] for i in parent_dto.allele_synonym_dtos]
+check('old symbol kept as a synonym', 'In(1)FM3' in syn_texts)
+check('old full name kept as a synonym', 'Inversion (1) First Multiple' in syn_texts)
+check('promoted symbol removed from synonyms (no duplicate)', syn_texts.count('FM3') == 0)
+check('unrelated synonym untouched', 'dm-FM3' in syn_texts)
+check('old symbol synonym keeps its name type', next(i['name_type_name'] for i in parent_dto.allele_synonym_dtos
+                                                     if i['format_text'] == 'In(1)FM3') == 'nomenclature_symbol')
+check('slot dicts are copies, not aliases', parent_dto.allele_symbol_dto is not balancer_dto.allele_symbol_dto)
+row = h.balancer_rename_report[0]
+check('report captures both names', row['new_symbol'] == 'FM3' and row['old_symbol'] == 'In(1)FM3')
+check('report marks the source', row['source'] == 'flag')
+
+print('--- parent with no full name of its own (18 of the 24) ---')
+parent_dto2 = FakeDTO(symbol=name_dto('nomenclature_symbol', 'In(1)Basc'), full_name=None, synonyms=[])
+parent2 = FakeEntity(2, 'FBab0004219', 'In(1)Basc', dto=parent_dto2)
+balancer2 = FakeEntity(102, 'FBba0000014', 'Basc',
+                       dto=FakeDTO(symbol=name_dto('nomenclature_symbol', 'Basc'),
+                                   full_name=name_dto('full_name', 'Bar-apricot-scute')))
+h2 = FakeHandler([parent2], [balancer2])
+h2.balancer_rename_map = {102: 2}
+h2.map_balancer_renames()
+check('empty full name slot just gets filled', parent_dto2.allele_full_name_dto['format_text'] == 'Bar-apricot-scute')
+check('no phantom full-name synonym added', [i['format_text'] for i in parent_dto2.allele_synonym_dtos] == ['In(1)Basc'])
+check('report records an empty old full name', h2.balancer_rename_report[0]['old_full_name'] == '')
+
+print('--- a parent whose DTO was never built is skipped, not crashed on ---')
+parent3 = FakeEntity(3, 'FBab0005463', 'In(3LR)TM3', dto=None)
+h3 = FakeHandler([parent3], [FakeEntity(103, 'FBba0000047', 'TM3', dto=FakeDTO(symbol=name_dto('nomenclature_symbol', 'TM3')))])
+h3.balancer_rename_map = {103: 3}
+h3.map_balancer_renames()
+check('no DTO means no rename and no exception', h3.balancer_rename_report == [])
+
+print('--- hard-coded SM6: names come from the ticket, not from chado ---')
+sm6_dto = FakeDTO(symbol=name_dto('nomenclature_symbol', 'In(2LR)SM6'), full_name=None,
+                  synonyms=[name_dto('nomenclature_symbol', 'SM6'),        # non-current synonym in chado
+                            name_dto('nomenclature_symbol', 'SM6a'),       # grafted by FTA-236
+                            name_dto('full_name', 'Second Multiple 6a')])  # grafted by FTA-236
+sm6_parent = FakeEntity(4, 'FBab0004818', 'In(2LR)SM6', dto=sm6_dto)
+h4 = FakeHandler([sm6_parent], [])
+h4.balancer_rename_map = {}
+h4.map_balancer_renames()
+
+check('SM6 symbol applied with no flag present', sm6_dto.allele_symbol_dto['format_text'] == 'SM6')
+check('SM6 full name fabricated', sm6_dto.allele_full_name_dto['format_text'] == 'Second Multiple 6')
+sm6_syns = [i['format_text'] for i in sm6_dto.allele_synonym_dtos]
+check('own symbol demoted to synonym', 'In(2LR)SM6' in sm6_syns)
+check('pre-existing SM6 synonym de-duplicated', sm6_syns.count('SM6') == 0)
+check('balancer names left as synonyms', 'SM6a' in sm6_syns and 'Second Multiple 6a' in sm6_syns)
+sm6_row = next(r for r in h4.balancer_rename_report if r['fbab_id'] == 'FBab0004818')
+check('report marks it hard-coded', sm6_row['source'] == 'hard-coded' and sm6_row['fbba_id'] == 'n/a')
+check('hard-coded rename has no evidence curies', sm6_dto.allele_symbol_dto['evidence_curies'] == [])
+
+print('--- a hard-coded target that is not in the export is reported, not applied ---')
+h5 = FakeHandler([], [])
+h5.balancer_rename_map = {}
+h5.map_balancer_renames()
+check('absent hard-coded parent logs an error', any('FBab0004818' in e for e in h5.log.errors))
+
+print(f'\n{sum(1 for _, ok in results if ok)}/{len(results)} checks PASSED')

--- a/docs/FTA-237/verify_run.sh
+++ b/docs/FTA-237/verify_run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# FTA-237 run verification.
+# Usage (on flysql26): verify_run.sh /data/alliance/PERSISTENT_main_FTA-237_balancer_rename
+# Or from a laptop:    ssh flysql26 "bash -s" < docs/FTA-237/verify_run.sh <rundir>
+set -euo pipefail
+DIR="${1:?usage: verify_run.sh <run directory>}"
+LOG=$(ls "$DIR"/allele_curation_*.log)
+TSV=$(ls "$DIR"/allele_curation_*.tsv | grep -v -e _notes -e _renames -e _merges -e _failures)
+RENAMES=$(ls "$DIR"/*_balancer_renames.tsv)
+
+echo '--- rename tallies from the log (expect 24 flags, 24 + 1 hard-coded = 25) ---'
+grep -E 'balancer rename flags|Renamed .* aberrations from curated flags|hard-coded rename of' "$LOG"
+
+echo '--- FBba retrieval (the nested BalancerHandler must have run) ---'
+grep -E 'obtained [0-9]+ FBba balancers' "$LOG"
+
+echo '--- errors (expect 0) ---'
+grep -c ' ERROR ' "$LOG" || true
+grep ' ERROR ' "$LOG" || true
+
+echo '--- name-collision warnings (expect 0 of each) ---'
+echo -n 'many current symbols: '
+grep -c 'many current symbols' "$LOG" || true
+echo -n 'many current full_names: '
+grep -c 'many current full_names' "$LOG" || true
+
+echo '--- rename TSV row count (expect 25) ---'
+tail -n +2 "$RENAMES" | wc -l
+
+echo '--- exactly one hard-coded row, and it must be FBab0004818 ---'
+awk -F'\t' 'NR>1 && $5=="hard-coded" {print}' "$RENAMES"
+
+echo '--- worked example: In(1)Basc exports as Basc / Bar-apricot-scute ---'
+grep -m1 'FB:FBab0004219' "$TSV"
+
+echo '--- SM6 case: symbol SM6 in the primary TSV ---'
+grep -m1 'FB:FBab0004818' "$TSV"
+
+echo '--- every renamed aberration keeps its old symbol as a synonym ---'
+missing=0
+while IFS=$'\t' read -r fbab old; do
+  line=$(grep -m1 "^FB:$fbab" "$TSV" || true)
+  if [ -z "$line" ]; then
+    echo "NOT IN PRIMARY TSV: $fbab"
+    missing=$((missing + 1))
+  elif ! printf '%s' "$line" | grep -qF "$old"; then
+    echo "MISSING old symbol synonym: $fbab ($old)"
+    missing=$((missing + 1))
+  fi
+done < <(awk -F'\t' 'NR>1 {print $1"\t"$7}' "$RENAMES" | sed 's/^FB://')
+echo "old-symbol synonym problems: $missing"
+
+echo '--- new symbol must be the exported symbol, not just a synonym ---'
+while IFS=$'\t' read -r fbab new; do
+  symbol=$(grep -m1 "^FB:$fbab" "$TSV" | cut -f2)
+  [ "$symbol" = "$new" ] || echo "SYMBOL MISMATCH: $fbab exported as '$symbol', expected '$new'"
+done < <(awk -F'\t' 'NR>1 {print $1"\t"$6}' "$RENAMES" | sed 's/^FB://')
+
+echo '--- done ---'

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -96,14 +96,23 @@ Environment variables:
   DATABASE                  Database name (e.g. production_chado)
   ADD_OBSOLETE              Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
   ADD_ALLELE_ALLELE_ASSOC   Set to 'YES' to emit the FTA-218 'allele_allele_association_ingest_set' (aberration
-                            'carries'/'breakpoint_allele' relations). Off by default: the Alliance schema has no
-                            such ingest set and lacks the two CV terms, so the data cannot yet be loaded.
+                            'carries'/'breakpoint_allele' relations, plus the FTA-236 alleles and insertions
+                            carried by a balancer and moved to its parent aberration). Off by default: the
+                            Alliance schema has no such ingest set and lacks the two CV terms, so the data
+                            cannot yet be loaded.
   ADD_IS_ABERRATION         Set to 'YES' to emit the 'is_aberration' boolean for FBab entities, and the
                             'is_balancer' boolean for those FBab entities flagged as balancers (FTA-235).
                             Both slots come from the same schema PR (#327), so one gate covers them.
                             Requires a LinkML release containing the slots (absent from v2.17.0).
 
 Notes:
+  FTA-236: the 38 FBba balancers carrying a "FTA: Balancer - merge with parent ..." internal note have
+  their synonyms, secondary IDs, comments, internal notes and references folded into the parent FBab
+  aberration. Those parts are NOT gated (the slots are long-released); only the carried alleles and
+  insertions wait on ADD_ALLELE_ALLELE_ASSOC. Three balancers are excluded from the 'carries' move by
+  curator decision: FM1 (FBba0000011), SM6a (FBba0000039) and SM6b (FBba0000040). See the
+  *_balancer_merges.tsv output for what moved.
+
   FTA-237: 24 aberrations are exported under their balancer's symbol and full name, driven by curated
   "FTA: Balancer - use balancer symbol and fullname for parent ..." internal notes, plus In(2LR)SM6
   (FBab0004818), which is renamed to "SM6" / "Second Multiple 6" from a hard-coded table because no
@@ -188,6 +197,30 @@ def main():
         curation_tsv.write_notes_tsv(
             filename=tsv_filename.replace('.tsv', '_notes.tsv'), entities=entities,
         )
+        # FTA-236: one row per FBba balancer merged into a parent FBab aberration, so curators can check
+        # what moved. Written unconditionally; the 'carries' counts stay 0 unless ADD_ALLELE_ALLELE_ASSOC
+        # is 'YES', since that gate controls the association export. write_association_tsv() needs a
+        # 'relation_name' cell, hence the constant, and the evidence sentinel is blanked because a merge
+        # carries no evidence of its own.
+        merges_filename = tsv_filename.replace('.tsv', '_balancer_merges.tsv')
+        curation_tsv.write_association_tsv(
+            filename=merges_filename,
+            rows=[dict(row, relation_name='merged_from_balancer') for row in aberration_handler.balancer_merge_report],
+            first_field='fbab_id',
+            second_field='fbba_id',
+            extra_fields=[
+                ('fbba_symbol', 'fbba_symbol', ''),
+                ('synonyms', 'synonyms', 0),
+                ('secondary_ids', 'secondary_ids', 0),
+                ('comments', 'comments', 0),
+                ('internal_notes', 'internal_notes', 0),
+                ('references', 'references', 0),
+                ('carries_alleles', 'carries_alleles', 0),
+                ('carries_excluded', 'carries_excluded', 0),
+            ],
+            no_pubs_sentinel='',
+        )
+        log.info(f'Generated TSV: {merges_filename} ({len(aberration_handler.balancer_merge_report)} balancer merges)')
         # FTA-237: one row per renamed aberration, so curators can check the 24 flag-driven renames and
         # the hard-coded In(2LR)SM6 case against their spreadsheet. write_association_tsv() is reused
         # rather than adding another writer; it needs a 'relation_name' cell, hence the constant below,

--- a/src/AGR_data_retrieval_curation_allele.py
+++ b/src/AGR_data_retrieval_curation_allele.py
@@ -102,6 +102,13 @@ Environment variables:
                             'is_balancer' boolean for those FBab entities flagged as balancers (FTA-235).
                             Both slots come from the same schema PR (#327), so one gate covers them.
                             Requires a LinkML release containing the slots (absent from v2.17.0).
+
+Notes:
+  FTA-237: 24 aberrations are exported under their balancer's symbol and full name, driven by curated
+  "FTA: Balancer - use balancer symbol and fullname for parent ..." internal notes, plus In(2LR)SM6
+  (FBab0004818), which is renamed to "SM6" / "Second Multiple 6" from a hard-coded table because no
+  flag exists for it. The aberration's own names are kept as synonyms. Not gated: the slots involved
+  are long-released. See the *_balancer_renames.tsv output for the full list.
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
@@ -181,6 +188,26 @@ def main():
         curation_tsv.write_notes_tsv(
             filename=tsv_filename.replace('.tsv', '_notes.tsv'), entities=entities,
         )
+        # FTA-237: one row per renamed aberration, so curators can check the 24 flag-driven renames and
+        # the hard-coded In(2LR)SM6 case against their spreadsheet. write_association_tsv() is reused
+        # rather than adding another writer; it needs a 'relation_name' cell, hence the constant below,
+        # and no_pubs_sentinel is blanked because a rename carries no evidence of its own.
+        renames_filename = tsv_filename.replace('.tsv', '_balancer_renames.tsv')
+        curation_tsv.write_association_tsv(
+            filename=renames_filename,
+            rows=[dict(row, relation_name='renamed_after_balancer') for row in aberration_handler.balancer_rename_report],
+            first_field='fbab_id',
+            second_field='fbba_id',
+            extra_fields=[
+                ('source', 'source', ''),
+                ('new_symbol', 'new_symbol', ''),
+                ('old_symbol', 'old_symbol', ''),
+                ('new_full_name', 'new_full_name', ''),
+                ('old_full_name', 'old_full_name', ''),
+            ],
+            no_pubs_sentinel='',
+        )
+        log.info(f'Generated TSV: {renames_filename} ({len(aberration_handler.balancer_rename_report)} renames)')
         # FTA-221: diagnostic TSV of note props whose text could not be cleaned (NULL, blank, or bad
         # SGML), so curators can find and fix the offending rows. Mirrors the construct/cassette
         # scripts. Combined across both handlers, since each collects its own failures.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -26,6 +26,7 @@ from harvdev_utils.reporting import (
 )
 from utils import export_chado_data
 
+BALANCER_MERGE_EXPECTED = 38     # FTA-236: curated "merge with parent" flags in chado as of 2026-08-14.
 BALANCER_RENAME_EXPECTED = 24    # FTA-237: curated "use balancer symbol and fullname" flags in chado as of 2026-08-14.
 
 
@@ -1239,6 +1240,26 @@ class AberrationHandler(MetaAlleleHandler):
     balancer_flag_regex = re.compile(r'^\s*:?\s*FTA:\s*balancer\s*-\s*mark this aberration as\b', re.IGNORECASE)
     balancer_flag_expected_count = 37    # Per FTA-235; a mismatch means the flag text or the curation record changed.
 
+    # FTA-236: the merge flag on an FBba balancer names its parent FBab aberration, e.g.
+    #   FTA: Balancer - merge with parent In(1)Basc (FBab0004219).
+    # 38 of these exist, naming 37 parents (In(2LR)SM6 takes both SM6a and SM6b). The instruction
+    # clause is part of the match because the FTA-237 rename flag opens the same way.
+    balancer_merge_regex = re.compile(
+        r'^\s*:?\s*FTA:\s*balancer\s*-\s*merge with parent'
+        r'\s+(?P<symbol>.+?)\s*\((?P<fbab>FBab[0-9]+)\)\s*\.?\s*$',
+        re.IGNORECASE)
+    # FTA-236: 'carries alleles' must NOT move for these balancers (curator decision, reasons not given).
+    balancer_carries_exclusions = {
+        'FBba0000011',    # FM1 -> In(1)FM1 (FBab0010486); 15 alleles held back.
+        'FBba0000039',    # SM6a -> In(2LR)SM6 (FBab0004818); 20 alleles held back.
+        'FBba0000040',    # SM6b -> In(2LR)SM6 (FBab0004818); 18 alleles held back.
+    }
+    # FTA-236: only these FBba prop types move to the parent aberration. A blanket props_by_type merge
+    # (as add_fbal_to_fbti does) would also carry 'availability' and 'derived_stock*' props, which
+    # map_extinction_info() reads to set is_extinct - a balancer's stock status is not the
+    # aberration's. The Alliance note type for each comes from aberration_prop_to_note_mapping.
+    balancer_graft_prop_types = ('misc', 'internal_notes')
+
     # FTA-237: this flag says the parent FBab should be exported under the balancer's current symbol
     # and full name, e.g.
     #   FTA: Balancer - use balancer symbol and fullname for parent In(1)Basc (FBab0004219).
@@ -1267,6 +1288,8 @@ class AberrationHandler(MetaAlleleHandler):
     cassette_ignore_list = set()         # FTA-218: FBal feature_ids that are construct cassettes, and so are never exported as alleles.
     balancer_ids = set()                 # FTA-235: FB curies of FBab aberrations flagged as balancers; filled regardless of the export gate.
     fbba_entities = {}                   # FTA-236/237: feature_id-keyed FBBalancer objects from the nested BalancerHandler.
+    balancer_merge_map = {}              # FTA-236: {FBba feature_id: parent FBab feature_id} for resolved merge flags.
+    balancer_merge_report = []            # FTA-236: dicts of what moved per balancer, for the curator TSV.
     balancer_rename_map = {}             # FTA-237: {FBba feature_id: parent FBab feature_id} for resolved rename flags.
     balancer_rename_report = []          # FTA-237: dicts of old/new names per renamed aberration, for the curator TSV.
 
@@ -1349,6 +1372,8 @@ class AberrationHandler(MetaAlleleHandler):
         # FTA-218: aberration-allele associations need FBal and FBti features in the feature_lookup, both so that
         # get_entity_relationships() can bucket relationships by related feature type, and so that the map step can
         # look up partner uniquenames. Gated so that production runs make no extra queries until the Alliance is ready.
+        # FTA-236 relies on the same lookup: the alleles and insertions a balancer carries are moved to its parent
+        # aberration as "carries" associations, and map_aberration_allele_associations() resolves those partners here.
         if getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES':
             self.build_feature_lookup(session, feature_types=['gene', 'allele', 'insertion'])
             self.cassette_ignore_list = self.get_cassette_allele_ids(session)
@@ -1591,6 +1616,8 @@ class AberrationHandler(MetaAlleleHandler):
         super().synthesize_info()
         self.flag_new_additions_and_obsoletes()
         self.adjust_aberration_organism()
+        self.synthesize_balancer_merge_map()
+        self.merge_balancers_into_aberrations()
         self.synthesize_balancer_rename_map()
         self.synthesize_secondary_ids()
         self.synthesize_synonyms()
@@ -1602,6 +1629,9 @@ class AberrationHandler(MetaAlleleHandler):
         # "carries"/"breakpoint_allele" CV terms.
         if getenv('ADD_ALLELE_ALLELE_ASSOC', None) == 'YES':
             self.synthesize_aberration_allele_associations()
+            # FTA-236: the alleles and insertions a flagged balancer carries become "carries"
+            # associations of its parent aberration, so they join the same gated ingest set.
+            self.synthesize_balancer_carries_associations()
         else:
             self.log.info('ADD_ALLELE_ALLELE_ASSOC not set to "YES"; skipping aberration-allele association synthesis.')
         self.qc_aberration_mutation_types()
@@ -1681,17 +1711,169 @@ class AberrationHandler(MetaAlleleHandler):
         return
 
     def _resolve_parent_feature_id(self, fbab_uniquename):
-        """Return the feature_id of an exportable parent FBab, or None (FTA-237).
+        """Return the feature_id of an exportable parent FBab, or None (FTA-236/237).
 
-        Only aberrations in self.fb_data_entities can be renamed: that dict holds the current,
-        non-obsolete FBab features this handler exports. An obsolete or unrecognised ID gets no
-        fallback on purpose. All 24 FTA-237 parents are current, so this never fires for the rename
-        flags; it exists so that a future curation change is reported rather than silently redirected.
+        Only aberrations in self.fb_data_entities can receive merged data or be renamed: that dict
+        holds the current, non-obsolete FBab features this handler exports. An obsolete or unrecognised
+        ID gets no fallback, by curator decision - Steven chose this over resolving stale IDs through
+        feature_dbxref (FTA-236 comment 43813, 2026-08-14), so that a note pointing at the wrong place
+        is reported rather than silently redirected. Do not add a secondary-ID fallback here.
+
+        All 24 FTA-237 rename parents are current. One FTA-236 merge flag, on AM1 (FBba0000688), names
+        the obsolete FBab0007127; a curation record loading the week of 2026-08-17 corrects it to
+        FBab0049550, so until then that one balancer is reported and skipped.
         """
         for aberration in self.fb_data_entities.values():
             if aberration.uniquename == fbab_uniquename:
                 return aberration.db_primary_id
         return None
+
+    def synthesize_balancer_merge_map(self):
+        """Map each merge-flagged FBba balancer to its parent FBab aberration (FTA-236)."""
+        self.log.info('Map flagged FBba balancers to their parent FBab aberrations.')
+        flag_counter = 0
+        for balancer in self.fbba_entities.values():
+            for fb_prop in balancer.props_by_type.get('internal_notes', []):
+                prop_value = fb_prop.chado_obj.value
+                if not prop_value:
+                    continue
+                match = self.balancer_merge_regex.match(prop_value)
+                if match is None:
+                    continue
+                flag_counter += 1
+                fbab_uniquename = match.group('fbab')
+                parent_feature_id = self._resolve_parent_feature_id(fbab_uniquename)
+                if parent_feature_id is None:
+                    self.log.error(f'FTA-236: balancer {balancer} names parent {fbab_uniquename} '
+                                   f'("{match.group("symbol")}"), which is not an exportable aberration '
+                                   f'(obsolete or unknown). No data merged; please fix the internal note.')
+                    break
+                self.balancer_merge_map[balancer.db_primary_id] = parent_feature_id
+                self.log.debug(f'FTA-236: {balancer} merges into {self.fb_data_entities[parent_feature_id]}.')
+                break
+        parents = set(self.balancer_merge_map.values())
+        self.log.info(f'Found {flag_counter} balancer merge flags; resolved {len(self.balancer_merge_map)} '
+                      f'balancers onto {len(parents)} parent aberrations.')
+        if self.testing is False and flag_counter != BALANCER_MERGE_EXPECTED:
+            self.log.warning(f'Expected {BALANCER_MERGE_EXPECTED} balancer merge flags per FTA-236, but found '
+                             f'{flag_counter}. Check the "internal_notes" flag text in chado.')
+        return
+
+    def add_fbba_to_fbab(self, balancer, aberration):
+        """Graft one FBba balancer's data onto its parent FBab aberration (FTA-236).
+
+        Follows add_fbal_to_fbti(): extend the parent's source-data lists before synthesize_* runs, so
+        every existing mapping method produces the merged output unchanged. Only whitelisted prop types
+        move (see balancer_graft_prop_types), and relationships are handled separately by
+        synthesize_balancer_carries_associations() so they cannot reach aberration-gene synthesis.
+        """
+        report = {
+            'fbba_id': balancer.uniquename,
+            'fbba_symbol': balancer.name,
+            'fbab_id': aberration.uniquename,
+            'synonyms': len(balancer.synonyms),
+            'secondary_ids': 1 + len(balancer.fb_sec_dbxrefs),
+            'comments': len(balancer.props_by_type.get('misc', [])),
+            'internal_notes': len(balancer.props_by_type.get('internal_notes', [])),
+            'references': len(balancer.pub_associations),
+            'carries_alleles': 0,
+            'carries_excluded': 0,
+        }
+        # Names. Per the ticket, the balancer's symbols and full names become synonyms of the parent;
+        # neither may rival the parent's own. merged_synonym_ids covers symbols (a rival current symbol
+        # makes map_synonyms() pick one arbitrarily and log "Found many current symbols");
+        # demoted_synonym_ids also covers full names, where a rival is worse - map_synonyms() sets no
+        # allele_full_name_dto at all and the aberration's own full name vanishes from the export.
+        # FTA-237 deliberately renames 24 of these aberrations to the balancer symbol/full name; it
+        # does that by setting the slots in map_balancer_renames(), not by skipping this demotion.
+        aberration.synonyms.extend(balancer.synonyms)
+        balancer_synonym_ids = [i.synonym_id for i in balancer.synonyms]
+        aberration.merged_synonym_ids.update(balancer_synonym_ids)
+        aberration.demoted_synonym_ids.update(balancer_synonym_ids)
+        # Identifiers: the balancer's current ID plus any of its own secondary IDs.
+        aberration.alt_fb_ids.append(f'FB:{balancer.uniquename}')
+        aberration.fb_sec_dbxrefs.extend(balancer.fb_sec_dbxrefs)
+        # Notes (whitelisted prop types only).
+        for prop_type in self.balancer_graft_prop_types:
+            balancer_props = balancer.props_by_type.get(prop_type, [])
+            if not balancer_props:
+                continue
+            try:
+                aberration.props_by_type[prop_type].extend(balancer_props)
+            except KeyError:
+                aberration.props_by_type[prop_type] = list(balancer_props)
+        # References: synthesize_pubs() reads pub_associations, so graft before it runs.
+        aberration.pub_associations.extend(balancer.pub_associations)
+        self.balancer_merge_report.append(report)
+        return report
+
+    def merge_balancers_into_aberrations(self):
+        """Graft every flagged FBba balancer onto its parent FBab aberration (FTA-236)."""
+        self.log.info('Merge flagged FBba balancer data into parent FBab aberrations.')
+        totals = {'synonyms': 0, 'secondary_ids': 0, 'comments': 0, 'internal_notes': 0, 'references': 0}
+        for fbba_feature_id, fbab_feature_id in self.balancer_merge_map.items():
+            balancer = self.fbba_entities[fbba_feature_id]
+            aberration = self.fb_data_entities[fbab_feature_id]
+            report = self.add_fbba_to_fbab(balancer, aberration)
+            for key in totals.keys():
+                totals[key] += report[key]
+        parents = set(self.balancer_merge_map.values())
+        self.log.info(f'Merged {len(self.balancer_merge_map)} balancers into {len(parents)} aberrations.')
+        for key in sorted(totals.keys()):
+            self.log.info(f'Moved {totals[key]} {key} from balancers to aberrations.')
+        return
+
+    def synthesize_balancer_carries_associations(self):
+        """Move a flagged balancer's carried alleles and insertions onto its parent (FTA-236).
+
+        In chado the two sources are:
+            1. type="carried_on",      subject=FBal, object=FBba (proforma AB5b) -> "carries"
+            2. type="associated_with", subject=FBba, object=FBti (proforma AB5a) -> "carries"
+        Both become Alliance "carries" associations from the parent FBab to the partner, so the keys
+        built here match synthesize_aberration_allele_associations() exactly and the existing
+        map_aberration_allele_associations() emits them with no changes.
+
+        These relationships are deliberately NOT grafted onto the parent entity: the parent's own
+        relationships also drive aberration-GENE association synthesis, and a balancer's links would
+        show up there as phantom gene associations.
+
+        Gated with the rest of the allele-allele associations (FTA-218): the Alliance has no
+        "allele_allele_association_ingest_set" yet.
+        """
+        self.log.info('Move balancer carried alleles and insertions onto parent aberrations.')
+        rel_specs = [
+            ('object', 'carried_on', self.feature_subtypes['allele'], 'AB5b'),
+            ('subject', 'associated_with', self.feature_subtypes['insertion'], 'AB5a'),
+        ]
+        partner_attr = {'subject': 'object_id', 'object': 'subject_id'}
+        moved = 0
+        excluded = 0
+        for fbba_feature_id, fbab_feature_id in self.balancer_merge_map.items():
+            balancer = self.fbba_entities[fbba_feature_id]
+            report_rows = [i for i in self.balancer_merge_report if i['fbba_id'] == balancer.uniquename]
+            is_excluded = balancer.uniquename in self.balancer_carries_exclusions
+            for entity_role, fb_rel_type, rel_entity_types, proforma_field in rel_specs:
+                relevant_rels = balancer.recall_relationships(self.log, entity_role=entity_role, rel_types=fb_rel_type,
+                                                              rel_entity_types=rel_entity_types)
+                for feat_rel in relevant_rels:
+                    partner_id = getattr(feat_rel.chado_obj, partner_attr[entity_role])
+                    if is_excluded:
+                        excluded += 1
+                        for row in report_rows:
+                            row['carries_excluded'] += 1
+                        continue
+                    rel_key = (fbab_feature_id, partner_id, 'carries')
+                    try:
+                        self.aberration_allele_rels[rel_key].append(feat_rel)
+                    except KeyError:
+                        self.aberration_allele_rels[rel_key] = [feat_rel]
+                        moved += 1
+                        for row in report_rows:
+                            row['carries_alleles'] += 1
+        self.log.info(f'Moved {moved} balancer "carries" associations onto parent aberrations.')
+        self.log.info(f'Held back {excluded} associations for the {len(self.balancer_carries_exclusions)} '
+                      f'balancers excluded by FTA-236.')
+        return
 
     def synthesize_balancer_rename_map(self):
         """Map each rename-flagged FBba balancer to the parent FBab it renames (FTA-237)."""

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -1711,21 +1711,29 @@ class AberrationHandler(MetaAlleleHandler):
         return
 
     def _resolve_parent_feature_id(self, fbab_uniquename):
-        """Return the feature_id of an exportable parent FBab, or None (FTA-236/237).
+        """Return the feature_id of a current parent FBab, or None (FTA-236/237).
 
-        Only aberrations in self.fb_data_entities can receive merged data or be renamed: that dict
-        holds the current, non-obsolete FBab features this handler exports. An obsolete or unrecognised
-        ID gets no fallback, by curator decision - Steven chose this over resolving stale IDs through
-        feature_dbxref (FTA-236 comment 43813, 2026-08-14), so that a note pointing at the wrong place
-        is reported rather than silently redirected. Do not add a secondary-ID fallback here.
+        NB - self.fb_data_entities holds obsolete aberrations as well as current ones: they are
+        exported as internal/obsolete rather than dropped. So membership of that dict is NOT enough,
+        and is_obsolete has to be checked explicitly. The 2026-08-14 run proved it: AM1 (FBba0000688)
+        named the obsolete FBab0007127, and without this check its data merged into that obsolete
+        entry instead of being reported.
 
-        All 24 FTA-237 rename parents are current. One FTA-236 merge flag, on AM1 (FBba0000688), names
-        the obsolete FBab0007127; a curation record loading the week of 2026-08-17 corrects it to
-        FBab0049550, so until then that one balancer is reported and skipped.
+        An obsolete or unrecognised ID gets no fallback, by curator decision - Steven chose this over
+        resolving stale IDs through feature_dbxref (FTA-236 comment 43813, 2026-08-14), so that a note
+        pointing at the wrong place is reported rather than silently redirected. Do not add a
+        secondary-ID fallback here.
+
+        All 24 FTA-237 rename parents are current. The one FTA-236 merge flag naming an obsolete
+        parent is AM1's; a curation record loading the week of 2026-08-17 corrects it to FBab0049550,
+        so until then that balancer is reported and skipped.
         """
         for aberration in self.fb_data_entities.values():
-            if aberration.uniquename == fbab_uniquename:
-                return aberration.db_primary_id
+            if aberration.uniquename != fbab_uniquename:
+                continue
+            if aberration.is_obsolete is True:
+                return None
+            return aberration.db_primary_id
         return None
 
     def synthesize_balancer_merge_map(self):
@@ -1839,6 +1847,13 @@ class AberrationHandler(MetaAlleleHandler):
 
         Gated with the rest of the allele-allele associations (FTA-218): the Alliance has no
         "allele_allele_association_ingest_set" yet.
+
+        NB - the partner type is checked against this handler's own feature_lookup rather than passed
+        to recall_relationships() as rel_entity_types. The nested BalancerHandler never calls
+        build_feature_lookup(), so get_entity_relationships() cannot fill its by-related-feature-type
+        buckets and that filter silently matches nothing - which is exactly what the 2026-08-14 run
+        showed, moving 0 associations while the relationships were plainly there. The lookup used here
+        is the one FTA-218 already builds under the same gate.
         """
         self.log.info('Move balancer carried alleles and insertions onto parent aberrations.')
         rel_specs = [
@@ -1848,15 +1863,27 @@ class AberrationHandler(MetaAlleleHandler):
         partner_attr = {'subject': 'object_id', 'object': 'subject_id'}
         moved = 0
         excluded = 0
+        skipped_unknown = 0
+        cassette_skipped = 0
         for fbba_feature_id, fbab_feature_id in self.balancer_merge_map.items():
             balancer = self.fbba_entities[fbba_feature_id]
             report_rows = [i for i in self.balancer_merge_report if i['fbba_id'] == balancer.uniquename]
             is_excluded = balancer.uniquename in self.balancer_carries_exclusions
             for entity_role, fb_rel_type, rel_entity_types, proforma_field in rel_specs:
-                relevant_rels = balancer.recall_relationships(self.log, entity_role=entity_role, rel_types=fb_rel_type,
-                                                              rel_entity_types=rel_entity_types)
+                relevant_rels = balancer.recall_relationships(self.log, entity_role=entity_role, rel_types=fb_rel_type)
                 for feat_rel in relevant_rels:
                     partner_id = getattr(feat_rel.chado_obj, partner_attr[entity_role])
+                    partner = self.feature_lookup.get(partner_id)
+                    if partner is None or partner['type'] not in rel_entity_types:
+                        skipped_unknown += 1
+                        continue
+                    # Cassette FBal features are never exported as alleles, so an association pointing
+                    # at one would dangle at the Alliance. Mirrors the FTA-218 check.
+                    if partner_id in self.cassette_ignore_list:
+                        self.log.warning(f'FTA-236: cassette FBal carried by balancer {balancer}, please check the '
+                                         f'data: {partner["name"]} ({partner["uniquename"]}) [proforma {proforma_field}]')
+                        cassette_skipped += 1
+                        continue
                     if is_excluded:
                         excluded += 1
                         for row in report_rows:
@@ -1873,6 +1900,10 @@ class AberrationHandler(MetaAlleleHandler):
         self.log.info(f'Moved {moved} balancer "carries" associations onto parent aberrations.')
         self.log.info(f'Held back {excluded} associations for the {len(self.balancer_carries_exclusions)} '
                       f'balancers excluded by FTA-236.')
+        self.log.info(f'Skipped {skipped_unknown} balancer relationships whose partner is not an exportable '
+                      f'allele or insertion.')
+        if cassette_skipped:
+            self.log.warning(f'Skipped {cassette_skipped} balancer relationships pointing at a cassette FBal feature.')
         return
 
     def synthesize_balancer_rename_map(self):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -28,6 +28,13 @@ from utils import export_chado_data
 
 BALANCER_MERGE_EXPECTED = 38     # FTA-236: curated "merge with parent" flags in chado as of 2026-08-14.
 BALANCER_RENAME_EXPECTED = 24    # FTA-237: curated "use balancer symbol and fullname" flags in chado as of 2026-08-14.
+# FTA-236: chado synonym types NOT grafted from a balancer onto its parent aberration. Steven's
+# decision (FTA-236 comment, 2026-08-19): exclude "nickname" from the balancer export. Filtering is
+# on the chado type deliberately - synthesize_synonyms() maps both "nickname" and "synonym" to the
+# LinkML name type "unspecified", so filtering on that would also drop every ordinary chado synonym
+# (162,999 rows against 482 nicknames). Whether nicknames should go from the export generally is
+# FTA-244; this constant is scoped to the graft only.
+BALANCER_EXCLUDED_SYNONYM_TYPES = ('nickname',)
 
 
 class MetaAlleleHandler(FeatureHandler):
@@ -1774,12 +1781,20 @@ class AberrationHandler(MetaAlleleHandler):
         every existing mapping method produces the merged output unchanged. Only whitelisted prop types
         move (see balancer_graft_prop_types), and relationships are handled separately by
         synthesize_balancer_carries_associations() so they cannot reach aberration-gene synthesis.
+
+        Synonyms of a chado type in BALANCER_EXCLUDED_SYNONYM_TYPES ("nickname") are not grafted, per
+        Steven's decision on FTA-236. That also removes two artifacts seen in UAT: a synonym identical
+        to the aberration's newly promoted symbol (Basc, TM3) and the duplicate SM6a/SM6b pair, which
+        arose because chado holds those names as both a nickname and a symbol. The "synonyms" count in
+        the merge report counts what is actually grafted, so it no longer includes skipped nicknames.
         """
+        grafted_synonyms = [s for s in balancer.synonyms
+                            if s.synonym.type.name not in BALANCER_EXCLUDED_SYNONYM_TYPES]
         report = {
             'fbba_id': balancer.uniquename,
             'fbba_symbol': balancer.name,
             'fbab_id': aberration.uniquename,
-            'synonyms': len(balancer.synonyms),
+            'synonyms': len(grafted_synonyms),
             'secondary_ids': 1 + len(balancer.fb_sec_dbxrefs),
             'comments': len(balancer.props_by_type.get('misc', [])),
             'internal_notes': len(balancer.props_by_type.get('internal_notes', [])),
@@ -1794,8 +1809,8 @@ class AberrationHandler(MetaAlleleHandler):
         # allele_full_name_dto at all and the aberration's own full name vanishes from the export.
         # FTA-237 deliberately renames 24 of these aberrations to the balancer symbol/full name; it
         # does that by setting the slots in map_balancer_renames(), not by skipping this demotion.
-        aberration.synonyms.extend(balancer.synonyms)
-        balancer_synonym_ids = [i.synonym_id for i in balancer.synonyms]
+        aberration.synonyms.extend(grafted_synonyms)
+        balancer_synonym_ids = [i.synonym_id for i in grafted_synonyms]
         aberration.merged_synonym_ids.update(balancer_synonym_ids)
         aberration.demoted_synonym_ids.update(balancer_synonym_ids)
         # Identifiers: the balancer's current ID plus any of its own secondary IDs.

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -19,11 +19,14 @@ from fb_datatypes import (
     FBAberration, FBAllele, FBBalancer
 )
 from feature_handler import FeatureHandler
+from harvdev_utils.char_conversions import sub_sup_sgml_to_html, sub_sup_to_sgml
 from harvdev_utils.reporting import (
     Cvterm, Feature, FeatureCvterm, FeatureGenotype, FeatureRelationship,
     Featureprop, Genotype, Phenotype, PhenotypeCvterm, Phenstatement, Pub
 )
 from utils import export_chado_data
+
+BALANCER_RENAME_EXPECTED = 24    # FTA-237: curated "use balancer symbol and fullname" flags in chado as of 2026-08-14.
 
 
 class MetaAlleleHandler(FeatureHandler):
@@ -1236,6 +1239,25 @@ class AberrationHandler(MetaAlleleHandler):
     balancer_flag_regex = re.compile(r'^\s*:?\s*FTA:\s*balancer\s*-\s*mark this aberration as\b', re.IGNORECASE)
     balancer_flag_expected_count = 37    # Per FTA-235; a mismatch means the flag text or the curation record changed.
 
+    # FTA-237: this flag says the parent FBab should be exported under the balancer's current symbol
+    # and full name, e.g.
+    #   FTA: Balancer - use balancer symbol and fullname for parent In(1)Basc (FBab0004219).
+    # 24 of these exist, one per parent, all naming a current non-obsolete FBab. As in FTA-235 the
+    # match runs through the instruction clause, since all three flag families open "FTA: Balancer -".
+    balancer_rename_regex = re.compile(
+        r'^\s*:?\s*FTA:\s*balancer\s*-\s*use balancer symbol and fullname for parent'
+        r'\s+(?P<symbol>.+?)\s*\((?P<fbab>FBab[0-9]+)\)\s*\.?\s*$',
+        re.IGNORECASE)
+    # FTA-237: one aberration is renamed without a curated flag. Per the ticket, In(2LR)SM6 takes the
+    # symbol "SM6" and full name "Second Multiple 6", because its two balancers SM6a (FBba0000039) and
+    # SM6b (FBba0000040) share it as a parent and neither of their names should win. Neither balancer
+    # carries a rename flag, so nothing in chado can drive this: "SM6" exists only as a non-current
+    # synonym of the aberration, and "Second Multiple 6" does not exist in chado at all. Keyed by FBab
+    # uniquename; the values are (symbol, full_name).
+    balancer_hardcoded_renames = {
+        'FBab0004818': ('SM6', 'Second Multiple 6'),
+    }
+
     # Additional export sets.
     aberration_gene_rels = {}            # Will be (FBab feature_id, FBgn feature_id, AGR_rel_type, ECO) tuples keying lists of FBRelationships.
     aberration_gene_associations = []    # Will be the final list of gene-aberration FBRelationships to export (AlleleGeneAssociationDTO under linkmldto attr).
@@ -1244,6 +1266,9 @@ class AberrationHandler(MetaAlleleHandler):
     aberration_allele_associations = []  # Will be the final list of aberration-allele FBRelationships (AlleleAlleleAssociationDTO under linkmldto attr).
     cassette_ignore_list = set()         # FTA-218: FBal feature_ids that are construct cassettes, and so are never exported as alleles.
     balancer_ids = set()                 # FTA-235: FB curies of FBab aberrations flagged as balancers; filled regardless of the export gate.
+    fbba_entities = {}                   # FTA-236/237: feature_id-keyed FBBalancer objects from the nested BalancerHandler.
+    balancer_rename_map = {}             # FTA-237: {FBba feature_id: parent FBab feature_id} for resolved rename flags.
+    balancer_rename_report = []          # FTA-237: dicts of old/new names per renamed aberration, for the curator TSV.
 
     # Additional reference info.
     chr_str_var_terms = []    # A list of cvterm_ids for child terms of "chromosome_structure_variation" (SO:0000240).
@@ -1353,6 +1378,24 @@ class AberrationHandler(MetaAlleleHandler):
         self.get_entity_xrefs(session)
         self.get_entity_timestamps(session)
         self.get_direct_reagent_collections(session)
+        self.get_balancer_entities(session)
+        return
+
+    def get_balancer_entities(self, session):
+        """Have the AberrationHandler run the BalancerHandler to get FBba data (FTA-237).
+
+        Mirrors AlleleHandler.get_insertion_entities(): the nested handler does its own full retrieval,
+        and only its fb_data_entities are kept. Nothing it maps or exports is used directly, so FBba
+        balancers still do not appear in the allele_ingest_set. What is used is each FBba's finished
+        AlleleDTO, whose allele_symbol_dto and allele_full_name_dto the rename step copies onto the
+        parent aberration.
+        """
+        separator = 80 * '#'
+        self.log.info(f'Have the AberrationHandler run the BalancerHandler.\n{separator}')
+        balancer_handler = BalancerHandler(self.log, self.testing)
+        export_chado_data(session, self.log, balancer_handler)
+        self.fbba_entities = balancer_handler.fb_data_entities
+        self.log.info(f'The AberrationHandler obtained {len(self.fbba_entities)} FBba balancers from chado.\n{separator}')
         return
 
     # Additional sub-methods to be run by synthesize_info() below.
@@ -1548,6 +1591,7 @@ class AberrationHandler(MetaAlleleHandler):
         super().synthesize_info()
         self.flag_new_additions_and_obsoletes()
         self.adjust_aberration_organism()
+        self.synthesize_balancer_rename_map()
         self.synthesize_secondary_ids()
         self.synthesize_synonyms()
         self.synthesize_pubs()
@@ -1636,6 +1680,47 @@ class AberrationHandler(MetaAlleleHandler):
         self.log.info(f'Flagged {counter} aberrations with is_aberration=True.')
         return
 
+    def _resolve_parent_feature_id(self, fbab_uniquename):
+        """Return the feature_id of an exportable parent FBab, or None (FTA-237).
+
+        Only aberrations in self.fb_data_entities can be renamed: that dict holds the current,
+        non-obsolete FBab features this handler exports. An obsolete or unrecognised ID gets no
+        fallback on purpose. All 24 FTA-237 parents are current, so this never fires for the rename
+        flags; it exists so that a future curation change is reported rather than silently redirected.
+        """
+        for aberration in self.fb_data_entities.values():
+            if aberration.uniquename == fbab_uniquename:
+                return aberration.db_primary_id
+        return None
+
+    def synthesize_balancer_rename_map(self):
+        """Map each rename-flagged FBba balancer to the parent FBab it renames (FTA-237)."""
+        self.log.info('Map rename-flagged FBba balancers to their parent FBab aberrations.')
+        flag_counter = 0
+        for balancer in self.fbba_entities.values():
+            for fb_prop in balancer.props_by_type.get('internal_notes', []):
+                prop_value = fb_prop.chado_obj.value
+                if not prop_value:
+                    continue
+                match = self.balancer_rename_regex.match(prop_value)
+                if match is None:
+                    continue
+                flag_counter += 1
+                fbab_uniquename = match.group('fbab')
+                parent_feature_id = self._resolve_parent_feature_id(fbab_uniquename)
+                if parent_feature_id is None:
+                    self.log.error(f'FTA-237: balancer {balancer} would rename parent {fbab_uniquename} '
+                                   f'("{match.group("symbol")}"), which is not an exportable aberration '
+                                   f'(obsolete or unknown). No rename applied; please fix the internal note.')
+                    break
+                self.balancer_rename_map[balancer.db_primary_id] = parent_feature_id
+                break
+        self.log.info(f'Found {flag_counter} balancer rename flags; resolved {len(self.balancer_rename_map)} renames.')
+        if self.testing is False and flag_counter != BALANCER_RENAME_EXPECTED:
+            self.log.warning(f'Expected {BALANCER_RENAME_EXPECTED} balancer rename flags per FTA-237, but found '
+                             f'{flag_counter}. Check the "internal_notes" flag text in chado.')
+        return
+
     def map_balancer_flag(self):
         """Flag FBab entities carrying the curated balancer internal note with "is_balancer" (FTA-235).
 
@@ -1668,6 +1753,124 @@ class AberrationHandler(MetaAlleleHandler):
         if self.testing is False and len(self.balancer_ids) != self.balancer_flag_expected_count:
             self.log.warning(f'Expected {self.balancer_flag_expected_count} balancer-flagged aberrations per FTA-235, '
                              f'but found {len(self.balancer_ids)}. Check the "internal_notes" flag text in chado.')
+        return
+
+    def map_balancer_renames(self):
+        """Export a rename-flagged aberration under its balancer's symbol and full name (FTA-237).
+
+        The nested BalancerHandler has already built a full AlleleDTO for every FBba, so the balancer's
+        allele_symbol_dto and allele_full_name_dto are correct - right display_text conversion, right
+        evidence curies - and are simply copied into the parent's slots. The aberration's own names
+        move to allele_synonym_dtos, as the ticket asks.
+
+        Must run after map_synonyms(), which is what populates the parent's name slots in the first
+        place. Any synonym matching a newly promoted name is dropped, so a name grafted by FTA-236
+        does not appear twice.
+        """
+        self.log.info('Rename flagged aberrations to use their balancer symbol and full name.')
+        renamed = 0
+        for fbba_feature_id, fbab_feature_id in self.balancer_rename_map.items():
+            balancer = self.fbba_entities[fbba_feature_id]
+            aberration = self.fb_data_entities[fbab_feature_id]
+            if aberration.linkmldto is None:
+                self.log.warning(f'FTA-237: {aberration} has no LinkML object to rename; skipping.')
+                continue
+            report = {
+                'fbab_id': aberration.uniquename,
+                'fbba_id': balancer.uniquename,
+                'source': 'flag',
+                'new_symbol': '',
+                'old_symbol': '',
+                'new_full_name': '',
+                'old_full_name': '',
+            }
+            new_dtos = {
+                'allele_symbol_dto': getattr(balancer.linkmldto, 'allele_symbol_dto', None),
+                'allele_full_name_dto': getattr(balancer.linkmldto, 'allele_full_name_dto', None),
+            }
+            self.apply_rename(aberration, new_dtos, report)
+            self.balancer_rename_report.append(report)
+            renamed += 1
+            self.log.debug(f'FTA-237: renamed {aberration} to "{report["new_symbol"]}" '
+                           f'("{report["new_full_name"]}") after balancer {balancer}.')
+        self.map_hardcoded_balancer_renames()
+        self.log.info(f'Renamed {renamed} aberrations from curated flags, plus '
+                      f'{len(self.balancer_rename_report) - renamed} hard-coded; '
+                      f'{len(self.balancer_rename_report)} in total.')
+        return
+
+    def apply_rename(self, aberration, new_dtos, report):
+        """Move an aberration's own names to synonyms and install the new ones (FTA-237).
+
+        Args:
+            aberration (FBAberration): the aberration being renamed.
+            new_dtos (dict): {slot_name: NameSlotAnnotationDTO dict or None} for the new names.
+            report (dict): the report row to fill in, mutated in place.
+
+        """
+        NAME_SLOT_LABELS = {'allele_symbol_dto': 'symbol', 'allele_full_name_dto': 'full_name'}
+        for slot_name, label in NAME_SLOT_LABELS.items():
+            new_dto = new_dtos.get(slot_name)
+            if new_dto is None:
+                continue
+            old_dto = getattr(aberration.linkmldto, slot_name)
+            report[f'new_{label}'] = new_dto['format_text']
+            if old_dto is not None:
+                report[f'old_{label}'] = old_dto['format_text']
+                aberration.linkmldto.allele_synonym_dtos.append(old_dto)
+            # Copy, so later edits to either DTO cannot bleed into the other entity's export.
+            setattr(aberration.linkmldto, slot_name, dict(new_dto))
+            self.drop_duplicate_synonyms(aberration, new_dto)
+        return
+
+    def map_hardcoded_balancer_renames(self):
+        """Apply the FTA-237 renames that no curated flag can drive (currently only In(2LR)SM6)."""
+        for fbab_uniquename, names in self.balancer_hardcoded_renames.items():
+            new_symbol, new_full_name = names
+            parent_feature_id = self._resolve_parent_feature_id(fbab_uniquename)
+            if parent_feature_id is None:
+                self.log.error(f'FTA-237: hard-coded rename target {fbab_uniquename} ("{new_symbol}") is not an '
+                               f'exportable aberration; rename not applied.')
+                continue
+            aberration = self.fb_data_entities[parent_feature_id]
+            if aberration.linkmldto is None:
+                self.log.warning(f'FTA-237: {aberration} has no LinkML object to rename; skipping.')
+                continue
+            new_dtos = {
+                'allele_symbol_dto': agr_datatypes.NameSlotAnnotationDTO(
+                    'nomenclature_symbol', new_symbol, sub_sup_sgml_to_html(sub_sup_to_sgml(new_symbol)), []).dict_export(),
+                'allele_full_name_dto': agr_datatypes.NameSlotAnnotationDTO(
+                    'full_name', new_full_name, sub_sup_sgml_to_html(sub_sup_to_sgml(new_full_name)), []).dict_export(),
+            }
+            report = {
+                'fbab_id': aberration.uniquename,
+                'fbba_id': 'n/a',
+                'source': 'hard-coded',
+                'new_symbol': '',
+                'old_symbol': '',
+                'new_full_name': '',
+                'old_full_name': '',
+            }
+            self.apply_rename(aberration, new_dtos, report)
+            self.balancer_rename_report.append(report)
+            self.log.info(f'FTA-237: applied the hard-coded rename of {aberration} to '
+                          f'"{new_symbol}" ("{new_full_name}").')
+        return
+
+    def drop_duplicate_synonyms(self, aberration, promoted_dto):
+        """Remove synonyms that duplicate a name just promoted into a name slot (FTA-237).
+
+        FTA-236 grafts the balancer's names onto the parent as synonyms; once one of them becomes the
+        parent's symbol or full name, the synonym entry is redundant. Matching is on name type plus
+        format_text, so a same-text synonym of a different type is left alone.
+        """
+        keep = []
+        for synonym_dto in aberration.linkmldto.allele_synonym_dtos:
+            is_duplicate = synonym_dto['format_text'] == promoted_dto['format_text']
+            if is_duplicate and synonym_dto['name_type_name'] == promoted_dto['name_type_name']:
+                continue
+            keep.append(synonym_dto)
+        aberration.linkmldto.allele_synonym_dtos = keep
         return
 
     def map_aberration_allele_associations(self):
@@ -1716,6 +1919,7 @@ class AberrationHandler(MetaAlleleHandler):
         self.map_aberration_mutation_types()
         self.map_aberration_gene_associations()
         self.map_synonyms()
+        self.map_balancer_renames()
         self.map_data_provider_dto()
         self.map_xrefs()
         self.map_entity_props_to_notes('aberration_prop_to_note_mapping')

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1071,6 +1071,15 @@ class PrimaryEntityHandler(DataHandler):
                 is_merged_symbol = syno_id in fb_data_entity.merged_synonym_ids and syno_dict['name_type_name'] in symbol_type_names
                 if syno_dict['is_current'] is True and is_merged_symbol and syno_dict['format_text'] != fb_data_entity.name:
                     syno_dict['is_current'] = False
+                # FTA-236: a balancer's names must never rival the parent aberration's own. Unlike
+                # merged_synonym_ids this covers full names too: map_synonyms() sets no
+                # allele_full_name_dto at all when it finds two current full names, so an undemoted
+                # balancer full name would delete the aberration's own from the export. The entity's
+                # own name is exempt for the same reason as above - a synonym_id can be shared by both
+                # features, and the entity must never lose its own name.
+                is_demoted = syno_id in fb_data_entity.demoted_synonym_ids
+                if syno_dict['is_current'] is True and is_demoted and syno_dict['format_text'] != fb_data_entity.name:
+                    syno_dict['is_current'] = False
                 # Classify is_internal (convert list of booleans into a single boolean).
                 if False in syno_dict['is_internal']:
                     syno_dict['is_internal'] = False

--- a/src/fb_datatypes.py
+++ b/src/fb_datatypes.py
@@ -93,6 +93,7 @@ class FBDataEntity(FBExportEntity):
         self.pub_associations = []        # Pub associations: e.g., FeaturePub, StrainPub.
         self.synonyms = []                # Synonym associations: e.g., FeatureSynonym.
         self.merged_synonym_ids = set()   # synonym_ids merged in from a superseded entity; never current symbols here.
+        self.demoted_synonym_ids = set()  # synonym_ids to force non-current for ALL name types (FTA-236 balancer merges).
         self.fb_sec_dbxrefs = []          # 2o/non-current FlyBase xref objects: e.g., FeatureDbxref.
         self.dbxrefs = []                 # Current xref objects: e.g., FeatureDbxref.
         self.props_by_type = {}           # Lists of FBProp objects keyed by prop type name.


### PR DESCRIPTION
Implements two sub-tasks of the [Submit balancers (FBba) to the Alliance](https://flybase.atlassian.net/browse/FTA-185) epic. They ship together because they share their retrieval and act on the same 38 balancers, and because they interact: the merge grafts a balancer's names onto its parent as synonyms, then the rename promotes two of them.

- **[FTA-236](https://flybase.atlassian.net/browse/FTA-236)** — the 38 FBba carrying `FTA: Balancer - merge with parent <SYMBOL> (<FBab_ID>).` have their synonyms, secondary IDs, comments, internal notes, references and carried alleles/insertions folded into the parent FBab aberration.
- **[FTA-237](https://flybase.atlassian.net/browse/FTA-237)** — the 24 FBba carrying `FTA: Balancer - use balancer symbol and fullname for parent ...` cause the parent to be exported under the balancer's symbol and full name, keeping its own names as synonyms. Plus one hard-coded case, In(2LR)SM6 → `SM6` / `Second Multiple 6`.

## Approach

Both reuse existing patterns rather than adding machinery:

- `AberrationHandler.get_balancer_entities()` runs a nested `BalancerHandler`, exactly as `AlleleHandler.get_insertion_entities()` runs a nested `InsertionHandler`. FBba are still not exported as alleles; what is used is their data and their finished `AlleleDTO`.
- **FTA-236 grafts** onto the parent entity before `synthesize_*` runs, as `add_fbal_to_fbti()` does, so `map_synonyms()`, `map_secondary_ids()`, `map_entity_props_to_notes()` and `map_pubs()` produce merged output unchanged.
- **FTA-237 swaps DTO slots** after `map_synonyms()`, copying the balancer's own `allele_symbol_dto` / `allele_full_name_dto` — correct `display_text` and evidence for free, no name text rebuilt for the 24.

Three deliberate narrowings, each with a reason a reviewer should check:

1. **Props are whitelisted** to `misc` and `internal_notes`. A blanket `props_by_type` merge would also carry `availability` and `derived_stock*`, which `map_extinction_info()` reads to set `is_extinct` — a balancer's stock status is not the aberration's.
2. **Carried alleles are injected** into `aberration_allele_rels`, not grafted onto the entity, because the parent's own relationships also drive aberration-**gene** synthesis, where a balancer's links would appear as phantom gene associations.
3. **New `FBDataEntity.demoted_synonym_ids`**, honoured for every name type in `synthesize_synonyms()`. `merged_synonym_ids` could not be reused: it covers symbols only, deliberately (FTA-234). This matters most for full names — `map_synonyms()` sets **no** `allele_full_name_dto` when it sees two current ones, so an undemoted balancer full name would delete the aberration's own, and 28 of the 38 balancers have one.

## Gating

Only the carried alleles/insertions are gated, behind the existing `ADD_ALLELE_ALLELE_ASSOC` (FTA-218: the Alliance still has no `allele_allele_association_ingest_set` and lacks the `carries` term). Names, IDs, notes, references and the renames all use long-released slots and are ungated.

## Verified against production_chado

Full runs on 14 Aug (artifacts in `flysql26:/data/alliance/PERSISTENT_main_FTA-23{6,7}_balancer_rename`):

| check | result |
|---|---|
| merges | 37 of 38 onto 36 parents; 160 synonyms, 39 secondary IDs, 26 comments, 67 internal notes, 432 references |
| carries | 177 moved, 53 held back for FM1/SM6a/SM6b per curator decision |
| renames | 24 flag-driven + 1 hard-coded = 25; all 24 diff identical to chado |
| name collisions | **0** `many current symbols`, **0** `many current full_names` |
| FTA-235 regression | unchanged: `is_balancer` × 37, `is_aberration` × 36859 |
| other warnings | 357, identical in count and type to the previous release run |

The 38th balancer, AM1 (`FBba0000688`), names the obsolete `FBab0007127` and is **reported as an error and skipped** — the curators' explicit choice over resolving stale IDs through `feature_dbxref` ([FTA-236 comment](https://flybase.atlassian.net/browse/FTA-236)). A correction to `FBab0049550` is due to load, after which the numbers become 38 balancers / 37 parents / 184 carries.

**The runs earned their keep** — they caught two bugs no offline test could, both now fixed with regression tests in `025728f`:

- `fb_data_entities` holds obsolete aberrations too (exported as `internal=True`), so a membership check was not a currency check, and AM1's data merged into the obsolete entry.
- The nested `BalancerHandler` never calls `build_feature_lookup()`, so `recall_relationships(rel_entity_types=...)` matched nothing and the carries move silently did nothing. Partners are now resolved against this handler's own lookup.

## Testing

No pytest suite exists here, and the repo venv cannot run on an arm64 Mac, so verification is: three offline `ast`-extraction harnesses that drive the real methods with duck-typed stand-ins (`docs/FTA-236/verify_merge_map.py` 14/14, `docs/FTA-236/verify_graft.py` 31/31, `docs/FTA-237/verify_renames.py` 30/30), expectation SQL whose numbers every claim above traces to (`docs/FTA-236/expected_counts.sql`, `docs/FTA-237/expected_renames.sql`), run-verification scripts (`docs/FTA-23{6,7}/verify_run.sh`), plus `py_compile`, the 160-char limit and the docstring codes `.flake8` enforces.

Design decisions and traps are written up in `docs/FTA-236/plan.md` and `docs/FTA-237/plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FTA-236]: https://flybase.atlassian.net/browse/FTA-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTA-237]: https://flybase.atlassian.net/browse/FTA-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ