### PR TITLE
feat(FTA-222): gate the transgenic tool "uses" slot behind ADD_TOOL_USES

### DIFF
--- a/src/AGR_data_retrieval_curation_transgenic_tool.py
+++ b/src/AGR_data_retrieval_curation_transgenic_tool.py
@@ -52,6 +52,11 @@ Environment variables:
   SERVER              Database server (e.g. flysql25)
   DATABASE            Database name (e.g. production_chado)
   ADD_OBSOLETE        Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
+  ADD_TOOL_USES       Set to 'YES' to emit the 'transgenic_tool_use_dtos' slot (TO4 'tool_uses' FBcv annotations).
+                      Off by default: the slot is only on agr_curation_schema 'main', where LinkML v2.17.0 still
+                      calls it 'use_curies' and has no TransgenicToolUseSlotAnnotationDTO class, so emitting it
+                      fails validation for the whole file. Requires a LinkML release containing the slot. The
+                      *_tool_uses.tsv is written either way, so this gates the JSON only. See FTA-222.
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
@@ -122,7 +127,7 @@ def main():
         )
         curation_tsv.write_tool_uses_tsv(
             filename=tsv_filename.replace('.tsv', '_tool_uses.tsv'), entities=entities,
-            datatype='transgenic_tool',
+            datatype='transgenic_tool', use_dtos_by_id=tool_handler.tool_use_dtos_by_id,
         )
 
     if not reference_session:

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -274,7 +274,7 @@ class TransgenicToolDTO(ReagentDTO):
         self.transgenic_tool_symbol_dto = None      # One NameSlotAnnotationDTO.
         self.transgenic_tool_full_name_dto = None   # One NameSlotAnnotationDTO.
         self.transgenic_tool_synonym_dtos = []      # Many NameSlotAnnotationDTO objects.
-        self.transgenic_tool_use_dtos = []          # TransgenicToolUseSlotAnnotationDTOs.
+        self.transgenic_tool_use_dtos = []          # TransgenicToolUseSlotAnnotationDTOs; gated by ADD_TOOL_USES (slot is agr_curation_schema main only).
         self.note_dtos = []                         # Will be NoteDTO objects.
         self.cross_reference_dtos = []
         self.required_fields.extend(['transgenic_tool_symbol_dto'])

--- a/src/curation_tsv.py
+++ b/src/curation_tsv.py
@@ -228,17 +228,31 @@ def write_components_tsv(*, filename, entities, datatype):
                 )
 
 
-def write_tool_uses_tsv(*, filename, entities, datatype, no_pubs_sentinel=NO_PUBS_SENTINEL):
-    """Write the tool-uses TSV (`{datatype}_use_dtos`)."""
+def write_tool_uses_tsv(
+    *,
+    filename,
+    entities,
+    datatype,
+    no_pubs_sentinel=NO_PUBS_SENTINEL,
+    use_dtos_by_id=None,
+):
+    """Write the tool-uses TSV (`{datatype}_use_dtos`).
+
+    `use_dtos_by_id` supplies slot annotations, keyed by primary external ID, for entities whose
+    exported dict carries no `{datatype}_use_dtos` key. The transgenic tool script passes the
+    handler's collected annotations so this TSV stays populated while ADD_TOOL_USES keeps the slot
+    out of the JSON; the cassette script omits it and reads the exported dicts as before.
+    """
     skip = should_skip_obsolete()
     use_key = f'{datatype}_use_dtos'
+    fallback = use_dtos_by_id or {}
     with open(filename, 'w') as outfile:
         outfile.write(TOOL_USES_TSV_HEADER)
         for entity_dict in entities:
             if skip and _is_excluded(entity_dict):
                 continue
             primary = entity_dict["primary_external_id"]
-            for comp in entity_dict.get(use_key, []):
+            for comp in entity_dict.get(use_key) or fallback.get(primary, []):
                 if 'evidence_curies' in comp:
                     evidence = EVIDENCE_DELIMITER.join(comp['evidence_curies'])
                 else:

--- a/src/transgenic_tool_handler.py
+++ b/src/transgenic_tool_handler.py
@@ -12,6 +12,7 @@ Author(s):
 # import csv
 # import re
 from logging import Logger
+from os import getenv
 import agr_datatypes
 import fb_datatypes
 from feature_handler import FeatureHandler
@@ -26,6 +27,9 @@ class ExperimentalToolHandler(FeatureHandler):
         self.fb_export_type = fb_datatypes.FBTool
         self.agr_export_type = agr_datatypes.TransgenicToolDTO
         self.primary_export_set = 'transgenic_tool_ingest_set'
+        # "tool_uses" slot annotations keyed by primary external ID, collected whether or not
+        # ADD_TOOL_USES is set so the curator TSV can report them (see map_tool_uses()).
+        self.tool_use_dtos_by_id = {}
 
     test_set = {
         'FBto0000001': 'C-Cerulean',  # First one
@@ -113,8 +117,20 @@ class ExperimentalToolHandler(FeatureHandler):
 
         Create one TransgenicToolUseSlotAnnotationDTO per FBcv term, carrying only the
         pubs that give evidence for that specific term.
+
+        The "transgenic_tool_use_dtos" slot exists only on agr_curation_schema "main": the latest
+        LinkML release (v2.17.0) still calls the slot "use_curies" and has no
+        TransgenicToolUseSlotAnnotationDTO class, so emitting it fails schema validation for the
+        whole transgenic tool file. The export is therefore gated behind ADD_TOOL_USES until a
+        LinkML release containing the slot is available (FTA-222). The annotations are always
+        collected into self.tool_use_dtos_by_id, gate or no gate, so the curator TSV reports them
+        while the JSON export stays clean (mirrors the ADD_IS_ABERRATION gate for alleles).
         """
         self.log.info('Map tool uses to Alliance object.')
+        add_uses = getenv('ADD_TOOL_USES', None) == 'YES'
+        if not add_uses:
+            self.log.info('ADD_TOOL_USES not set to "YES"; collecting tool uses for the TSV, but not '
+                          'exporting the "transgenic_tool_use_dtos" slot.')
         data_key = 'tool_uses'
         counter = 0
         for tool in self.fb_data_entities.values():
@@ -133,12 +149,20 @@ class ExperimentalToolHandler(FeatureHandler):
                     accession_to_pubs[accession] = set()
                 accession_to_pubs[accession].add(pub_curie)
             # Create one DTO per FBcv term.
+            slot_dtos = []
             for accession, pub_curies in accession_to_pubs.items():
                 slot_dto = agr_datatypes.TransgenicToolUseSlotAnnotationDTO(
                     sorted(pub_curies), [f'FBcv:{accession}']).dict_export()
-                tool.linkmldto.transgenic_tool_use_dtos.append(slot_dto)
+                slot_dtos.append(slot_dto)
                 counter += 1
+            if not slot_dtos:
+                continue
+            self.tool_use_dtos_by_id[tool.linkmldto.primary_external_id] = slot_dtos
+            if add_uses:
+                tool.linkmldto.transgenic_tool_use_dtos.extend(slot_dtos)
         self.log.info(f'Generated {counter} transgenic tool use slot annotations.')
+        if not add_uses:
+            self.log.info(f'Withheld tool uses for {len(self.tool_use_dtos_by_id)} tools from the JSON export.')
         return
 
     def synthesize_tool_associations(self):


### PR DESCRIPTION
## Why

`transgenic_tool_use_dtos` was being exported unconditionally, but the slot exists only on `agr_curation_schema` **main**. The current release, LinkML v2.17.0, still calls it `use_curies` and has no `TransgenicToolUseSlotAnnotationDTO` class at all — so emitting it fails schema validation for the *whole* transgenic tool file.

This turned up while auditing the export feature gates for FTA-222. Every other slot in this situation is gated; this one wasn't.

## What

Gates the slot behind `ADD_TOOL_USES`, following the existing `ADD_IS_ABERRATION` pattern so the gate covers the **JSON only**.

The wrinkle worth reviewing: the curator TSV and the JSON are generated from the *same* exported dicts, so simply not populating the slot would have silently emptied `*_tool_uses.tsv`. Instead:

- `map_tool_uses()` always builds the slot annotations and collects them into a new `self.tool_use_dtos_by_id`, gate or no gate.
- It only assigns to `linkmldto.transgenic_tool_use_dtos` when the gate is on.
- `write_tool_uses_tsv()` takes an optional `use_dtos_by_id` fallback and reads it when the exported dict has no `*_use_dtos` key.

`generate_export_dict()` (`handler.py:1141`) drops optional empty-list fields, so with the gate off the property is absent from the JSON entirely rather than exported as `[]` — an empty unknown property would still have failed validation, so this is what makes the gate actually work.

The cassette script shares `write_tool_uses_tsv()` and is **unaffected**: it omits the new kwarg and keeps reading the exported dicts exactly as before.

## Verification

- 8 behavioural checks pass: gate off/on, a lowercase `yes` correctly *not* opening the gate, and all three TSV call shapes — including no row duplication when both the exported key and the fallback are present.
- flake8: **zero new findings**, confirmed by linting the `origin/main` versions of the same four files with the same config and cwd and diffing (49 pre-existing findings before, 49 after).

Caveats: the tests stub `agr_datatypes`/`feature_handler`, so they cover the gate and TSV wiring rather than the real DTO shape — the project venv is x86_64-broken locally, so the export itself wasn't run. The gate name follows the `tool_uses` proforma field and `map_tool_uses()`; easy to rename if `ADD_TRANSGENIC_TOOL_USES` reads better.

## Notes

Removing this gate needs a LinkML release containing the slot, and then Alliance app support for transgenic tools generally — the curation app has no TransgenicTool entity, ingest set or load type today, so the whole export is unloadable regardless of this slot. FTA-222 has the full gate inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)