### PR TITLE
feat(FTA-222): gate the gene change events slot behind ADD_GENE_CHANGE_EVENTS

### DIFF
--- a/src/AGR_data_retrieval_curation_gene.py
+++ b/src/AGR_data_retrieval_curation_gene.py
@@ -53,6 +53,13 @@ Environment variables:
   SERVER              Database server (e.g. flysql25)
   DATABASE            Database name (e.g. production_chado)
   ADD_OBSOLETE        Set to 'NO' to exclude obsolete/internal rows from the TSVs only; JSON output is unaffected
+  ADD_GENE_CHANGE_EVENTS
+                      Set to 'YES' to emit the 'gene_change_event_dtos' slot ('Nomenclature History',
+                      FTA-192/FTA-193). Off by default, but note this gate is precautionary, not a fix: the
+                      slot IS in LinkML v2.17.0 so the file validates either way, and the curation app
+                      ignores unknown properties rather than rejecting them. It is gated because the app has
+                      no GeneDTO field for it, so the data is silently dropped on ingest. The
+                      *_gene_change_events.tsv is written either way, so this gates the JSON only. See FTA-222.
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
@@ -121,6 +128,7 @@ def main():
         )
         curation_tsv.write_gene_change_events_tsv(
             filename=tsv_filename.replace('.tsv', '_gene_change_events.tsv'), entities=entities,
+            events_by_id=gene_handler.gene_change_event_dtos_by_id,
         )
         curation_tsv.write_skipped_identity_source_tsv(
             filename=tsv_filename.replace('.tsv', '_skipped_identity_source.tsv'),

--- a/src/agr_datatypes.py
+++ b/src/agr_datatypes.py
@@ -237,7 +237,7 @@ class GeneDTO(GenomicEntityDTO):
         self.gene_secondary_id_dtos = []        # Annotation IDs and 2o FlyBase IDs.
         # self.reference_curies = []              # Not yet part of LinkML, so not exported - should be added to LinkML model?
         self.note_dtos = []                     # Will be NoteDTO objects.
-        self.gene_change_event_dtos = []        # Will be GeneChangeEventSlotAnnotationDTO objects.
+        self.gene_change_event_dtos = []        # GeneChangeEventSlotAnnotationDTOs; gated by ADD_GENE_CHANGE_EVENTS (app has no field for it).
         self.gcrp_cross_reference_dto = None    # Will be a single CrossReferenceDTO object for UniProt/GCRP xref, if any.
         self.required_fields.extend(['gene_symbol_dto'])
 

--- a/src/curation_tsv.py
+++ b/src/curation_tsv.py
@@ -144,21 +144,27 @@ def write_notes_tsv(*, filename, entities):
                 outfile.write(f"{primary}\t{note['note_type_name']}\t{free_text}\t{evidence}\n")
 
 
-def write_gene_change_events_tsv(*, filename, entities):
+def write_gene_change_events_tsv(*, filename, entities, events_by_id=None):
     """Write the gene change events TSV (`gene_change_event_dtos` slot).
 
     One row per change event. Rename events (from 'identity_source') fill the
     symbol columns; nomenclature comment events fill the note column with the
     inner note's free_text. Evidence curies are pipe-joined.
+
+    `events_by_id` supplies the change events, keyed by primary external ID, for genes whose
+    exported dict carries no `gene_change_event_dtos` key. The gene script passes the handler's
+    collected events so this TSV stays populated while ADD_GENE_CHANGE_EVENTS keeps the slot out
+    of the JSON.
     """
     skip = should_skip_obsolete()
+    fallback = events_by_id or {}
     with open(filename, 'w') as outfile:
         outfile.write(GENE_CHANGE_EVENTS_TSV_HEADER)
         for entity_dict in entities:
             if skip and _is_excluded(entity_dict):
                 continue
             primary = entity_dict["primary_external_id"]
-            for event in entity_dict.get("gene_change_event_dtos", []):
+            for event in entity_dict.get("gene_change_event_dtos") or fallback.get(primary, []):
                 event_type = event.get("event_type_name", "")
                 renamed_from = event.get("symbol_renamed_from", "")
                 renamed_to = event.get("symbol_renamed_to", "")

--- a/src/gene_handler.py
+++ b/src/gene_handler.py
@@ -12,6 +12,7 @@ Author(s):
 import csv
 import re
 from logging import Logger
+from os import getenv
 from harvdev_utils.char_conversions import clean_free_text
 import agr_datatypes
 import fb_datatypes
@@ -42,6 +43,9 @@ class GeneHandler(FeatureHandler):
         self.agr_export_type = agr_datatypes.GeneDTO
         self.primary_export_set = 'gene_ingest_set'
         self.skipped_identity_source = []    # Multi-token "identity_source" props skipped during change event mapping.
+        # Change events keyed by primary external ID, collected whether or not ADD_GENE_CHANGE_EVENTS
+        # is set so the curator TSV can report them (see map_gene_change_events()).
+        self.gene_change_event_dtos_by_id = {}
 
     test_set = {
         'FBgn0284084': 'wg',                  # Current annotated nuclear protein_coding gene.
@@ -305,8 +309,21 @@ class GeneHandler(FeatureHandler):
         (confirmed by Steven, FTA-193); event_status_name and current_version are omitted (made
         optional in schema PR #326, no FlyBase data to import).
 
+        The JSON export is gated behind ADD_GENE_CHANGE_EVENTS. Unlike the other export gates this
+        one is precautionary rather than a fix: "gene_change_event_dtos" IS in the released LinkML
+        v2.17.0, so the gene file validates either way, and the curation app sets Jackson's
+        FAIL_ON_UNKNOWN_PROPERTIES to false, so it silently drops the slot instead of rejecting the
+        file. But the app has no GeneDTO field for it (no "changeEvent" anywhere in agr_curation),
+        so the data goes nowhere on ingest; the gate makes that explicit and protects us if the
+        Alliance ever starts rejecting unknown properties (FTA-222).
+        The events are always collected into self.gene_change_event_dtos_by_id, gate or no gate, so
+        the curator TSV reports them while the JSON stays clean (as ADD_TOOL_USES does for tools).
         """
         self.log.info('Map gene "Nomenclature History" props to Alliance gene change events.')
+        add_events = getenv('ADD_GENE_CHANGE_EVENTS', None) == 'YES'
+        if not add_events:
+            self.log.info('ADD_GENE_CHANGE_EVENTS not set to "YES"; collecting change events for the '
+                          'TSV, but not exporting the "gene_change_event_dtos" slot.')
         nomen_comment_counter = 0
         identity_source_counter = 0
         skipped_identity_source_counter = 0
@@ -314,6 +331,7 @@ class GeneHandler(FeatureHandler):
             if gene.linkmldto is None:
                 continue
             gene_id = gene.linkmldto.primary_external_id
+            events = []
             # 'gene_nomenclature_comment' -> one change event per comment, comment held as inner note.
             nomen_notes = self.convert_prop_to_note(gene, 'gene_nomenclature_comment', 'gene_nomenclature_note')
             for note in nomen_notes:
@@ -323,7 +341,7 @@ class GeneHandler(FeatureHandler):
                     note.get('evidence_curies', []),
                 )
                 change_event.note_dtos = [note]
-                gene.linkmldto.gene_change_event_dtos.append(change_event.dict_export())
+                events.append(change_event.dict_export())
                 nomen_comment_counter += 1
             # 'identity_source' -> symbol_renamed_to (new, first) and symbol_renamed_from (old, second).
             for fb_prop in gene.props_by_type.get('identity_source', []):
@@ -351,11 +369,19 @@ class GeneHandler(FeatureHandler):
                 )
                 change_event.symbol_renamed_to = symbols[0]
                 change_event.symbol_renamed_from = symbols[1]
-                gene.linkmldto.gene_change_event_dtos.append(change_event.dict_export())
+                events.append(change_event.dict_export())
                 identity_source_counter += 1
+            if not events:
+                continue
+            self.gene_change_event_dtos_by_id[gene_id] = events
+            if add_events:
+                gene.linkmldto.gene_change_event_dtos.extend(events)
         self.log.info(f'Mapped {nomen_comment_counter} "gene_nomenclature_comment" change events.')
         self.log.info(f'Mapped {identity_source_counter} "identity_source" change events '
                       f'({skipped_identity_source_counter} skipped due to unexpected value format).')
+        if not add_events:
+            self.log.info(f'Withheld change events for {len(self.gene_change_event_dtos_by_id)} genes '
+                          f'from the JSON export.')
         return
 
     # Elaborate on query_chado_and_export() for the GeneHandler.


### PR DESCRIPTION
## Why

The curation app has no `GeneDTO` field for `gene_change_event_dtos` — the string `changeEvent` appears nowhere in `agr_curation`'s 3,925 files — so the FTA-192 'Nomenclature History' data we export is **silently dropped on ingest**. This gates it, both to make that explicit and to protect the gene file if the Alliance ever starts rejecting unknown properties.

### Please read this before merging: this gate is precautionary, not a fix

It is **not** the same situation as `ADD_TOOL_USES` (#105), and the docstring and the script's env-var epilog both say so. (Correction to an earlier version of this description: that epilog is source documentation only, not user-visible. `set_up_db_reading()` builds its own argparse and handles `--help` first, so each script's second parser — the one holding the gate docs — never renders. Pre-existing; `ADD_OBSOLETE` is documented the same way.)

| | `ADD_TOOL_USES` (#105) | `ADD_GENE_CHANGE_EVENTS` (this PR) |
|---|---|---|
| In released v2.17.0? | No — main only, `use_curies` in v2.17.0 | **Yes** |
| Ungated → validation | **Fails for the whole file** | Passes |
| Ungated → ingest | Ignored | Ignored |

The app sets `FAIL_ON_UNKNOWN_PROPERTIES = false` (`config/RestDefaultObjectMapper.java`), so an ungated slot is ignored rather than rejected. So emitting this slot today is harmless — it just goes nowhere.

**That means this PR is genuinely optional.** Reasonable to merge it for consistency and safety; also reasonable to reject it and leave the slot flowing, since it costs nothing and would start persisting the moment the app adds the field. Your call.

Caveat on the Jackson check: `RestDefaultObjectMapper` is the JAX-RS mapper. I could not confirm the bulk-file ingest path uses the same one — GitHub code search returns nothing for that repo, even for control terms.

## What

Same JSON-only split as `ADD_TOOL_USES`, so curators keep their data:

- `map_gene_change_events()` accumulates each gene's events into a local list and always stores them in the new `self.gene_change_event_dtos_by_id`, gate or no gate.
- It only extends `linkmldto.gene_change_event_dtos` when the gate is on.
- `write_gene_change_events_tsv()` takes an optional `events_by_id` fallback, so `*_gene_change_events.tsv` stays populated with the gate off.

The malformed-`identity_source` skip path and its diagnostic TSV are untouched.

## Verification

10 checks pass, including:

- a gene carrying a nomenclature comment **and** two `identity_source` renames (the multi-event-per-gene path, which is where the local-accumulation refactor could have gone wrong)
- the malformed `identity_source` value still skipped and recorded in `skipped_identity_source`
- no duplication when the gate is on and both the exported key and the fallback are present
- the writer still working without the new kwarg
- the `ADD_TOOL_USES` tests from #105 still passing

flake8: **clean, exit 0**, under the project venv's own flake8. Correcting an earlier version of this description, which cited "49 pre-existing findings before and after": those D204s were invented by a scratch flake8 that had `flake8-docstrings` installed. The project's flake8 carries no docstring plugin (mccabe/pycodestyle/pyflakes only), so D-codes never fire here and the `D100,D103,D104` entries in `.flake8` are vestigial.

These checks were re-run against the **real** DTOs after this branch was pushed: the repo venv was x86_64-broken (dangling Intel-Homebrew interpreter) and has since been rebuilt for arm64, so the gene assertions now exercise the real `GeneChangeEventSlotAnnotationDTO`, the real `dict_export()` and the real `curation_tsv` writer, with only the two DB-backed helpers (`convert_prop_to_note`, `lookup_pub_curies`) stubbed. That includes the load-bearing one: with the gate off the slot is genuinely **absent** from the exported dict, not present as an empty array.

Still not covered: a full retrieval run against chado, which needs a reachable database host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

