### PR TITLE
fix(FTA-238): restrict systematic_name to genes and anchor its regex

### DIFF
--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1034,6 +1034,14 @@ class PrimaryEntityHandler(DataHandler):
         }
         # AGR name types that represent a symbol, as opposed to a full name or a plain synonym.
         symbol_type_names = ['nomenclature_symbol', 'systematic_name']
+        # FTA-238: only genes may carry a systematic name. Steven, Gillian and Gil all confirmed
+        # (FTA-238, 2026-08-11) that "systematic" is a gene concept and that the Alliance slot is
+        # gene_systematic_name, scoped to genes, so no other data class may retype a symbol this way.
+        # Previously every caller of this method did, which mistyped 46,315 of 47,953 exported
+        # systematic_name DTOs - almost all of them allele symbols of unnamed genes. Applying FBti
+        # lineIDs or FBsn stock IDs as systematic names would need a chado flag, not a string pattern,
+        # and is deliberately out of scope here.
+        retype_systematic_names = self.datatype == 'gene'
         for fb_data_entity in self.fb_data_entities.values():
             # For each entity, gather synonym_id-keyed dict of synonym info.
             for feat_syno in fb_data_entity.synonyms:
@@ -1055,8 +1063,9 @@ class PrimaryEntityHandler(DataHandler):
             # Go back over each synonym and refine each
             for syno_id, syno_dict in fb_data_entity.synonym_dict.items():
                 # Then modify attributes as needed.
-                # Identify systematic names.
-                if (re.match(self.regex['systematic_name'], syno_dict['format_text']) and syno_dict['name_type_name'] == 'nomenclature_symbol'):
+                # Identify systematic names (genes only - see retype_systematic_names above).
+                is_nomenclature_symbol = syno_dict['name_type_name'] == 'nomenclature_symbol'
+                if retype_systematic_names and is_nomenclature_symbol and re.match(self.regex['systematic_name'], syno_dict['format_text']):
                     syno_dict['name_type_name'] = 'systematic_name'
                 # Classify is_current (convert list of booleans into a single boolean).
                 if True in syno_dict['is_current']:

--- a/src/handler.py
+++ b/src/handler.py
@@ -216,7 +216,12 @@ class DataHandler(object):
         'cell_line': r'^FBtc[0-9]{7}$',
         'clone': r'^FBcl[0-9]{7}$',
         'panther': r'PTHR[0-9]{5}',
-        'systematic_name': r'^(D[a-z]{3}\\|)(CG|CR|G[A-Z])[0-9]{4,5}',
+        # FTA-238: anchored at both ends, so an allele symbol that merely starts with an annotation
+        # ID (CG17836[142]) is no longer retyped as a systematic name. The optional -(R|P)[A-Z]*
+        # tail keeps annotated transcript/polypeptide forms (CG12345-RA, CR3456-PB) matching, at
+        # Gil's request, for if FBtr/FBpp are ever exported. The | inside the first group is what
+        # makes the species prefix optional; it is not part of the defect.
+        'systematic_name': r'^(D[a-z]{3}\\|)(CG|CR|G[A-Z])[0-9]{4,5}(-(R|P)[A-Z]*)?$',
     }
 
     # Feature sub-types that are considered their own data class.


### PR DESCRIPTION
> **Ready for review — both verification runs are in and both pass**, see the two run comments below. Allele export: 48,028 → **0** `systematic_name` DTOs, with `nomenclature_symbol` up by exactly 48,028 and records unchanged. Gene export: 445,335 → **445,064**, with the dedicated `gene_systematic_name_dto` slot untouched at 17,871 and all 842,967 name texts byte-identical.
>
> **Reviewer note:** this relabels 48,028 DTOs in the allele submission, so it is worth a curator eye even though no name, symbol or record changes. Two differences in those run diffs come from changes already merged to main, not from this PR — 34 balancer nicknames (FTA-236, `d1607a1`) and 10,894 `gene_change_event_dtos` (`ADD_GENE_CHANGE_EVENTS`, #106). Both are explained in the run comments.

## The defect, in two parts

Two problems with one cause. `systematic_name` had no end anchor, so any symbol merely *starting* with an annotation ID was retyped — `CG17836[142]` and friends. And the retyping lived in shared code, so **every** caller of `synthesize_synonyms()` applied it, not just genes. Together they mistyped **46,315 of 47,953** `systematic_name` DTOs in the 2026_02 allele export (96.6%).

## What the curators decided

Per FTA-238 (Steven, Gillian and Gil, 2026-08-11/12), `systematic_name` is a **gene-only** concept: the Alliance slot is `gene_systematic_name`, scoped to genes. Crucially, **anchoring alone is not sufficient** — Gillian's point was that typing *any* allele as `systematic_name` is wrong even when it happens to be a bare annotation ID. So this PR is deliberately larger than the one-character fix the ticket originally proposed.

## Changes

**`handler.py`** — anchor the regex at both ends, keeping an optional `-(R|P)[A-Z]*` tail so annotated transcript/polypeptide forms (`CG12345-RA`, `CR3456-PB`) still match. Gil asked for that against future FBtr/FBpp export. The `|` in the leading group, which makes the species prefix optional, was never part of the defect.

**`entity_handler.py`** — gate the retyping on `self.datatype == 'gene'`. The flag is hoisted above the entity loop because it is loop-invariant, and because `.flake8` replaces pycodestyle's defaults so **W503 and W504 are both active** — which rules out breaking the condition at an operator, and the inline three-clause version exceeds 160 chars.

## Measured effect

Gene side, against `fb_2026_02_reporting_audit`, non-obsolete genes, distinct symbol synonyms — the ticket asked for this to be *confirmed rather than assumed*:

| | count |
|---|---|
| bare annotation IDs — keep `systematic_name` | 23,303 |
| transcript/polypeptide forms — deliberately kept per Gil | 47 |
| **stop being `systematic_name`** | **131 distinct names / 159 (gene, symbol) pairs** |

Those 131 are clearly right to drop: `CG107278` and `CG111913` (six digits — the old regex matched the first five and ignored the rest), `CG13004-5'utr`, `CG12717-related`, `CG12930A`/`CG12930B`, `CG10332-ORFA`.

Non-gene classes stop retyping entirely, so **all 47,953** `systematic_name` DTOs in the allele export become `nomenclature_symbol`. That is larger than the `$`-only estimate of 46,315, and is what Gillian asked for.

No name text changes, no symbol changes, no records added or removed — `entity_handler.py` treats `nomenclature_symbol` and `systematic_name` alike when filling the symbol slot, so symbol *choice* is unaffected.

## Bonus fix

Closes the strain trap documented on the ticket. `map_strain_synonyms()` matches `nomenclature_symbol` exactly, so a retyped strain symbol would have fallen through and left `agm_full_name_dto` unset — the one place the mistyping lost data rather than mislabelling it. Strains can no longer be retyped at all. No live cases today; it was latent.

## Out of scope, per the same discussion

- Applying systematic names to FBti lineIDs (`MI02330`) or FBsn stock IDs (`DGRC101`) — Gil and Gillian agreed these need a flag in chado, not a string pattern.
- The Alliance DTO naming asymmetry (`SystematicNameSlotAnnotationDTO` vs the gene-scoped slot) — Steven is raising that with Chris G.
- The `_systematic_name_dto` placeholder that could ship for non-gene DTOs. Latent only (all three write paths require `curr_anno_id`, which only genes synthesise), noted on the ticket, left alone to keep this diff reviewable.

## Verification done

- **22 unit checks pass**: every documented case from the ticket, Gil's transcript/polypeptide forms, and gene-vs-allele-vs-construct gating driven through the real `synthesize_synonyms()`.
- **flake8 clean** under the project's own config.
- Gene-side counts measured against chado, as above.

## What still needs doing before this merges

- [x] ~~A real export run, diffed against a baseline~~ — **allele run done and verified** (`PERSISTENT_main_FTA-238_allele`, production_chado): `systematic_name` **48,028 → 0**, `nomenclature_symbol` **+48,028 exactly**, record count identical at 617,355, and the only name-text changes are 34 balancer nicknames from the already-merged FTA-236 fix — 0 additions. See the run comment below.
- [x] ~~The **gene** export run~~ — **done and verified** (`PERSISTENT_main_FTA-238_gene`, fb_2026_02_reporting): `systematic_name` **445,335 → 445,064**, `nomenclature_symbol` **+271 exactly**, the dedicated `gene_systematic_name_dto` slot unchanged at 17,871, records identical at 255,967, and all 842,967 `format_text` values **hash identically** — no name text changed. See the gene run comment below. — no symbol changes, no record count changes. The `PERSISTENT_*` artifacts on flysql26 can supply the "before" side.
- [x] ~~Re-check the **gene** export specifically~~ — **done, see the baseline-comparison comment below.** Measured on the real gene export: of 445,335 `systematic_name` DTOs, 445,064 keep their typing and only **271** (0.06%) lose it, all of them clearly wrong as systematic names (`CG144778`, `GH05057p`, `CG3957/wmd`, `CG6673-A`).

Caveat on the tests: they drive the real `synthesize_synonyms()` but with stubbed chado synonym objects, so they cover the typing logic rather than a full export path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




