### PR TITLE
refactor(FTA-216): move handler accumulators from class body into __init__

### DIFF
--- a/src/agm_handlers.py
+++ b/src/agm_handlers.py
@@ -155,6 +155,13 @@ class GenotypeHandler(PrimaryEntityHandler):
         self.fb_export_type = fb_datatypes.FBGenotype
         self.agr_export_type = agr_datatypes.AffectedGenomicModelDTO
         self.primary_export_set = 'agm_ingest_set'
+        # Additional export sets.
+        self.agm_component_associations = []    # A list of AgmAlleleAssociationDTOs.
+        # Additional reference info.
+        self.dmel_insertion_allele_ids = []    # feature_ids for alleles related to FBti insertions (associated_with/progenitor).
+        self.transgenic_allele_ids = []        # feature_ids for alleles related to FBtp constructs.
+        self.in_vitro_allele_ids = []          # feature_ids for alleles having "in vitro construct" CV term annotations.
+        self.introgressed_aberr_ids = []       # feature_ids for aberrations of type "introgressed_chromosome".
 
     test_set = {
         2: 'Ab(1)ZWD16 | FBab0027942',                             # The first genotype in the table.
@@ -192,15 +199,6 @@ class GenotypeHandler(PrimaryEntityHandler):
 
         # 525357: 'w[*]; betaTub60D[2] Kr[If-1]|CyO',                              # Genotype from stock; genotype_id here is for FB2024_06 only.
     }
-
-    # Additional export sets.
-    agm_component_associations = []    # A list of AgmAlleleAssociationDTOs.
-
-    # Additional reference info.
-    dmel_insertion_allele_ids = []    # feature_ids for alleles related to FBti insertions (associated_with/progenitor).
-    transgenic_allele_ids = []        # feature_ids for alleles related to FBtp constructs.
-    in_vitro_allele_ids = []          # feature_ids for alleles having "in vitro construct" CV term annotations.
-    introgressed_aberr_ids = []       # feature_ids for aberrations of type "introgressed_chromosome".
 
     # Elaborate on get_general_data() for the GenotypeHandler.
     def get_general_data(self, session):

--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -148,6 +148,15 @@ class AlleleHandler(MetaAlleleHandler):
         self.transgenic_fbal_fbti_dict = {}    # Will be FBal-feature_id-keyed dict of FBti feature_id lists (via FBtp to unspecified FBti).
         self.fbti_entities = {}                # Will be feature_id-keyed FBAllele objects generated from FBti insertions.
         self.generic_ti_fbtp_ids = set()       # FTA-180 Part B: set of FBtp feature_ids flagged 'FTA: generic TI construct'.
+        # Additional export sets.
+        self.allele_gene_rels = {}                 # Will be (allele feature_id, gene feature_id) tuples keying lists of FBRelationships.
+        # Final list of gene-allele FBRelationships to export (AlleleGeneAssociationDTO under linkmldto attr).
+        self.allele_gene_associations = []
+        self.allele_construct_rels = {}            # Will be (allele feature_id, construct feature_id) tuples keying lists of FBRelationships.
+        self.allele_construct_associations = []    # Will be the final list of construct-allele FBRelationships to export (AlleleConstructAssociationDTO).
+        # Additional reference info.
+        self.allele_class_terms = []          # A list of cvterm_ids for child terms of "allele_class" (FBcv:0000286).
+        self.allele_mutant_type_terms = []    # A list of cvterm_ids for child terms of chromosome_structure_variation or sequence_alteration.
 
     test_set = {
         'FBal0386858': 'SppL[CR70402-TG4.1]',   # Insertion allele superceded by FBti0226866 (superseded_by_at_locus_insertion).
@@ -203,12 +212,6 @@ class AlleleHandler(MetaAlleleHandler):
         'FBal0064059': 'ebi[k16213]',   # FTA-207 note props: internal_notes, misc, origin_comment, origin_type.
     }
 
-    # Additional export sets.
-    allele_gene_rels = {}                 # Will be (allele feature_id, gene feature_id) tuples keying lists of FBRelationships.
-    allele_gene_associations = []         # Will be the final list of gene-allele FBRelationships to export (AlleleGeneAssociationDTO under linkmldto attr).
-    allele_construct_rels = {}            # Will be (allele feature_id, construct feature_id) tuples keying lists of FBRelationships.
-    allele_construct_associations = []    # Will be the final list of construct-allele FBRelationships to export (AlleleConstructAssociationDTO).
-
     # Simple mapping of props to Alliance note types, for cases where it is one-to-one correspondence.
     # The key is the cvterm.name for the FlyBase prop type.
     # The value is a tuple representing the Alliance note type, and where to append the note: (Alliance note type name, Alliance slot name).
@@ -226,9 +229,6 @@ class AlleleHandler(MetaAlleleHandler):
         'origin_comment': ('notes_on_origin', 'note_dtos'),    # FBal
     }
 
-    # Additional reference info.
-    allele_class_terms = []          # A list of cvterm_ids for child terms of "allele_class" (FBcv:0000286).
-    allele_mutant_type_terms = []    # A list of cvterm_ids for child terms of chromosome_structure_variation or sequence_alteration.
     inheritance_mode_terms = {
         'recessive': 'recessive',
         'dominant': 'dominant',
@@ -1199,6 +1199,24 @@ class AberrationHandler(MetaAlleleHandler):
         super().__init__(log, testing)
         self.datatype = 'aberration'
         self.fb_export_type = FBAberration
+        # Additional export sets.
+        self.aberration_gene_rels = {}            # Will be (FBab feature_id, FBgn feature_id, AGR_rel_type, ECO) tuples keying lists of FBRelationships.
+        # Final list of gene-aberration FBRelationships to export (AlleleGeneAssociationDTO under linkmldto attr).
+        self.aberration_gene_associations = []
+        # FTA-218: aberration-to-allele associations ("carries" and "breakpoint_allele").
+        self.aberration_allele_rels = {}          # Will be (FBab feature_id, FBal/FBti feature_id, AGR_rel_type) tuples keying lists of FBRelationships.
+        # Final list of aberration-allele FBRelationships (AlleleAlleleAssociationDTO under linkmldto attr).
+        self.aberration_allele_associations = []
+        self.balancer_ids = set()                 # FTA-235: FB curies of FBab aberrations flagged as balancers; filled regardless of the export gate.
+        self.balancer_merge_map = {}              # FTA-236: {FBba feature_id: parent FBab feature_id} for resolved merge flags.
+        self.balancer_merge_report = []            # FTA-236: dicts of what moved per balancer, for the curator TSV.
+        self.balancer_rename_map = {}             # FTA-237: {FBba feature_id: parent FBab feature_id} for resolved rename flags.
+        self.balancer_rename_report = []          # FTA-237: dicts of old/new names per renamed aberration, for the curator TSV.
+        # Additional reference info.
+        self.chr_str_var_terms = []    # A list of cvterm_ids for child terms of "chromosome_structure_variation" (SO:0000240).
+        self.seq_alt_terms = []        # A list of cvterm_ids for child terms of "sequence_alteration" (SO:0001059).
+        self.str_var_terms = []        # A list of cvterm_ids for child terms of "structural_variant" (SO:0001537).
+        self.chr_del_terms = []        # A list of cvterm_ids for child terms of "chromosomal_deletion" (SO:1000029).
 
     test_set = {
         'FBab0000001': 'Df(2R)03072',           # Random selection.
@@ -1286,25 +1304,8 @@ class AberrationHandler(MetaAlleleHandler):
         'FBab0004818': ('SM6', 'Second Multiple 6'),
     }
 
-    # Additional export sets.
-    aberration_gene_rels = {}            # Will be (FBab feature_id, FBgn feature_id, AGR_rel_type, ECO) tuples keying lists of FBRelationships.
-    aberration_gene_associations = []    # Will be the final list of gene-aberration FBRelationships to export (AlleleGeneAssociationDTO under linkmldto attr).
-    # FTA-218: aberration-to-allele associations ("carries" and "breakpoint_allele").
-    aberration_allele_rels = {}          # Will be (FBab feature_id, FBal/FBti feature_id, AGR_rel_type) tuples keying lists of FBRelationships.
-    aberration_allele_associations = []  # Will be the final list of aberration-allele FBRelationships (AlleleAlleleAssociationDTO under linkmldto attr).
     cassette_ignore_list = set()         # FTA-218: FBal feature_ids that are construct cassettes, and so are never exported as alleles.
-    balancer_ids = set()                 # FTA-235: FB curies of FBab aberrations flagged as balancers; filled regardless of the export gate.
     fbba_entities = {}                   # FTA-236/237: feature_id-keyed FBBalancer objects from the nested BalancerHandler.
-    balancer_merge_map = {}              # FTA-236: {FBba feature_id: parent FBab feature_id} for resolved merge flags.
-    balancer_merge_report = []            # FTA-236: dicts of what moved per balancer, for the curator TSV.
-    balancer_rename_map = {}             # FTA-237: {FBba feature_id: parent FBab feature_id} for resolved rename flags.
-    balancer_rename_report = []          # FTA-237: dicts of old/new names per renamed aberration, for the curator TSV.
-
-    # Additional reference info.
-    chr_str_var_terms = []    # A list of cvterm_ids for child terms of "chromosome_structure_variation" (SO:0000240).
-    seq_alt_terms = []        # A list of cvterm_ids for child terms of "sequence_alteration" (SO:0001059).
-    str_var_terms = []        # A list of cvterm_ids for child terms of "structural_variant" (SO:0001537).
-    chr_del_terms = []        # A list of cvterm_ids for child terms of "chromosomal_deletion" (SO:1000029).
 
     # Additional sub-methods for get_general_data().
     def get_cassette_allele_ids(self, session):

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -27,6 +27,17 @@ class CassetteHandler(FeatureHandler):
         self.agr_export_type = agr_datatypes.CassetteDTO
         self.primary_export_set = 'cassette_ingest_set'
         self.incremental_update = False
+        # Additional export sets.
+        self.cassette_tool_associations = []
+        self.cassette_genomic_entity_associations = []
+        self.cassette_str_associations = []
+        self.cassette_cassette_rels = {}
+        # Anonymous cassette export sets. The source list, anon_cassette_data, stays a class
+        # attribute: receive_anon_cassette_data() rebinds it wholesale, so it is not shared state.
+        self.anon_cassettes = []
+        self.anon_cassette_tool_associations = []
+        self.anon_cassette_genomic_entity_associations = []
+        self.anon_cassette_str_associations = []
         # NOTE: We have general alleles in here too so we can check we only get the casssettes here.
     #       Also Cassettes are in the Allele code to check we only get these once.
     test_set = {
@@ -129,16 +140,8 @@ class CassetteHandler(FeatureHandler):
     }
     cassette_associations = []  # Should delete this one later
     # cassette_component_free_text_associations = []
-    cassette_tool_associations = []
-    cassette_genomic_entity_associations = []
-    cassette_str_associations = []
-    cassette_cassette_rels = {}
     # Anonymous cassette data (populated via receive_anon_cassette_data).
     anon_cassette_data = []
-    anon_cassettes = []
-    anon_cassette_tool_associations = []
-    anon_cassette_genomic_entity_associations = []
-    anon_cassette_str_associations = []
 
     # FTA-224: the feature.type values that make an FBsf a sequence targeting reagent.
     STR_SEQFEAT_TYPES = ('RNAi_reagent', 'sgRNA')

--- a/src/construct_handler.py
+++ b/src/construct_handler.py
@@ -40,6 +40,11 @@ class ConstructHandler(FeatureHandler):
         self.fbal_tool_uses = {}              # {fbal_fid: [{cvterm_name, accession, pub_id}, ...]}
         # FTA-182 v3: pubs on the producedby rel (FBti subject -> generic-TI FBtp object).
         self.ti_producedby_pubs = {}          # {ti_fid: [pub_id, ...]}
+        # Additional sets for export added to the handler.
+        # Will be a list of FBExportEntity objects (rels), map to ConstructGenomicEntityAssociationDTO.
+        self.construct_associations = []
+        # Will be a list of FBExportEntity objects, map to ConstructCassetteAssociationDTO.
+        self.construct_cassette_associations = []
 
     # FBals whose marked_with relationship maps to 'has_transcriptional_unit'
     # instead of the default 'has_selectable_marker' (FTA-139, reused by FTA-183).
@@ -140,10 +145,6 @@ class ConstructHandler(FeatureHandler):
     }
 
     # Additional set for export added to the handler.
-    # Will be a list of FBExportEntity objects (rels), map to ConstructGenomicEntityAssociationDTO.
-    construct_associations = []
-    # Will be a list of FBExportEntity objects, map to ConstructCassetteAssociationDTO.
-    construct_cassette_associations = []
     # Anonymous cassette data.
 
     # Elaborate on get_general_data() for the ConstructHandler.

--- a/src/disease_handlers.py
+++ b/src/disease_handlers.py
@@ -1601,10 +1601,9 @@ class AlleleDiseaseHandler(DataHandler):
         self.fb_export_type = fb_datatypes.FBAlleleDiseaseAnnotation
         self.agr_export_type = agr_datatypes.AlleleDiseaseAnnotationDTO
         self.primary_export_set = 'disease_allele_ingest_set'
-
-    # A dict of unique disease annotation attributes.
-    # This will be used after initial data pull to filter out redundant disease annotations.
-    uniq_dis_dict = {}
+        # A dict of unique disease annotation attributes.
+        # This will be used after initial data pull to filter out redundant disease annotations.
+        self.uniq_dis_dict = {}
 
     # Key disease annotation term sets and look ups.
     relevant_qualifiers = [

--- a/src/gene_handler.py
+++ b/src/gene_handler.py
@@ -46,6 +46,8 @@ class GeneHandler(FeatureHandler):
         # Change events keyed by primary external ID, collected whether or not ADD_GENE_CHANGE_EVENTS
         # is set so the curator TSV can report them (see map_gene_change_events()).
         self.gene_change_event_dtos_by_id = {}
+        # Additional reference info.
+        self.pthr_dict = {}                  # Will be an 1:1 FBgn_ID-PTHR xref dict.
 
     test_set = {
         'FBgn0284084': 'wg',                  # Current annotated nuclear protein_coding gene.
@@ -70,9 +72,6 @@ class GeneHandler(FeatureHandler):
         'FBgn0026367': 'Scer_GAL80',          # Current yeast gene, SGD:S000004515.
         'FBgn0287889': 'SARS-CoV-2_ORF3a',    # Current SARS-CoV2 gene, REFSEQ:YP_009724391.
     }
-
-    # Additional reference info.
-    pthr_dict = {}                   # Will be an 1:1 FBgn_ID-PTHR xref dict.
 
     gene_prop_to_note_mapping = {
         'misc': ('comment', 'note_dtos'),

--- a/src/handler.py
+++ b/src/handler.py
@@ -63,6 +63,7 @@ class DataHandler(object):
         self.cvterm_lookup = {}                     # A cvterm_id-keyed dict of dicts with these keys: 'name', 'cv_name', 'db_name', 'curie'.
         self.organism_lookup = {}                   # An organism_id-keyed dict of organism info.
         self.chr_dict = {}                          # Will be a feature_id-keyed dict of chr scaffold uniquenames.
+        self.mod_official_dbs = {}                  # FTA-216: organism-abbreviation-keyed dict of MOD official db names.
         self.feature_lookup = {}                    # feature_id-keyed dicts {uniquename, curie, is_obsolete, type, organism_id, name, symbol, exported}.
         self.uname_feature_lookup = {}              # FB uniquename-keyed dicts of self.feature_lookup.values().
         self.allele_gene_lookup = {}                # allele feature_id-keyed dict of related gene feature_id (current features only).
@@ -83,9 +84,8 @@ class DataHandler(object):
     # Sample set for faster testing: use uniquename-keyed names of objects, tailored for each handler.
     test_set = {}
 
-    # Alliance organism abbreviations and official dbs.
+    # Alliance organism abbreviations.
     alliance_organisms = ['Scer', 'Cele', 'Dmel', 'Drer', 'Xlae', 'Xtro', 'Mmus', 'Rnor', 'Hsap', 'SARS-CoV-2']
-    mod_official_dbs = {}
 
     # Alliance db names should correspond to the contents of this file:
     # https://github.com/alliance-genome/agr_schemas/blob/master/resourceDescriptors.yaml

--- a/src/transgenic_tool_handler.py
+++ b/src/transgenic_tool_handler.py
@@ -30,6 +30,8 @@ class ExperimentalToolHandler(FeatureHandler):
         # "tool_uses" slot annotations keyed by primary external ID, collected whether or not
         # ADD_TOOL_USES is set so the curator TSV can report them (see map_tool_uses()).
         self.tool_use_dtos_by_id = {}
+        self.tool_associations = []
+        self.tool_tool_rels = {}
 
     test_set = {
         'FBto0000001': 'C-Cerulean',  # First one
@@ -47,8 +49,6 @@ class ExperimentalToolHandler(FeatureHandler):
         # At the moment, just for code development. (line below)
         # 'internal_notes': ('internal_note', 'note_dtos'),
     }
-    tool_associations = []
-    tool_tool_rels = {}
 
     def get_general_data(self, session):
         """Extend the method for the AlleleHandler."""


### PR DESCRIPTION
> **Draft** — no behavioural change and nothing pending verification-wise; opened as a draft so it can be reviewed at leisure. Unlike #107 this needs **no export run**: it relocates declarations without altering output. 59 insertions against 58 deletions is essentially the same lines moved.

## The defect

The lists and dicts that accumulate associations, relationships and other per-run data were declared in the **class body**. The code mutates them in place (`append` / `extend` / `self.x[k] = …`) and never rebinds them, so every instance of a class — and of its subclasses — wrote into the *same shared object*.

Worst case was `mod_official_dbs`, which sits on the `DataHandler` base and was therefore shared by every handler of every type in a process.

## Why it matters, and why nothing is broken today

Latent, not an active data bug: each retrieval script builds one handler per class and exits. Two scripts already create sibling handlers in one process — `AGR_data_retrieval_curation_allele.py` (Allele + Aberration) and `AGR_data_retrieval_curation_agm.py` (Genotype + Strain) — but those pairs are *siblings*, and their shared ancestors declare no mutable accumulators, so neither inherits the other's. They do share `mod_official_dbs`; it is keyed by organism abbreviation with identical values each time, so the second write is idempotent. That is luck, not design.

It breaks the moment the same class is instantiated twice in one process: the second run inherits the first run's associations and double-exports them. Natural to hit in a unit test, an incremental/reference-db comparison, or if a script is extended to handle two releases — and it would surface as inflated association counts in the JSON, which is easy to miss.

## What moved

All **39** in-place-mutated declarations, into the corresponding `__init__` as `self.<name>`, comments kept:

| file | moved |
|---|---|
| `allele_handlers.py` | 19 (6 AlleleHandler, 13 AberrationHandler) |
| `cassette_handler.py` | 8 |
| `agm_handlers.py` | 5 |
| `construct_handler.py` | 2 |
| `transgenic_tool_handler.py` | 2 |
| `handler.py` | 1 — `mod_official_dbs`, the base-class case |
| `gene_handler.py` | 1 — `pthr_dict` |
| `disease_handlers.py` | 1 — `uniq_dis_dict` |

**39, not the 42** the ticket's sequencing note estimated. Re-measuring on current main showed the FTA-236 merge added four (`balancer_merge_map`, `balancer_merge_report`, `balancer_rename_map`, `balancer_rename_report`), not seven — `balancer_ids` was already counted, and two of the others turned out to be rebound rather than mutated.

## Deliberately left as class attributes

`cassette_ignore_list`, `fbba_entities` and `anon_cassette_data` are **rebound wholesale** (`self.x = …`) before use, which already creates a proper instance attribute — they were never shared state. A comment at the `anon_cassettes` block records why its source list stays behind, so it doesn't read as an oversight.

Read-only class data is untouched: `test_set`, `regex`, `feature_subtypes`, the `*_prop_to_note_mapping` dicts and the rest — 42 mutable class declarations remain, all constants or rebound.

## Why the move is safe

Two checks before touching anything, both clean:

1. **No accumulator is accessed via the class** (`SomeHandler.attr`) anywhere in `src/`.
2. Eleven of them appear as **name strings**, which looked risky — but they all reach `getattr(self, …)` via `flag_internal_fb_entities()`, and that resolves instance attributes, so string-driven access keeps working.

## Verification

- **The actual bug is tested**: each class is instantiated **twice**, and for all 39 accumulators the test asserts the two instances hold *different objects*, the name is *absent from every class in the MRO*, and mutating one does *not* leak into the other. `mod_official_dbs` is checked across two **different** handler types, since that was the base-class case.
- **AST re-scan**: zero in-place-mutated class attributes remain.
- All **13** handlers still import and instantiate.
- The FTA-238 and export-gate/real-DTO suites still pass as regressions.
- flake8 clean on all eight files. (The 9 `F824` warnings elsewhere in `src/` are pre-existing on main, in files this PR does not touch.)

Three inline comments moved above their assignment, because the extra indent plus `self.` pushed them past the 160-char limit.

## Not included

The `_systematic_name_dto` placeholder that could ship for non-gene DTOs — noted on the ticket, still latent (all three write paths require `curr_anno_id`, which only genes synthesise), and left alone to keep this diff purely mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
