### PR TITLE
fix(FTA-232): sort set-derived output so consecutive exports stop differing

### DIFF
--- a/src/allele_handlers.py
+++ b/src/allele_handlers.py
@@ -110,7 +110,11 @@ class MetaAlleleHandler(FeatureHandler):
             elif metaallele.sf_reagent_colls:
                 collections.extend(metaallele.sf_reagent_colls)
             if collections:
-                collections = list(set(collections))
+                # FTA-232: sort by name before picking. These are Library ORM objects, whose hash is
+                # object identity, so the order varies per run regardless of PYTHONHASHSEED - and since
+                # collections[0].name is exported, the value itself could differ between runs, not just
+                # an order. Alphabetical is a stable tie-break, not a curation rule.
+                collections = sorted(set(collections), key=lambda coll: coll.name)
                 metaallele.linkmldto.in_collection_name = collections[0].name
                 if len(collections) > 1:
                     self.log.warning(f'{metaallele} has many relevant collections: {[i.name for i in collections]}')

--- a/src/cassette_handler.py
+++ b/src/cassette_handler.py
@@ -500,7 +500,9 @@ class CassetteHandler(FeatureHandler):
         if data_key in entity.prop_data.keys():
             for item in entity.prop_data[data_key]:
                 pubs.add(item['pub'])
-        pub_curies = ['FB:' + item for item in list(pubs)]
+        # FTA-232: sorted so the warning below reads the same across runs; comparing two runs' logs
+        # otherwise needs the pub lists normalised before they match.
+        pub_curies = ['FB:' + item for item in sorted(pubs)]
         if len(pub_curies) == 1:  # 1
             return pub_curies
         if len(pub_curies) > 1:  # 1 a

--- a/src/disease_handlers.py
+++ b/src/disease_handlers.py
@@ -571,7 +571,8 @@ class AGMDiseaseHandler(DataHandler):
                 # self.log.debug(f'Many ECOs for model_key={ukey}: {uniqued_list}')
                 many_counter += 1
         self.log.info(f'Have {zero_counter} keys in lookup with NO ECO; {one_counter} keys with ONE ECO; {many_counter} keys with MANY ECOS.')
-        self.log.info(f'Have these distinct ECO codes: {set(distinct_ecos)}')
+        # FTA-232: sorted so this line is stable across runs.
+        self.log.info(f'Have these distinct ECO codes: {sorted(set(distinct_ecos))}')
         return
 
     def lookup_eco_codes_for_modifier_annotations(self):

--- a/src/entity_handler.py
+++ b/src/entity_handler.py
@@ -1019,7 +1019,10 @@ class PrimaryEntityHandler(DataHandler):
             secondary_ids = []
             for xref in fb_data_entity.fb_sec_dbxrefs:
                 secondary_ids.append(f'FB:{xref.dbxref.accession}')
-            fb_data_entity.alt_fb_ids = list(set(fb_data_entity.alt_fb_ids).union(set(secondary_ids)))
+            # FTA-232: sorted, not list(set(...)) - these are strings, and Python randomises string
+            # hashing per process, so an unsorted set made two exports of identical chado data differ
+            # in the exported secondary_identifiers order.
+            fb_data_entity.alt_fb_ids = sorted(set(fb_data_entity.alt_fb_ids).union(set(secondary_ids)))
         return
 
     def synthesize_synonyms(self):
@@ -1116,6 +1119,9 @@ class PrimaryEntityHandler(DataHandler):
             for prop_list in fb_data_entity.props_by_type.values():
                 for prop in prop_list:
                     fb_data_entity.all_pubs.extend(prop.pubs)
+            # FTA-232: deliberately NOT sorted. These are pub_ids, and hash(int) == int, so set
+            # iteration is already stable across processes. reference_curies is built from this list
+            # below, so sorting would reorder every entity's references for no determinism gain.
             fb_data_entity.all_pubs = list(set(fb_data_entity.all_pubs))
         return
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -344,6 +344,8 @@ class DataHandler(object):
             pub_id_list = [pub_id_list]
         pub_curie_list = []
         # First, try to get curies for each pub_id.
+        # FTA-232: deliberately NOT sorted - pub_ids are ints, so this iteration is already stable
+        # across processes, and sorting would reorder exported evidence lists for no gain.
         for pub_id in set(pub_id_list):
             try:
                 pub_curie_list.append(self.bibliography[pub_id])


### PR DESCRIPTION
> **All three pre-merge checks now pass on a real export** — see the run comment below: two consecutive runs byte-identical with `PYTHONHASHSEED` unset, ID sets unchanged (order sorted for 6 of 7 multi-ID records), and `in_collection_name` unchanged. Verified at testing-mode scale (67 records) rather than the full export; still a draft pending a decision to publish.

## The defect

Python randomises string hashing per process, so `list(set(...))` over strings iterates differently from run to run. Two exports of identical chado data produced JSON and TSV that differed, and the Alliance received a changed payload for entities that had not changed.

The cost is **review noise, not wrong data**. During FTA-228 a cassette diff showed **462 rows** differing in the "secondary FBid(s)" column alone — every one the same IDs reordered — and it had to be ruled out as a regression before the change under review could be trusted. FTA-113 and FTA-220 both needed `PYTHONHASHSEED` pinned for the same reason.

## What changed — 4 sites

| site | element type | reaches | live cases |
|---|---|---|---|
| `entity_handler.py` `synthesize_secondary_ids()` | strings | exported `secondary_identifiers` | **16,242** entities with ≥2 secondary IDs (of 68,472 with ≥1) |
| `allele_handlers.py` `map_collections()` | Library ORM objects | exported `in_collection_name` **value** | 0 — latent |
| `cassette_handler.py` `lookup_expresses_pub_curies()` | strings | log text | fires on cassette runs |
| `disease_handlers.py` ECO summary | strings | log text | every disease run |

`allele_handlers.py` is the interesting one: the set holds Library ORM objects, whose hash is object **identity**, so ordering varies per run *regardless of `PYTHONHASHSEED`* — and `collections[0].name` is the exported value, so the value itself could change, not just an order. It now sorts by name; the existing `len > 1` warning is untouched. Alphabetical is a stable tie-break, not a curation rule — if curators later want a specific precedence between collections, that is its own ticket.

Note FTA-236 increased exposure at site 1: merged aberrations now gain `FB:FBba…` secondary IDs, and the current export shows FBab0004818 as `['FB:FBba0000040', 'FB:FBba0000039']` — reverse numeric order, the randomisation visible in shipped data.

## What was deliberately left alone

Comments at `entity_handler.py` (`all_pubs`) and `handler.py` (`lookup_pub_curies`) now record *why*, so this does not get "fixed" later:

- **Int-valued sets are already stable across processes** (`hash(int) == int`). These feed the large exported lists — `reference_curies` comes from `all_pubs`, and evidence curies from `lookup_pub_curies` iterating `set(pub_id_list)`. Sorting them would reorder e.g. TM3's 145 `reference_curies` on the next export: a large one-off diff with **zero** determinism benefit, which is the opposite of what this ticket is for.
- `construct_handler.py` — string set, but the list is only used when `len == 1`; otherwise `[]`. A one-element list cannot reorder.
- The disease ECO lookup — string set, but every consumer uses only `in keys()`, `len()`, and `[0]` when `len == 1`.

Both were re-verified against current main rather than taken from the ticket's audit.

## Verification, and why the control matters

A single process cannot observe hash randomisation, so the test spawns subprocesses under `PYTHONHASHSEED` = 1, 2, 3, 4 and `random`:

```
PASS  deterministic across seeds ['1','2','3','4','random']
PASS  independent of insertion order
PASS  sorted and complete
PASS  control: pre-fix gave 5 different orders across 5 seeds
PASS  control: pre-fix in_collection_name took 3 different values
      ['Alpha-collection','Mid-collection','Zeta-collection']
```

The last two lines are the point: the same probe was run against a pristine checkout of pre-fix `main`, so a vacuous pass is impossible. That control also **reproduced the ticket's worst claim live** — `in_collection_name` took three different values across five seeds, i.e. the exported *value* changing between runs, not merely an ordering. Latent in production today (the current allele log records no multi-collection cases), but now demonstrated rather than inferred.

Regressions: the FTA-216, FTA-238, export-gate and nickname suites all pass; 8 handlers still instantiate; flake8 clean.

## Before merging

- [x] ~~One export run, checked against a baseline~~ — **done**, see the run comment below. Pre-fix vs post-fix on real chado: **ID sets differ in 0 records**, order changed in 6, and 6 were unsorted pre-fix. Testing-mode scale (67 records, 7 with ≥2 IDs), not the full export.
- [x] ~~`in_collection_name` should not change~~ — **confirmed, 0 changed.**
- [x] ~~Two consecutive exports with `PYTHONHASHSEED` unset should be byte-identical~~ — **confirmed: all 9 data files byte-for-byte equal.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

